### PR TITLE
Fix logout message limit reset

### DIFF
--- a/app/(auth)/actions.ts
+++ b/app/(auth)/actions.ts
@@ -4,6 +4,7 @@
 import { z } from 'zod';
 import { createUser, getUser, transferChatOwnership } from '@/lib/db/queries';
 import { signIn } from './auth';
+import { cookies } from 'next/headers';
 import type { User } from '@/lib/db/schema';
 import { ChatSDKError } from '@/lib/errors';
 
@@ -67,9 +68,11 @@ export const login = async (
       }
     }
     
-    const redirectTo = chatIdToResume 
+    const redirectTo = chatIdToResume
       ? `/chat/${chatIdToResume}${unsentPrompt ? `?prompt=${encodeURIComponent(unsentPrompt)}` : ''}`
       : '/';
+
+    cookies().delete('loggedOut');
 
     return { status: 'success', redirectTo };
 
@@ -139,9 +142,11 @@ export const register = async (
       redirect: false,
     });
     
-    const redirectTo = chatIdToResume 
+    const redirectTo = chatIdToResume
       ? `/chat/${chatIdToResume}${unsentPrompt ? `?prompt=${encodeURIComponent(unsentPrompt)}` : ''}`
       : '/';
+
+    cookies().delete('loggedOut');
 
     return { status: 'success', redirectTo };
   } catch (error) {

--- a/app/(chat)/api/message-status/route.ts
+++ b/app/(chat)/api/message-status/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { auth, type UserType } from '@/app/(auth)/auth';
 import { getMessageCountByUserId } from '@/lib/db/queries';
 import { entitlementsByUserType } from '@/lib/ai/entitlements';
+import { cookies } from 'next/headers';
 import { addHours, isAfter, subHours } from 'date-fns';
 import { db } from '@/lib/db/drizzle-client'; // Assuming you'll create a central db client
 import { message, chat } from '@/lib/db/schema';
@@ -18,12 +19,23 @@ export async function GET() {
   const userType: UserType = session.user.type;
   const maxMessages = entitlementsByUserType[userType].maxMessagesPerDay;
 
+  const logoutCookie = cookies().get('loggedOut');
+
+  if (logoutCookie && userType === 'guest') {
+    return NextResponse.json({
+      messagesLeft: 0,
+      maxMessages,
+      nextResetTimestamp: null,
+      userType,
+    });
+  }
+
   const messagesInLast24Hours = await getMessageCountByUserId({
     id: userId,
     differenceInHours: 24,
   });
 
-  const messagesLeft = Math.max(0, maxMessages - messagesInLast24Hours);
+  let messagesLeft = Math.max(0, maxMessages - messagesInLast24Hours);
   let nextResetTimestamp: number | null = null;
 
   if (userType === 'guest') {

--- a/components/sidebar-user-nav.tsx
+++ b/components/sidebar-user-nav.tsx
@@ -97,6 +97,7 @@ export function SidebarUserNav({ user }: { user: User }) {
                   if (isGuest) {
                     router.push('/login');
                   } else {
+                    document.cookie = 'loggedOut=1; path=/';
                     signOut({
                       redirectTo: '/',
                     });

--- a/components/sign-out-form.tsx
+++ b/components/sign-out-form.tsx
@@ -1,6 +1,7 @@
 import Form from 'next/form';
 
 import { signOut } from '@/app/(auth)/auth';
+import { cookies } from 'next/headers';
 
 export const SignOutForm = () => {
   return (
@@ -8,6 +9,8 @@ export const SignOutForm = () => {
       className="w-full"
       action={async () => {
         'use server';
+        const cookieStore = cookies();
+        cookieStore.set('loggedOut', '1');
 
         await signOut({
           redirectTo: '/',


### PR DESCRIPTION
## Summary
- set logout cookie before calling `signOut`
- server sign-out sets cookie too
- clear logout cookie on login or register
- block message quota when `loggedOut` cookie exists

## Testing
- `pnpm exec playwright test` *(fails: Serving HTML report)*

------
https://chatgpt.com/codex/tasks/task_e_684342256130832a9038760608885afa