### PR TITLE
Show Google profile pics

### DIFF
--- a/components/sidebar-user-nav.tsx
+++ b/components/sidebar-user-nav.tsx
@@ -53,7 +53,7 @@ export function SidebarUserNav({ user }: { user: User }) {
                 className="data-[state=open]:bg-sidebar-accent bg-background data-[state=open]:text-sidebar-accent-foreground h-10"
               >
                 <Image
-                  src={`https://avatar.vercel.sh/${user.email}`}
+                  src={user.image ?? `https://avatar.vercel.sh/${user.email}`}
                   alt={user.email ?? 'User Avatar'}
                   width={24}
                   height={24}

--- a/next.config.ts
+++ b/next.config.ts
@@ -9,6 +9,9 @@ const nextConfig: NextConfig = {
       {
         hostname: 'avatar.vercel.sh',
       },
+      {
+        hostname: 'lh3.googleusercontent.com',
+      },
     ],
   },
 };


### PR DESCRIPTION
## Summary
- display the authenticated user's `image` in the sidebar if available
- allow Google profile picture domain in Next.js image config

## Testing
- `pnpm exec biome lint components/sidebar-user-nav.tsx next.config.ts`
- `pnpm test` *(fails: Serving HTML report)*

------
https://chatgpt.com/codex/tasks/task_e_6842a2a41978832a8cc61134cc3bb46c