### PR TITLE
Add Google OAuth login support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,10 @@ BLOB_READ_WRITE_TOKEN=****
 # Instructions to create a PostgreSQL database here: https://vercel.com/docs/storage/vercel-postgres/quickstart
 POSTGRES_URL=****
 
+# Google OAuth Credentials
+GOOGLE_CLIENT_ID=****
+GOOGLE_CLIENT_SECRET=****
+
 
 # Instructions to create a Redis store here:
 # https://vercel.com/docs/redis

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ You will need to use the environment variables [defined in `.env.example`](.env.
 1. Install Vercel CLI: `npm i -g vercel`
 2. Link local instance with Vercel and GitHub accounts (creates `.vercel` directory): `vercel link`
 3. Download your environment variables: `vercel env pull`
+4. Add your Google OAuth credentials (`GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET`) to `.env.local`
 
 ```bash
 pnpm install

--- a/app/(auth)/auth.ts
+++ b/app/(auth)/auth.ts
@@ -1,9 +1,12 @@
 import { compare } from 'bcrypt-ts';
 import NextAuth, { type DefaultSession } from 'next-auth';
 import Credentials from 'next-auth/providers/credentials';
+import GoogleProvider from 'next-auth/providers/google';
+import { randomUUID } from 'crypto';
 import {
   createGuestUser,
   getUser,
+  createUser,
 } from '@/lib/db/queries';
 import { authConfig } from './auth.config';
 import { DUMMY_PASSWORD } from '@/lib/constants';
@@ -84,9 +87,29 @@ export const {
         return { ...guestUser, type: 'guest' };
       },
     }),
+
+    GoogleProvider({
+      clientId: process.env.GOOGLE_CLIENT_ID ?? '',
+      clientSecret: process.env.GOOGLE_CLIENT_SECRET ?? '',
+      allowDangerousEmailAccountLinking: true,
+    }),
   ],
 
   callbacks: {
+    async signIn({ user, account }) {
+      if (account?.provider === 'google') {
+        if (!user.email) return false;
+        const [existingUser] = await getUser(user.email);
+        if (existingUser) {
+          user.id = existingUser.id;
+        } else {
+          const newUser = await createUser(user.email, randomUUID());
+          user.id = newUser.id;
+        }
+        (user as any).type = 'regular';
+      }
+      return true;
+    },
     async jwt({ token, user }) {
       if (user) {
         token.id = (user as any).id;

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -7,10 +7,13 @@ import { useActionState, useEffect, useState, useRef } from 'react';
 
 import { AuthForm } from '@/components/auth-form';
 import { SubmitButton } from '@/components/submit-button';
+import { Button } from '@/components/ui/button';
+import { Separator } from '@/components/ui/separator';
+import { LogoGoogle } from '@/components/icons';
 
 import { register } from '../actions';
 import { toast } from '@/components/toast';
-import { useSession } from 'next-auth/react';
+import { useSession, signIn } from 'next-auth/react';
 import { useSWRConfig } from 'swr';
 
 export interface RegisterActionState {
@@ -102,6 +105,15 @@ export default function Page() {
     formAction(formData);
   };
 
+  const handleGoogleSignIn = () => {
+    const params = new URLSearchParams();
+    if (chatIdToResume) params.set('chatIdToResume', chatIdToResume);
+    if (guestUserId) params.set('guestUserId', guestUserId);
+    if (unsentPrompt) params.set('unsentPrompt', unsentPrompt);
+    const callbackUrl = params.size ? `/?${params.toString()}` : '/';
+    signIn('google', { callbackUrl });
+  };
+
   return (
     <div className="flex h-dvh w-screen items-start pt-12 md:pt-0 md:items-center justify-center bg-background">
       <div className="w-full max-w-md overflow-hidden rounded-2xl gap-12 flex flex-col">
@@ -111,6 +123,12 @@ export default function Page() {
             Create an account with your email and password
           </p>
         </div>
+        <div className="px-4 sm:px-16">
+          <Button variant="outline" className="w-full" onClick={handleGoogleSignIn}>
+            <LogoGoogle /> Continue with Google
+          </Button>
+        </div>
+        <Separator className="my-6" />
         <AuthForm action={handleSubmit} defaultEmail={email}>
           <SubmitButton isSuccessful={isSuccessful}>Sign Up</SubmitButton>
           <p className="text-center text-sm text-gray-600 mt-4 dark:text-zinc-400">

--- a/app/(auth)/register/page.tsx
+++ b/app/(auth)/register/page.tsx
@@ -7,10 +7,13 @@ import { useActionState, useEffect, useState, useRef } from 'react';
 
 import { AuthForm } from '@/components/auth-form';
 import { SubmitButton } from '@/components/submit-button';
+import { Button } from '@/components/ui/button';
+import { Separator } from '@/components/ui/separator';
+import { LogoGoogle } from '@/components/icons';
 
 import { register } from '../actions';
 import { toast } from '@/components/toast';
-import { useSession } from 'next-auth/react';
+import { useSession, signIn } from 'next-auth/react';
 import { useSWRConfig } from 'swr';
 
 export interface RegisterActionState {
@@ -104,6 +107,15 @@ export default function Page() {
     formAction(formData);
   };
 
+  const handleGoogleSignIn = () => {
+    const params = new URLSearchParams();
+    if (chatIdToResume) params.set('chatIdToResume', chatIdToResume);
+    if (guestUserId) params.set('guestUserId', guestUserId);
+    if (unsentPrompt) params.set('unsentPrompt', unsentPrompt);
+    const callbackUrl = params.size ? `/?${params.toString()}` : '/';
+    signIn('google', { callbackUrl });
+  };
+
   return (
     <div className="flex h-dvh w-screen items-start pt-12 md:pt-0 md:items-center justify-center bg-background">
       <div className="w-full max-w-md overflow-hidden rounded-2xl gap-12 flex flex-col">
@@ -113,6 +125,12 @@ export default function Page() {
             Create an account with your email and password
           </p>
         </div>
+        <div className="px-4 sm:px-16">
+          <Button variant="outline" className="w-full" onClick={handleGoogleSignIn}>
+            <LogoGoogle /> Continue with Google
+          </Button>
+        </div>
+        <Separator className="my-6" />
         <AuthForm action={handleSubmit} defaultEmail={email}>
           <SubmitButton isSuccessful={isSuccessful}>Sign Up</SubmitButton>
           <p className="text-center text-sm text-gray-600 mt-4 dark:text-zinc-400">

--- a/components/ui/login-signup-dialog.tsx
+++ b/components/ui/login-signup-dialog.tsx
@@ -12,8 +12,10 @@ import {
   DialogOverlay,
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
+import { LogoGoogle } from '@/components/icons';
 import Link from 'next/link';
 import { useLoginSignupPopup } from '@/hooks/use-login-signup-popup';
+import { signIn } from 'next-auth/react';
 // import { X } from 'lucide-react'; // No longer needed here if DialogContent provides it
 // import { useEffect } from 'react'; // No longer needed for body blur
 
@@ -39,6 +41,19 @@ export function LoginSignupDialog() {
     return basePath;
   };
 
+  const getCallbackUrl = () => {
+    if (chatContext) {
+      const params = new URLSearchParams();
+      params.append('chatIdToResume', chatContext.chatId);
+      params.append('guestUserId', chatContext.guestUserId);
+      if (chatContext.unsentPrompt) {
+        params.append('unsentPrompt', chatContext.unsentPrompt);
+      }
+      return `/?${params.toString()}`;
+    }
+    return '/';
+  };
+
   return (
     <Dialog open={isOpen} onOpenChange={(newOpenState) => { if (!newOpenState) closePopup(); }}>
       <DialogOverlay className="backdrop-blur-sm" /> {/* backdrop-blur-sm added by default in globals.css modification or here */}
@@ -58,6 +73,16 @@ export function LoginSignupDialog() {
           </DialogDescription>
         </DialogHeader>
         <DialogFooter className="flex-col gap-2 sm:flex-col sm:gap-2 pt-4">
+          <Button
+            variant="outline"
+            className="w-full"
+            onClick={() => {
+              signIn('google', { callbackUrl: getCallbackUrl() });
+              closePopup();
+            }}
+          >
+            <LogoGoogle /> Continue with Google
+          </Button>
           <Button asChild onClick={closePopup} className="w-full">
             <Link href={getAuthLink('/login')}>Login</Link>
           </Button>


### PR DESCRIPTION
## Summary
- enable Google provider for NextAuth and create DB user on sign-in
- add Google sign-in buttons to login, registration and popup dialog
- document new `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` vars

## Testing
- `pnpm lint` *(fails: unexpected token, lint/style/noNonNullAssertion)*
- `pnpm test` *(failed: Serving HTML report at http://localhost:9323)*

------
https://chatgpt.com/codex/tasks/task_e_6840c011aae0832a9500eed58921bea7