### PR TITLE
Fix race condition in guest message limit

### DIFF
--- a/app/(chat)/api/chat/route.ts
+++ b/app/(chat)/api/chat/route.ts
@@ -12,9 +12,9 @@ import {
   createStreamId,
   deleteChatById,
   getChatById,
-  getMessageCountByUserId,
   getMessagesByChatId,
   saveChat,
+  saveUserMessageWithLimit,
   saveMessages,
 } from '@/lib/db/queries';
 import { generateUUID, getTrailingMessageId } from '@/lib/utils';
@@ -72,15 +72,6 @@ export async function POST(request: Request) {
     }
     const userType: UserType = session.user.type;
 
-    const messageCount = await getMessageCountByUserId({
-      id: session.user.id,
-      differenceInHours: 24,
-    });
-
-    if (messageCount >= entitlementsByUserType[userType].maxMessagesPerDay) {
-      return new ChatSDKError('limit_exceeded:chat', 'Message limit reached for the day.').toResponse();
-    }
-
     const chat = await getChatById({ id });
     if (!chat) {
       const title = await generateTitleFromUserMessage({ message });
@@ -101,21 +92,21 @@ export async function POST(request: Request) {
       message,
     });
 
+    const userMessage = await saveUserMessageWithLimit({
+      userId: session.user.id,
+      chatId: id,
+      messageId: message.id,
+      parts: message.parts,
+      attachments: message.experimental_attachments ?? [],
+      maxMessages: entitlementsByUserType[userType].maxMessagesPerDay,
+    });
+
+    if (!userMessage) {
+      return new ChatSDKError('limit_exceeded:chat', 'Message limit reached for the day.').toResponse();
+    }
+
     const { longitude, latitude, city, country } = geolocation(request);
     const requestHints: RequestHints = { longitude, latitude, city, country };
-
-    await saveMessages({
-      messages: [
-        {
-          chatId: id,
-          id: message.id,
-          role: 'user',
-          parts: message.parts,
-          attachments: message.experimental_attachments ?? [],
-          createdAt: new Date(),
-        },
-      ],
-    });
 
     const streamId = generateUUID();
     await createStreamId({ streamId, chatId: id });

--- a/lib/db/queries.ts
+++ b/lib/db/queries.ts
@@ -11,6 +11,7 @@ import {
   gte,
   inArray,
   lt,
+  sql,
   type SQL,
 } from 'drizzle-orm';
 import { drizzle } from 'drizzle-orm/postgres-js';
@@ -589,4 +590,55 @@ export async function getStreamIdsByChatId({ chatId }: { chatId: string }) {
       'Failed to get stream ids by chat id',
     );
   }
+}export async function saveUserMessageWithLimit({
+  userId,
+  chatId,
+  messageId,
+  parts,
+  attachments,
+  maxMessages,
+}: {
+  userId: string;
+  chatId: string;
+  messageId: string;
+  parts: any;
+  attachments: any;
+  maxMessages: number;
+}) {
+  const targetDate = new Date(Date.now() - 24 * 60 * 60 * 1000);
+
+  return db.transaction(async (tx) => {
+    await tx.execute(sql`SELECT 1 FROM "User" WHERE id = ${userId} FOR UPDATE`);
+
+    const [stats] = await tx
+      .select({ count: count(message.id) })
+      .from(message)
+      .innerJoin(chat, eq(message.chatId, chat.id))
+      .where(
+        and(
+          eq(chat.userId, userId),
+          gte(message.createdAt, targetDate),
+          eq(message.role, 'user'),
+        ),
+      )
+      .execute();
+
+    if ((stats?.count ?? 0) >= maxMessages) {
+      return null;
+    }
+
+    const [inserted] = await tx
+      .insert(message)
+      .values({
+        id: messageId,
+        chatId,
+        role: 'user',
+        parts,
+        attachments,
+        createdAt: new Date(),
+      })
+      .returning();
+
+    return inserted;
+  });
 }


### PR DESCRIPTION
## Summary
- enforce per-user message limit in DB transaction to avoid race conditions
- insert user message through `saveUserMessageWithLimit`

## Testing
- `pnpm test` *(fails: Codex couldn't run certain commands due to environnment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_68407de44230832ab56629fd8ead4203