### PR TITLE
preserve guest messages after logout

### DIFF
--- a/app/(auth)/api/auth/guest/route.ts
+++ b/app/(auth)/api/auth/guest/route.ts
@@ -6,6 +6,7 @@ import { NextResponse } from 'next/server';
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const redirectUrl = searchParams.get('redirectUrl') || '/';
+  const guestId = searchParams.get('guestId') || undefined;
 
   const token = await getToken({
     req: request,
@@ -17,5 +18,9 @@ export async function GET(request: Request) {
     return NextResponse.redirect(new URL('/', request.url));
   }
 
-  return signIn('guest', { redirect: true, redirectTo: redirectUrl });
+  return signIn('guest', {
+    redirect: true,
+    redirectTo: redirectUrl,
+    guestId,
+  });
 }

--- a/app/(auth)/auth.ts
+++ b/app/(auth)/auth.ts
@@ -4,9 +4,10 @@ import Credentials from 'next-auth/providers/credentials';
 import {
   createGuestUser,
   getUser,
+  getUserById,
 } from '@/lib/db/queries';
 import { authConfig } from './auth.config';
-import { DUMMY_PASSWORD } from '@/lib/constants';
+import { DUMMY_PASSWORD, guestRegex } from '@/lib/constants';
 import type { DefaultJWT } from 'next-auth/jwt';
 
 export type UserType = 'guest' | 'regular';
@@ -76,10 +77,17 @@ export const {
 
     /* 2. One‑click guest users  */
     Credentials({
-      id: 'guest',            // 👈 matches signIn('guest')
+      id: 'guest', // 👈 matches signIn('guest')
       name: 'Guest account',
-      credentials: {},
-      async authorize() {
+      credentials: { guestId: { label: 'Guest ID', type: 'text', optional: true } },
+      async authorize(credentials) {
+        if (credentials?.guestId) {
+          const existingUser = await getUserById(credentials.guestId);
+          if (existingUser && guestRegex.test(existingUser.email)) {
+            return { ...existingUser, type: 'guest' };
+          }
+        }
+
         const [guestUser] = await createGuestUser();
         return { ...guestUser, type: 'guest' };
       },

--- a/components/sidebar-user-nav.tsx
+++ b/components/sidebar-user-nav.tsx
@@ -3,7 +3,8 @@
 import { ChevronUp } from 'lucide-react';
 import Image from 'next/image';
 import type { User } from 'next-auth';
-import { signOut, useSession } from 'next-auth/react';
+import { signOut, signIn, useSession } from 'next-auth/react';
+import { useEffect } from 'react';
 import { useTheme } from 'next-themes';
 
 import {
@@ -29,6 +30,16 @@ export function SidebarUserNav({ user }: { user: User }) {
   const { setTheme, theme } = useTheme();
 
   const isGuest = guestRegex.test(data?.user?.email ?? '');
+
+  useEffect(() => {
+    if (isGuest && data?.user?.id) {
+      try {
+        localStorage.setItem('guestUserId', data.user.id);
+      } catch {
+        // ignore write errors
+      }
+    }
+  }, [isGuest, data?.user?.id]);
 
   return (
     <SidebarMenu>
@@ -97,8 +108,20 @@ export function SidebarUserNav({ user }: { user: User }) {
                   if (isGuest) {
                     router.push('/login');
                   } else {
-                    signOut({
-                      redirectTo: '/',
+                    const storedGuestId = (() => {
+                      try {
+                        return localStorage.getItem('guestUserId');
+                      } catch {
+                        return null;
+                      }
+                    })();
+
+                    signOut({ redirect: false }).then(() => {
+                      signIn('guest', {
+                        redirect: true,
+                        redirectTo: '/',
+                        guestId: storedGuestId || undefined,
+                      });
                     });
                   }
                 }}

--- a/lib/db/queries.ts
+++ b/lib/db/queries.ts
@@ -98,6 +98,15 @@ export async function getUser(email: string): Promise<Array<User>> {
   }
 }
 
+export async function getUserById(id: string): Promise<User | null> {
+  try {
+    const [foundUser] = await db.select().from(user).where(eq(user.id, id)).limit(1);
+    return foundUser || null;
+  } catch (error) {
+    throw new ChatSDKError('bad_request:database', 'Failed to get user by id');
+  }
+}
+
 export async function createUser(email: string, password: string): Promise<User> {
   const hashedPassword = generateHashedPassword(password);
 


### PR DESCRIPTION
## Summary
- allow specifying guestId for guest auth flow
- support retrieving user by ID in the queries
- store guest session id in localStorage
- when logging out, sign back in with previous guestId

## Testing
- `npm test` *(fails: 34 did not run)*

------
https://chatgpt.com/codex/tasks/task_e_68409e0c9d04832a930dac05008652b2