### PR TITLE
Type callbacks for Chat component

### DIFF
--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -1,7 +1,7 @@
 // components/chat.tsx
 'use client';
 
-import type { Attachment, CreateMessage, Message as SDKMessage, UIMessage, ChatRequestOptions as CoreChatRequestOptions } from 'ai';
+import type { Attachment, UIMessage, ChatRequestOptions as CoreChatRequestOptions } from 'ai';
 import { useChat, type UseChatHelpers } from '@ai-sdk/react';
 import { useEffect, useState, useCallback, useRef } from 'react';
 import useSWR, { useSWRConfig } from 'swr';
@@ -17,7 +17,7 @@ import { unstable_serialize } from 'swr/infinite';
 import { getChatHistoryPaginationKey } from './sidebar-history';
 import { toast } from './toast';
 import type { Session } from 'next-auth';
-import { useSearchParams, useRouter } from 'next/navigation'; // useRouter if needed for URL clearing
+import { useSearchParams } from 'next/navigation';
 import { useChatVisibility } from '@/hooks/use-chat-visibility';
 import { useAutoResume } from '@/hooks/use-auto-resume';
 import { ChatSDKError } from '@/lib/errors';
@@ -54,7 +54,6 @@ export function Chat({
 }) {
   const { mutate: mutateGlobal } = useSWRConfig();
   const { openPopup: openLoginSignupPopup } = useLoginSignupPopup();
-  const router = useRouter();
   const hasSetInitialInputRef = useRef(false);
 
   const { visibilityType } = useChatVisibility({
@@ -156,10 +155,8 @@ export function Chat({
   }, [propInitialInput, promptFromAuthRedirect, queryFromUrl, setInput, status, messages.length]);
 
 
-  const handleSubmit = useCallback((
-    eOrForm?: React.FormEvent<HTMLFormElement> | undefined, // Make event optional
-    chatRequestOptions?: ChatRequestOptions
-  ) => {
+  const handleSubmit: UseChatHelpers['handleSubmit'] = useCallback(
+    (eOrForm, chatRequestOptions) => {
     if (eOrForm && typeof eOrForm === 'object' && 'preventDefault' in eOrForm) {
       eOrForm.preventDefault();
     }
@@ -190,10 +187,8 @@ export function Chat({
   }, [messageStatus, openLoginSignupPopup, internalUseChatHandleSubmit, id, attachments, input, session.user?.id]);
 
 
-  const append = useCallback(async (
-    message: SDKMessage | CreateMessage,
-    chatRequestOptions?: ChatRequestOptions,
-  ): Promise<string | null> => {
+  const append: UseChatHelpers['append'] = useCallback(
+    async (message, chatRequestOptions) => {
     if (messageStatus?.userType === 'guest' && (messageStatus.messagesLeft <= 0)) {
        if (session.user?.id) {
          openLoginSignupPopup({

--- a/lib/db/queries.ts
+++ b/lib/db/queries.ts
@@ -36,7 +36,10 @@ import { generateHashedPassword } from './utils';
 import type { VisibilityType } from '@/components/visibility-selector';
 import { ChatSDKError } from '../errors';
 
-const client = postgres(process.env.POSTGRES_URL!);
+if (!process.env.POSTGRES_URL) {
+  throw new Error('POSTGRES_URL is not defined');
+}
+const client = postgres(process.env.POSTGRES_URL);
 const db = drizzle(client);
 
 


### PR DESCRIPTION
## Summary
- type `handleSubmit` and `append` callbacks in `Chat`
- remove unused `useRouter` hook
- ensure postgres URL is checked before creating client

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68416adbc4dc832ab6f54d035770b422