### PR TITLE
Fix input clearing on chat completion

### DIFF
--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -104,8 +104,6 @@ export function Chat({
     onFinish: () => {
       mutateGlobal(unstable_serialize(getChatHistoryPaginationKey));
       mutateMessageStatus();
-      setInput('');
-      setAttachments([]);
     },
     onError: (error) => {
       if (error instanceof ChatSDKError) {


### PR DESCRIPTION
## Summary
- keep partially typed message when a response finishes

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Serving HTML report, tests require environment setup)*

------
https://chatgpt.com/codex/tasks/task_e_684295d1d310832a83fabbaf60d8a9bd