### PR TITLE
Add stripe upgrade flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,3 +21,12 @@ GOOGLE_CLIENT_SECRET=****
 # Instructions to create a Redis store here:
 # https://vercel.com/docs/redis
 REDIS_URL=****
+
+# Stripe Credentials
+STRIPE_SECRET_KEY=****
+STRIPE_PRICE_BASIC_ID=****
+STRIPE_PRICE_GEMIDDELD_ID=****
+STRIPE_PRICE_TOP_ID=****
+
+# Base URL of your deployed application
+NEXT_PUBLIC_APP_URL=****

--- a/app/(auth)/auth.ts
+++ b/app/(auth)/auth.ts
@@ -12,7 +12,7 @@ import { authConfig } from './auth.config';
 import { DUMMY_PASSWORD } from '@/lib/constants';
 import type { DefaultJWT } from 'next-auth/jwt';
 
-export type UserType = 'guest' | 'regular';
+export type UserType = 'guest' | 'regular' | 'basic' | 'gemiddeld' | 'top';
 
 /* ─── Type augmentations ───────────────────────────────────────────── */
 declare module 'next-auth' {

--- a/app/(chat)/api/checkout/route.ts
+++ b/app/(chat)/api/checkout/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from 'next/server';
+import stripe from '@/lib/stripe';
+import { auth } from '@/app/(auth)/auth';
+
+const PRICE_MAP: Record<string, string | undefined> = {
+  'basic-model': process.env.STRIPE_PRICE_BASIC_ID,
+  'gemiddeld-model': process.env.STRIPE_PRICE_GEMIDDELD_ID,
+  'top-model': process.env.STRIPE_PRICE_TOP_ID,
+};
+
+export async function POST(req: Request) {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { planId } = await req.json();
+  const priceId = PRICE_MAP[planId];
+  if (!priceId) {
+    return NextResponse.json({ error: 'Invalid plan' }, { status: 400 });
+  }
+
+  const checkout = await stripe.checkout.sessions.create({
+    mode: 'payment',
+    line_items: [{ price: priceId, quantity: 1 }],
+    success_url: `${process.env.NEXT_PUBLIC_APP_URL}/?success=true`,
+    cancel_url: `${process.env.NEXT_PUBLIC_APP_URL}/?canceled=true`,
+    customer_email: session.user.email ?? undefined,
+    metadata: { userId: session.user.id, planId },
+  });
+
+  return NextResponse.json({ url: checkout.url });
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,7 +5,8 @@ import { ThemeProvider } from '@/components/theme-provider';
 
 import './globals.css';
 import { SessionProvider } from 'next-auth/react';
-import { LoginSignupDialog } from '@/components/ui/login-signup-dialog'; // Added
+import { LoginSignupDialog } from '@/components/ui/login-signup-dialog';
+import { UpgradeDialog } from '@/components/ui/upgrade-dialog';
 
 export const metadata: Metadata = {
   metadataBase: new URL('https://chat.vercel.ai'),
@@ -77,7 +78,8 @@ export default async function RootLayout({
           <Toaster position="top-center" />
           <SessionProvider>
             {children}
-            <LoginSignupDialog /> {/* Added Dialog Here */}
+            <LoginSignupDialog />
+            <UpgradeDialog />
           </SessionProvider>
         </ThemeProvider>
       </body>

--- a/components/chat-header.tsx
+++ b/components/chat-header.tsx
@@ -14,6 +14,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip';
 import { type VisibilityType, VisibilitySelector } from './visibility-selector';
 import type { Session } from 'next-auth';
 import { MessageLimitIndicator } from './message-limit-indicator'; // Added
+import { useUpgradePopup } from '@/hooks/use-upgrade-popup';
 
 function PureChatHeader({
   chatId,
@@ -30,6 +31,7 @@ function PureChatHeader({
 }) {
   const router = useRouter();
   const { open } = useSidebar();
+  const { openPopup: openUpgradePopup } = useUpgradePopup();
 
   const { width: windowWidth } = useWindowSize();
 
@@ -79,6 +81,15 @@ function PureChatHeader({
 
       <div className="flex-grow md:flex-grow-0" /> {/* Pushes elements to the right more effectively */}
 
+      {session?.user?.type === 'regular' && (
+        <Button
+          variant="outline"
+          className="hidden md:flex py-1.5 px-2 h-fit md:h-[34px] order-last md:order-4 ml-2"
+          onClick={() => openUpgradePopup()}
+        >
+          Upgrade
+        </Button>
+      )}
 
       <Button
         className="bg-zinc-900 dark:bg-zinc-100 hover:bg-zinc-800 dark:hover:bg-zinc-200 text-zinc-50 dark:text-zinc-900 hidden md:flex py-1.5 px-2 h-fit md:h-[34px] order-last md:order-5 ml-2" // order-4 to order-last/5 and ml-auto to ml-2

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -22,6 +22,7 @@ import { useChatVisibility } from '@/hooks/use-chat-visibility';
 import { useAutoResume } from '@/hooks/use-auto-resume';
 import { ChatSDKError } from '@/lib/errors';
 import { useLoginSignupPopup } from '@/hooks/use-login-signup-popup';
+import { useUpgradePopup } from '@/hooks/use-upgrade-popup';
 import type { UserType } from '@/app/(auth)/auth';
 
 type ChatRequestOptions = CoreChatRequestOptions;
@@ -54,6 +55,7 @@ export function Chat({
 }) {
   const { mutate: mutateGlobal } = useSWRConfig();
   const { openPopup: openLoginSignupPopup } = useLoginSignupPopup();
+  const { openPopup: openUpgradePopup } = useUpgradePopup();
   const hasSetInitialInputRef = useRef(false);
 
   const { visibilityType } = useChatVisibility({
@@ -158,13 +160,17 @@ export function Chat({
     // Allow calling without an event when submitting programmatically
     eOrForm?.preventDefault?.();
     
-    if (messageStatus?.userType === 'guest' && (messageStatus.messagesLeft <= 0 && input.trim() !== '')) {
-      if (session.user?.id) {
-        openLoginSignupPopup({
-          chatId: id,
-          guestUserId: session.user.id,
-          unsentPrompt: input,
-        });
+    if (messageStatus && messageStatus.messagesLeft <= 0 && input.trim() !== '') {
+      if (messageStatus.userType === 'guest') {
+        if (session.user?.id) {
+          openLoginSignupPopup({
+            chatId: id,
+            guestUserId: session.user.id,
+            unsentPrompt: input,
+          });
+        }
+      } else {
+        openUpgradePopup();
       }
       return;
     }
@@ -181,18 +187,22 @@ export function Chat({
     // The first argument to useChat's handleSubmit can be an event or options.
     // If eOrForm is an event, it's passed. If it's undefined (programmatic call), pass undefined.
     internalUseChatHandleSubmit(eOrForm, optionsWithAttachments);
-  }, [messageStatus, openLoginSignupPopup, internalUseChatHandleSubmit, id, attachments, input, session.user?.id]);
+  }, [messageStatus, openLoginSignupPopup, openUpgradePopup, internalUseChatHandleSubmit, id, attachments, input, session.user?.id]);
 
 
   const append: UseChatHelpers['append'] = useCallback(
     async (message, chatRequestOptions) => {
-    if (messageStatus?.userType === 'guest' && (messageStatus.messagesLeft <= 0)) {
-       if (session.user?.id) {
-         openLoginSignupPopup({
-           chatId: id,
-           guestUserId: session.user.id,
-           unsentPrompt: typeof message.content === 'string' ? message.content : input,
-         });
+    if (messageStatus && messageStatus.messagesLeft <= 0) {
+       if (messageStatus.userType === 'guest') {
+         if (session.user?.id) {
+           openLoginSignupPopup({
+             chatId: id,
+             guestUserId: session.user.id,
+             unsentPrompt: typeof message.content === 'string' ? message.content : input,
+           });
+         }
+       } else {
+         openUpgradePopup();
        }
       return null;
     }
@@ -202,7 +212,7 @@ export function Chat({
     }
     return internalUseChatAppend(message, chatRequestOptions);
   // Dependencies for the outer useCallback wrapper for `append`
-  }, [messageStatus?.userType, messageStatus?.messagesLeft, session?.user?.id, openLoginSignupPopup, id, input, internalUseChatAppend]);
+  }, [messageStatus, session?.user?.id, openLoginSignupPopup, openUpgradePopup, id, input, internalUseChatAppend]);
 
   const { data: votes } = useSWR<Array<Vote>>(
     messages.length >= 2 ? `/api/vote?chatId=${id}` : null,

--- a/components/message-limit-indicator.tsx
+++ b/components/message-limit-indicator.tsx
@@ -86,7 +86,7 @@ export function MessageLimitIndicator({
     );
   }
 
-   if (data.userType !== 'guest') {
+   if (data.userType !== 'guest' && data.userType !== 'regular') {
      return null;
    }
 

--- a/components/ui/upgrade-dialog.tsx
+++ b/components/ui/upgrade-dialog.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogOverlay } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { useUpgradePopup } from '@/hooks/use-upgrade-popup';
+import { useState } from 'react';
+
+interface Plan {
+  id: string;
+  name: string;
+  description: string;
+  price: string;
+  image: string;
+}
+
+const plans: Array<Plan> = [
+  { id: 'basic-model', name: 'BASIC MODEL', description: 'The fast and reliable model.', price: '€4.99', image: '/placeholder.png' },
+  { id: 'gemiddeld-model', name: 'GEMMIDDELD MODEL', description: 'Very good model capable of most tasks.', price: '€9.99', image: '/placeholder.png' },
+  { id: 'top-model', name: 'TOP MODEL', description: 'Best state of the art model capable of everything.', price: '€19.99', image: '/placeholder.png' },
+];
+
+export function UpgradeDialog() {
+  const { isOpen, closePopup } = useUpgradePopup();
+  const [loadingId, setLoadingId] = useState<string | null>(null);
+
+  async function checkout(planId: string) {
+    setLoadingId(planId);
+    const res = await fetch('/api/checkout', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ planId }),
+    });
+    const data = await res.json();
+    setLoadingId(null);
+    if (data.url) {
+      window.location.href = data.url;
+    }
+  }
+
+  if (!isOpen) return null;
+
+  return (
+    <Dialog open={isOpen} onOpenChange={closePopup}>
+      <DialogOverlay className="backdrop-blur-sm" />
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Upgrade Account</DialogTitle>
+          <DialogDescription>Select a model to unlock unlimited access.</DialogDescription>
+        </DialogHeader>
+        <div className="grid gap-4 mt-4">
+          {plans.map((plan) => (
+            <div key={plan.id} className="border rounded-md p-4 flex flex-col items-start">
+              <img src={plan.image} alt={plan.name} className="h-24 w-full object-cover rounded" />
+              <h3 className="mt-2 font-semibold">{plan.name}</h3>
+              <p className="text-sm text-muted-foreground">{plan.description}</p>
+              <p className="font-bold mt-2">{plan.price}</p>
+              <Button className="mt-2 w-full" onClick={() => checkout(plan.id)} disabled={loadingId === plan.id}>
+                {loadingId === plan.id ? 'Loading...' : 'Purchase'}
+              </Button>
+            </div>
+          ))}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/ui/upgrade-dialog.tsx
+++ b/components/ui/upgrade-dialog.tsx
@@ -1,6 +1,13 @@
 'use client';
 
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogOverlay } from '@/components/ui/dialog';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogOverlay,
+} from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { useUpgradePopup } from '@/hooks/use-upgrade-popup';
 import { useState } from 'react';
@@ -14,9 +21,27 @@ interface Plan {
 }
 
 const plans: Array<Plan> = [
-  { id: 'basic-model', name: 'BASIC MODEL', description: 'The fast and reliable model.', price: '€4.99', image: '/placeholder.png' },
-  { id: 'gemiddeld-model', name: 'GEMMIDDELD MODEL', description: 'Very good model capable of most tasks.', price: '€9.99', image: '/placeholder.png' },
-  { id: 'top-model', name: 'TOP MODEL', description: 'Best state of the art model capable of everything.', price: '€19.99', image: '/placeholder.png' },
+  {
+    id: 'basic-model',
+    name: 'BASIC MODEL',
+    description: 'The fast and reliable model.',
+    price: '€4.99',
+    image: '/placeholder.png',
+  },
+  {
+    id: 'gemiddeld-model',
+    name: 'GEMMIDDELD MODEL',
+    description: 'Very good model capable of most tasks.',
+    price: '€9.99',
+    image: '/placeholder.png',
+  },
+  {
+    id: 'top-model',
+    name: 'TOP MODEL',
+    description: 'Best state of the art model capable of everything.',
+    price: '€19.99',
+    image: '/placeholder.png',
+  },
 ];
 
 export function UpgradeDialog() {
@@ -45,16 +70,31 @@ export function UpgradeDialog() {
       <DialogContent className="max-w-lg">
         <DialogHeader>
           <DialogTitle>Upgrade Account</DialogTitle>
-          <DialogDescription>Select a model to unlock unlimited access.</DialogDescription>
+          <DialogDescription>
+            Select a model to unlock unlimited access.
+          </DialogDescription>
         </DialogHeader>
-        <div className="grid gap-4 mt-4">
+        <div className="flex flex-wrap gap-4 mt-4">
           {plans.map((plan) => (
-            <div key={plan.id} className="border rounded-md p-4 flex flex-col items-start">
-              <img src={plan.image} alt={plan.name} className="h-24 w-full object-cover rounded" />
+            <div
+              key={plan.id}
+              className="border rounded-md p-4 flex flex-col items-start w-full sm:w-1/3"
+            >
+              <img
+                src={plan.image}
+                alt={plan.name}
+                className="h-24 w-full object-cover rounded"
+              />
               <h3 className="mt-2 font-semibold">{plan.name}</h3>
-              <p className="text-sm text-muted-foreground">{plan.description}</p>
+              <p className="text-sm text-muted-foreground">
+                {plan.description}
+              </p>
               <p className="font-bold mt-2">{plan.price}</p>
-              <Button className="mt-2 w-full" onClick={() => checkout(plan.id)} disabled={loadingId === plan.id}>
+              <Button
+                className="mt-2 w-full"
+                onClick={() => checkout(plan.id)}
+                disabled={loadingId === plan.id}
+              >
                 {loadingId === plan.id ? 'Loading...' : 'Purchase'}
               </Button>
             </div>

--- a/hooks/use-upgrade-popup.ts
+++ b/hooks/use-upgrade-popup.ts
@@ -1,0 +1,13 @@
+import { create } from 'zustand';
+
+interface UpgradePopupState {
+  isOpen: boolean;
+  openPopup: () => void;
+  closePopup: () => void;
+}
+
+export const useUpgradePopup = create<UpgradePopupState>((set) => ({
+  isOpen: false,
+  openPopup: () => set({ isOpen: true }),
+  closePopup: () => set({ isOpen: false }),
+}));

--- a/lib/ai/entitlements.ts
+++ b/lib/ai/entitlements.ts
@@ -11,16 +11,31 @@ export const entitlementsByUserType: Record<UserType, Entitlements> = {
    * For users without an account
    */
   guest: {
-    maxMessagesPerDay: 1, // <-- CHANGED FROM 20 to 1
-    availableChatModelIds: ['chat-model', 'chat-model-reasoning'],
+    maxMessagesPerDay: 10,
+    availableChatModelIds: ['chat-model'],
   },
 
   /*
    * For users with an account
    */
   regular: {
-    maxMessagesPerDay: 100,
-    availableChatModelIds: ['chat-model', 'chat-model-reasoning'],
+    maxMessagesPerDay: 10,
+    availableChatModelIds: ['chat-model'],
+  },
+
+  basic: {
+    maxMessagesPerDay: Number.MAX_SAFE_INTEGER,
+    availableChatModelIds: ['basic-model'],
+  },
+
+  gemiddeld: {
+    maxMessagesPerDay: Number.MAX_SAFE_INTEGER,
+    availableChatModelIds: ['gemiddeld-model'],
+  },
+
+  top: {
+    maxMessagesPerDay: Number.MAX_SAFE_INTEGER,
+    availableChatModelIds: ['top-model'],
   },
 
   /*

--- a/lib/ai/entitlements.ts
+++ b/lib/ai/entitlements.ts
@@ -11,7 +11,7 @@ export const entitlementsByUserType: Record<UserType, Entitlements> = {
    * For users without an account
    */
   guest: {
-    maxMessagesPerDay: 10,
+    maxMessagesPerDay: 1,
     availableChatModelIds: ['chat-model'],
   },
 

--- a/lib/ai/models.ts
+++ b/lib/ai/models.ts
@@ -17,4 +17,19 @@ export const chatModels: Array<ChatModel> = [
     name: 'Reasoning model',
     description: 'Uses advanced reasoning',
   },
+  {
+    id: 'basic-model',
+    name: 'BASIC MODEL',
+    description: 'The fast and reliable model. Unlimited access.',
+  },
+  {
+    id: 'gemiddeld-model',
+    name: 'GEMMIDDELD MODEL',
+    description: 'Very good model capable of most tasks. Unlimited access.',
+  },
+  {
+    id: 'top-model',
+    name: 'TOP MODEL',
+    description: 'State of the art model capable of everything. Unlimited access.',
+  },
 ];

--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -18,6 +18,9 @@ export const myProvider = isTestEnvironment
       languageModels: {
         'chat-model': chatModel,
         'chat-model-reasoning': reasoningModel,
+        'basic-model': chatModel,
+        'gemiddeld-model': chatModel,
+        'top-model': chatModel,
         'title-model': titleModel,
         'artifact-model': artifactModel,
       },
@@ -27,6 +30,10 @@ export const myProvider = isTestEnvironment
       languageModels: {
         /* flagship model for normal chat                                */
         'chat-model': openai('gpt-4.1'),             // GPT‑4.1 :contentReference[oaicite:4]{index=4}
+
+        'basic-model': openai('gpt-4.1'),
+        'gemiddeld-model': openai('gpt-4.1'),
+        'top-model': openai('gpt-4.1'),
 
         /* reasoning stream with <think> traces, using 4o‑mini           */
         'chat-model-reasoning': wrapLanguageModel({

--- a/lib/stripe.ts
+++ b/lib/stripe.ts
@@ -1,0 +1,8 @@
+// eslint-disable-next-line import/no-unresolved
+import Stripe from 'stripe';
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY || '', {
+  apiVersion: '2022-11-15',
+});
+
+export default stripe;

--- a/package.json
+++ b/package.json
@@ -88,7 +88,8 @@
     "tailwindcss-animate": "^1.0.7",
     "usehooks-ts": "^3.1.0",
     "zod": "^3.23.8",
-    "zustand": "^5.0.5"
+    "zustand": "^5.0.5",
+    "stripe": "^12.0.0"
   },
   "devDependencies": {
     "@biomejs/biome": "1.9.4",


### PR DESCRIPTION
## Summary
- add stripe dependency and helper
- define entitlements for paid plans
- add new chat models and provider mappings
- implement upgrade dialog with checkout API
- show upgrade button when free user hits limit
- expose upgrade popup via layout

## Testing
- `pnpm lint`
- `pnpm test` *(fails: browsers not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6843f02f5874832a8b9c67c6cca6fe10