### PR TITLE
Fix guest session reset after logout

### DIFF
--- a/app/(auth)/api/auth/guest/route.ts
+++ b/app/(auth)/api/auth/guest/route.ts
@@ -1,11 +1,15 @@
-import { signIn } from '@/app/(auth)/auth';
+import { signIn, auth } from '@/app/(auth)/auth';
 import { isDevelopmentEnvironment } from '@/lib/constants';
 import { getToken } from 'next-auth/jwt';
 import { NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const redirectUrl = searchParams.get('redirectUrl') || '/';
+
+  const cookieStore = await cookies();
+  const existingGuestId = cookieStore.get('guest-user-id')?.value;
 
   const token = await getToken({
     req: request,
@@ -17,5 +21,21 @@ export async function GET(request: Request) {
     return NextResponse.redirect(new URL('/', request.url));
   }
 
-  return signIn('guest', { redirect: true, redirectTo: redirectUrl });
+  await signIn('guest', {
+    redirect: false,
+    redirectTo: redirectUrl,
+    guestId: existingGuestId,
+  });
+
+  const session = await auth();
+  if (session?.user?.id) {
+    cookieStore.set('guest-user-id', session.user.id, {
+      httpOnly: true,
+      sameSite: 'lax',
+      path: '/',
+      maxAge: 60 * 60 * 24 * 30,
+    });
+  }
+
+  return NextResponse.redirect(new URL(redirectUrl, request.url));
 }

--- a/app/(auth)/auth.ts
+++ b/app/(auth)/auth.ts
@@ -7,6 +7,7 @@ import {
   createGuestUser,
   getUser,
   createUser,
+  getUserById,
 } from '@/lib/db/queries';
 import { authConfig } from './auth.config';
 import { DUMMY_PASSWORD } from '@/lib/constants';
@@ -71,8 +72,17 @@ const providers = [
   Credentials({
     id: 'guest', // matches signIn('guest')
     name: 'Guest account',
-    credentials: {},
-    async authorize() {
+    credentials: {
+      guestId: { label: 'Guest ID', type: 'text', required: false },
+    },
+    async authorize(credentials) {
+      if (credentials?.guestId) {
+        const user = await getUserById(credentials.guestId);
+        if (user) {
+          return { ...user, type: 'guest' };
+        }
+      }
+
       const [guestUser] = await createGuestUser();
       return { ...guestUser, type: 'guest' };
     },

--- a/lib/db/queries.ts
+++ b/lib/db/queries.ts
@@ -101,6 +101,15 @@ export async function getUser(email: string): Promise<Array<User>> {
   }
 }
 
+export async function getUserById(id: string): Promise<User | null> {
+  try {
+    const [foundUser] = await db.select().from(user).where(eq(user.id, id)).limit(1);
+    return foundUser ?? null;
+  } catch (error) {
+    throw new ChatSDKError('bad_request:database', 'Failed to get user by id');
+  }
+}
+
 export async function createUser(email: string, password: string): Promise<User> {
   const hashedPassword = generateHashedPassword(password);
 


### PR DESCRIPTION
## Summary
- retain guest identity across auth cycles
- reuse guest user ID when signing in anonymously
- add DB helper to look up users by ID
- fix async cookie usage in guest auth route

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Serving HTML report at http://localhost:9323. Press Ctrl+C to quit.)*

------
https://chatgpt.com/codex/tasks/task_e_6842de92b9b8832a9360b44f27b48781