### PR TITLE
Fix guest count persistence after logout

### DIFF
--- a/app/(auth)/api/auth/guest/route.ts
+++ b/app/(auth)/api/auth/guest/route.ts
@@ -1,7 +1,8 @@
-import { signIn } from '@/app/(auth)/auth';
+import { signIn, auth } from '@/app/(auth)/auth';
 import { isDevelopmentEnvironment } from '@/lib/constants';
 import { getToken } from 'next-auth/jwt';
 import { NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
@@ -17,5 +18,24 @@ export async function GET(request: Request) {
     return NextResponse.redirect(new URL('/', request.url));
   }
 
-  return signIn('guest', { redirect: true, redirectTo: redirectUrl });
+  const cookieStore = await cookies();
+  const existingGuestId = cookieStore.get('guest-id')?.value;
+
+  const signInOptions: Record<string, any> = {
+    redirect: false,
+    redirectTo: redirectUrl,
+  };
+  if (existingGuestId) signInOptions.id = existingGuestId;
+
+  const url = await signIn('guest', signInOptions);
+
+  const session = await auth();
+  if (session?.user?.id && session.user.type === 'guest') {
+    cookieStore.set('guest-id', session.user.id, {
+      path: '/',
+      maxAge: 60 * 60 * 24 * 30,
+    });
+  }
+
+  return NextResponse.redirect(url);
 }

--- a/app/(auth)/auth.ts
+++ b/app/(auth)/auth.ts
@@ -7,6 +7,7 @@ import {
   createGuestUser,
   getUser,
   createUser,
+  getUserById,
 } from '@/lib/db/queries';
 import { authConfig } from './auth.config';
 import { DUMMY_PASSWORD } from '@/lib/constants';
@@ -71,8 +72,16 @@ const providers = [
   Credentials({
     id: 'guest', // matches signIn('guest')
     name: 'Guest account',
-    credentials: {},
-    async authorize() {
+    credentials: {
+      id: { label: 'Guest ID', type: 'text', required: false },
+    },
+    async authorize(credentials) {
+      if (credentials?.id) {
+        const [existingUser] = await getUserById(credentials.id);
+        if (existingUser) {
+          return { ...existingUser, type: 'guest' };
+        }
+      }
       const [guestUser] = await createGuestUser();
       return { ...guestUser, type: 'guest' };
     },

--- a/lib/db/queries.ts
+++ b/lib/db/queries.ts
@@ -136,6 +136,17 @@ export async function createUser(
   }
 }
 
+export async function getUserById(id: string): Promise<Array<User>> {
+  try {
+    return await db.select().from(user).where(eq(user.id, id));
+  } catch (error) {
+    throw new ChatSDKError(
+      'bad_request:database',
+      'Failed to get user by id',
+    );
+  }
+}
+
 export async function createGuestUser(): Promise<
   Array<Pick<User, 'id' | 'email'>>
 > {


### PR DESCRIPTION
## Summary
- preserve guest ID across sign-in/sign-out
- allow guest provider to reuse an existing user id
- expose getUserById DB helper
- fix cookies() usage in guest auth route

## Testing
- `pnpm lint`
- `pnpm test` *(fails: 34 did not run)*

------
https://chatgpt.com/codex/tasks/task_e_6843178bf52c832a99aef50d68c45c6a