### PR TITLE
Fix google signin when credentials absent

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ You will need to use the environment variables [defined in `.env.example`](.env.
 2. Link local instance with Vercel and GitHub accounts (creates `.vercel` directory): `vercel link`
 3. Download your environment variables: `vercel env pull`
 4. Add your Google OAuth credentials (`GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET`) to `.env.local`
+5. If these credentials are missing, Google sign-in will be disabled and only guest accounts are available.
 
 ```bash
 pnpm install

--- a/app/(auth)/auth.ts
+++ b/app/(auth)/auth.ts
@@ -2,7 +2,7 @@ import { compare } from 'bcrypt-ts';
 import NextAuth, { type DefaultSession } from 'next-auth';
 import Credentials from 'next-auth/providers/credentials';
 import GoogleProvider from 'next-auth/providers/google';
-import { randomUUID } from 'crypto';
+import { randomUUID } from 'node:crypto';
 import {
   createGuestUser,
   getUser,
@@ -38,6 +38,57 @@ declare module 'next-auth/jwt' {
 }
 
 /* ─── Auth.js configuration  ──────────────────────────────────────── */
+/* Determine available authentication providers */
+const providers = [
+  /* 1. Regular e‑mail/password users  */
+  Credentials({
+    id: 'credentials', // explicit id
+    name: 'Credentials',
+    credentials: {},
+    async authorize({ email, password }: any) {
+      /* Look up the user */
+      const users = await getUser(email);
+      if (users.length === 0) {
+        /* Dummy hash to equalise timing */
+        await compare(password, DUMMY_PASSWORD);
+        return null;
+      }
+
+      const [user] = users;
+      if (!user.password) {
+        await compare(password, DUMMY_PASSWORD);
+        return null;
+      }
+
+      const passwordsMatch = await compare(password, user.password);
+      if (!passwordsMatch) return null;
+
+      return { ...user, type: 'regular' };
+    },
+  }),
+
+  /* 2. One‑click guest users  */
+  Credentials({
+    id: 'guest', // matches signIn('guest')
+    name: 'Guest account',
+    credentials: {},
+    async authorize() {
+      const [guestUser] = await createGuestUser();
+      return { ...guestUser, type: 'guest' };
+    },
+  }),
+];
+
+if (process.env.GOOGLE_CLIENT_ID && process.env.GOOGLE_CLIENT_SECRET) {
+  providers.push(
+    GoogleProvider({
+      clientId: process.env.GOOGLE_CLIENT_ID,
+      clientSecret: process.env.GOOGLE_CLIENT_SECRET,
+      allowDangerousEmailAccountLinking: true,
+    }),
+  );
+}
+
 export const {
   handlers: { GET, POST },
   auth,
@@ -45,55 +96,12 @@ export const {
   signOut,
 } = NextAuth({
   /** ENV: set AUTH_SECRET & (optionally) AUTH_URL  */
-  trustHost: !!process.env.AUTH_TRUST_HOST || process.env.NODE_ENV !== 'production',
+  trustHost:
+    !!process.env.AUTH_TRUST_HOST || process.env.NODE_ENV !== 'production',
 
   ...authConfig,
 
-  providers: [
-    /* 1. Regular e‑mail/password users  */
-    Credentials({
-      id: 'credentials',      // 👈 explicit id
-      name: 'Credentials',
-      credentials: {},
-      async authorize({ email, password }: any) {
-        /* Look up the user */
-        const users = await getUser(email);
-        if (users.length === 0) {
-          /* Dummy hash to equalise timing */
-          await compare(password, DUMMY_PASSWORD);
-          return null;
-        }
-
-        const [user] = users;
-        if (!user.password) {
-          await compare(password, DUMMY_PASSWORD);
-          return null;
-        }
-
-        const passwordsMatch = await compare(password, user.password);
-        if (!passwordsMatch) return null;
-
-        return { ...user, type: 'regular' };
-      },
-    }),
-
-    /* 2. One‑click guest users  */
-    Credentials({
-      id: 'guest',            // 👈 matches signIn('guest')
-      name: 'Guest account',
-      credentials: {},
-      async authorize() {
-        const [guestUser] = await createGuestUser();
-        return { ...guestUser, type: 'guest' };
-      },
-    }),
-
-    GoogleProvider({
-      clientId: process.env.GOOGLE_CLIENT_ID ?? '',
-      clientSecret: process.env.GOOGLE_CLIENT_SECRET ?? '',
-      allowDangerousEmailAccountLinking: true,
-    }),
-  ],
+  providers,
 
   callbacks: {
     async signIn({ user, account }) {

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -16,6 +16,8 @@ import { toast } from '@/components/toast';
 import { useSession, signIn } from 'next-auth/react';
 import { useSWRConfig } from 'swr';
 
+const googleEnabled = process.env.NEXT_PUBLIC_GOOGLE_AUTH_ENABLED === 'true';
+
 export interface RegisterActionState {
   status:
     | 'idle'
@@ -123,11 +125,17 @@ export default function Page() {
             Create an account with your email and password
           </p>
         </div>
-        <div className="px-4 sm:px-16">
-          <Button variant="outline" className="w-full" onClick={handleGoogleSignIn}>
-            <LogoGoogle /> Continue with Google
-          </Button>
-        </div>
+        {googleEnabled && (
+          <div className="px-4 sm:px-16">
+            <Button
+              variant="outline"
+              className="w-full"
+              onClick={handleGoogleSignIn}
+            >
+              <LogoGoogle /> Continue with Google
+            </Button>
+          </div>
+        )}
         <Separator className="my-6" />
         <AuthForm action={handleSubmit} defaultEmail={email}>
           <SubmitButton isSuccessful={isSuccessful}>Sign Up</SubmitButton>

--- a/app/(auth)/register/page.tsx
+++ b/app/(auth)/register/page.tsx
@@ -16,6 +16,8 @@ import { toast } from '@/components/toast';
 import { useSession, signIn } from 'next-auth/react';
 import { useSWRConfig } from 'swr';
 
+const googleEnabled = process.env.NEXT_PUBLIC_GOOGLE_AUTH_ENABLED === 'true';
+
 export interface RegisterActionState {
   status:
     | 'idle'
@@ -125,11 +127,17 @@ export default function Page() {
             Create an account with your email and password
           </p>
         </div>
-        <div className="px-4 sm:px-16">
-          <Button variant="outline" className="w-full" onClick={handleGoogleSignIn}>
-            <LogoGoogle /> Continue with Google
-          </Button>
-        </div>
+        {googleEnabled && (
+          <div className="px-4 sm:px-16">
+            <Button
+              variant="outline"
+              className="w-full"
+              onClick={handleGoogleSignIn}
+            >
+              <LogoGoogle /> Continue with Google
+            </Button>
+          </div>
+        )}
         <Separator className="my-6" />
         <AuthForm action={handleSubmit} defaultEmail={email}>
           <SubmitButton isSuccessful={isSuccessful}>Sign Up</SubmitButton>

--- a/next.config.ts
+++ b/next.config.ts
@@ -4,6 +4,12 @@ const nextConfig: NextConfig = {
   experimental: {
     ppr: true,
   },
+  env: {
+    NEXT_PUBLIC_GOOGLE_AUTH_ENABLED: process.env.GOOGLE_CLIENT_ID &&
+      process.env.GOOGLE_CLIENT_SECRET
+      ? 'true'
+      : 'false',
+  },
   images: {
     remotePatterns: [
       {


### PR DESCRIPTION
## Summary
- conditionally enable Google auth provider when credentials are present
- expose a boolean env for client-side checks
- hide Google signin button when disabled
- document that Google credentials are optional

## Testing
- `pnpm lint`
- `pnpm test` *(fails: playwright tests require dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6842b09ecba8832ab42502dd775fc639