### PR TITLE
Implement guest user persistence

### DIFF
--- a/app/(auth)/api/auth/guest/route.ts
+++ b/app/(auth)/api/auth/guest/route.ts
@@ -2,6 +2,7 @@ import { signIn } from '@/app/(auth)/auth';
 import { isDevelopmentEnvironment } from '@/lib/constants';
 import { getToken } from 'next-auth/jwt';
 import { NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
@@ -17,5 +18,12 @@ export async function GET(request: Request) {
     return NextResponse.redirect(new URL('/', request.url));
   }
 
-  return signIn('guest', { redirect: true, redirectTo: redirectUrl });
+  const cookieStore = await cookies();
+  const guestUserId = cookieStore.get('guest_user_id')?.value;
+
+  return signIn('guest', {
+    redirect: true,
+    redirectTo: redirectUrl,
+    guestUserId,
+  });
 }

--- a/app/(auth)/api/auth/guest/route.ts
+++ b/app/(auth)/api/auth/guest/route.ts
@@ -18,12 +18,17 @@ export async function GET(request: Request) {
     return NextResponse.redirect(new URL('/', request.url));
   }
 
-  const cookieStore = await cookies();
+  const cookieStore = cookies();
   const guestUserId = cookieStore.get('guest_user_id')?.value;
 
-  return signIn('guest', {
+  const signInOptions: Record<string, any> = {
     redirect: true,
     redirectTo: redirectUrl,
-    guestUserId,
-  });
+  };
+
+  if (guestUserId) {
+    signInOptions.guestUserId = guestUserId;
+  }
+
+  return signIn('guest', signInOptions);
 }

--- a/app/(auth)/auth.ts
+++ b/app/(auth)/auth.ts
@@ -75,12 +75,17 @@ const providers = [
     name: 'Guest account',
     credentials: {},
     async authorize(credentials, request) {
-      const cookieStore = await cookies();
-      const cookieId =
-        (credentials as any)?.guestUserId || cookieStore.get('guest_user_id')?.value;
+      const cookieStore = cookies();
+      const credentialId = (credentials as any)?.guestUserId;
+      const cookieId = cookieStore.get('guest_user_id')?.value;
 
-      if (cookieId) {
-        const existingUser = await getUserById(cookieId);
+      const candidateId =
+        credentialId && credentialId !== 'undefined' ? credentialId : cookieId;
+
+      const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+      if (candidateId && uuidRegex.test(candidateId)) {
+        const existingUser = await getUserById(candidateId);
         if (existingUser) {
           const expires = new Date(Date.now() + 1000 * 60 * 60 * 24 * 365);
           cookieStore.set('guest_user_id', existingUser.id, {

--- a/app/(auth)/auth.ts
+++ b/app/(auth)/auth.ts
@@ -7,10 +7,12 @@ import {
   createGuestUser,
   getUser,
   createUser,
+  getUserById,
 } from '@/lib/db/queries';
 import { authConfig } from './auth.config';
 import { DUMMY_PASSWORD } from '@/lib/constants';
 import type { DefaultJWT } from 'next-auth/jwt';
+import { cookies } from 'next/headers';
 
 export type UserType = 'guest' | 'regular';
 
@@ -72,8 +74,33 @@ const providers = [
     id: 'guest', // matches signIn('guest')
     name: 'Guest account',
     credentials: {},
-    async authorize() {
+    async authorize(credentials, request) {
+      const cookieStore = await cookies();
+      const cookieId =
+        (credentials as any)?.guestUserId || cookieStore.get('guest_user_id')?.value;
+
+      if (cookieId) {
+        const existingUser = await getUserById(cookieId);
+        if (existingUser) {
+          const expires = new Date(Date.now() + 1000 * 60 * 60 * 24 * 365);
+          cookieStore.set('guest_user_id', existingUser.id, {
+            httpOnly: true,
+            sameSite: 'lax',
+            secure: process.env.NODE_ENV === 'production',
+            expires,
+          });
+          return { ...existingUser, type: 'guest' };
+        }
+      }
+
       const [guestUser] = await createGuestUser();
+      const expires = new Date(Date.now() + 1000 * 60 * 60 * 24 * 365);
+      cookieStore.set('guest_user_id', guestUser.id, {
+        httpOnly: true,
+        sameSite: 'lax',
+        secure: process.env.NODE_ENV === 'production',
+        expires,
+      });
       return { ...guestUser, type: 'guest' };
     },
   }),

--- a/lib/db/queries.ts
+++ b/lib/db/queries.ts
@@ -101,6 +101,15 @@ export async function getUser(email: string): Promise<Array<User>> {
   }
 }
 
+export async function getUserById(id: string): Promise<User | null> {
+  try {
+    const [foundUser] = await db.select().from(user).where(eq(user.id, id));
+    return foundUser ?? null;
+  } catch (error) {
+    throw new ChatSDKError('bad_request:database', 'Failed to get user by id');
+  }
+}
+
 export async function createUser(email: string, password: string): Promise<User> {
   const hashedPassword = generateHashedPassword(password);
 

--- a/tests/e2e/session.test.ts
+++ b/tests/e2e/session.test.ts
@@ -205,4 +205,29 @@ test.describe('Entitlements', () => {
       getMessageByErrorCode('rate_limit:chat'),
     );
   });
+
+  test('Guest message count persists after login and logout', async ({ page }) => {
+    const authPage = new AuthPage(page);
+    const testUser = generateRandomTestUser();
+
+    await chatPage.createNewChat();
+    await chatPage.sendUserMessage('Why is the sky blue?');
+    await chatPage.isGenerationComplete();
+
+    await authPage.register(testUser.email, testUser.password);
+    await authPage.expectToastToContain('Account created successfully!');
+    await page.waitForURL('/');
+
+    await authPage.openSidebar();
+    const userNavButton = page.getByTestId('user-nav-button');
+    await userNavButton.click();
+    const authMenuItem = page.getByTestId('user-nav-item-auth');
+    await authMenuItem.click();
+    await page.waitForURL('/');
+
+    await chatPage.sendUserMessage('Another question?');
+    await chatPage.expectToastToContain(
+      getMessageByErrorCode('rate_limit:chat'),
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- add `getUserById` query helper
- persist guest credentials via `guest_user_id` cookie
- reuse cookie value in guest auth route
- regression test to ensure guest session counts persist

## Testing
- `pnpm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842bf6c0bd0832a91fe948d788b3859