### PR TITLE
Fix cursor position after login

### DIFF
--- a/components/multimodal-input.tsx
+++ b/components/multimodal-input.tsx
@@ -92,6 +92,11 @@ function PureMultimodalInput({
       const finalValue = domValue || localStorageInput || '';
       setInput(finalValue);
       adjustHeight();
+      if (finalValue) {
+        textareaRef.current.focus();
+        const len = finalValue.length;
+        textareaRef.current.setSelectionRange(len, len);
+      }
     }
     // Only run once after hydration
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
## Summary
- keep cursor at end of chat input after restoring unsent text

## Testing
- `npx playwright test` *(fails: 34 did not run)*

------
https://chatgpt.com/codex/tasks/task_e_68408d96a088832aa533c3c6cf10600c