### PR TITLE
Update guest session message limit test

### DIFF
--- a/tests/e2e/session.test.ts
+++ b/tests/e2e/session.test.ts
@@ -3,6 +3,7 @@ import { AuthPage } from '../pages/auth';
 import { generateRandomTestUser } from '../helpers';
 import { ChatPage } from '../pages/chat';
 import { getMessageByErrorCode } from '@/lib/errors';
+import { entitlementsByUserType } from '@/lib/ai/entitlements';
 
 test.describe
   .serial('Guest Session', () => {
@@ -192,10 +193,12 @@ test.describe('Entitlements', () => {
     chatPage = new ChatPage(page);
   });
 
-  test('Guest user cannot send more than 20 messages/day', async () => {
+  test(
+    `Guest user cannot send more than ${entitlementsByUserType.guest.maxMessagesPerDay} messages/day`,
+    async () => {
     await chatPage.createNewChat();
 
-    for (let i = 0; i <= 20; i++) {
+    for (let i = 0; i < entitlementsByUserType.guest.maxMessagesPerDay; i++) {
       await chatPage.sendUserMessage('Why is the sky blue?');
       await chatPage.isGenerationComplete();
     }


### PR DESCRIPTION
## Summary
- import `entitlementsByUserType` in `session.test.ts`
- use the guest entitlement limit for the message loop
- reflect current limit in the test title

## Testing
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/...)*
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/...)*

------
https://chatgpt.com/codex/tasks/task_e_684057971780832ab14d92ce5df4c6d0