### PR TITLE
Fix document timestamp index check

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -69,7 +69,7 @@ export function getDocumentTimestampByIndex(
   index: number,
 ) {
   if (!documents) return new Date();
-  if (index > documents.length) return new Date();
+  if (index < 0 || index >= documents.length) return new Date();
 
   return documents[index].createdAt;
 }


### PR DESCRIPTION
## Summary
- fix index range check in `getDocumentTimestampByIndex`

## Testing
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.12.3.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68405606c400832ab739a6a1d3f90318