### PR TITLE
Fix stripe env config and upgrade UI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,3 +21,12 @@ GOOGLE_CLIENT_SECRET=****
 # Instructions to create a Redis store here:
 # https://vercel.com/docs/redis
 REDIS_URL=****
+
+# Stripe Credentials
+STRIPE_SECRET_KEY=****
+STRIPE_PRICE_BASIC_ID=****
+STRIPE_PRICE_GEMIDDELD_ID=****
+STRIPE_PRICE_TOP_ID=****
+
+# Base URL of your deployed application
+NEXT_PUBLIC_APP_URL=****

--- a/components/ui/upgrade-dialog.tsx
+++ b/components/ui/upgrade-dialog.tsx
@@ -1,6 +1,13 @@
 'use client';
 
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogOverlay } from '@/components/ui/dialog';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogOverlay,
+} from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { useUpgradePopup } from '@/hooks/use-upgrade-popup';
 import { useState } from 'react';
@@ -14,9 +21,27 @@ interface Plan {
 }
 
 const plans: Array<Plan> = [
-  { id: 'basic-model', name: 'BASIC MODEL', description: 'The fast and reliable model.', price: '€4.99', image: '/placeholder.png' },
-  { id: 'gemiddeld-model', name: 'GEMMIDDELD MODEL', description: 'Very good model capable of most tasks.', price: '€9.99', image: '/placeholder.png' },
-  { id: 'top-model', name: 'TOP MODEL', description: 'Best state of the art model capable of everything.', price: '€19.99', image: '/placeholder.png' },
+  {
+    id: 'basic-model',
+    name: 'BASIC MODEL',
+    description: 'The fast and reliable model.',
+    price: '€4.99',
+    image: '/placeholder.png',
+  },
+  {
+    id: 'gemiddeld-model',
+    name: 'GEMMIDDELD MODEL',
+    description: 'Very good model capable of most tasks.',
+    price: '€9.99',
+    image: '/placeholder.png',
+  },
+  {
+    id: 'top-model',
+    name: 'TOP MODEL',
+    description: 'Best state of the art model capable of everything.',
+    price: '€19.99',
+    image: '/placeholder.png',
+  },
 ];
 
 export function UpgradeDialog() {
@@ -45,16 +70,31 @@ export function UpgradeDialog() {
       <DialogContent className="max-w-lg">
         <DialogHeader>
           <DialogTitle>Upgrade Account</DialogTitle>
-          <DialogDescription>Select a model to unlock unlimited access.</DialogDescription>
+          <DialogDescription>
+            Select a model to unlock unlimited access.
+          </DialogDescription>
         </DialogHeader>
-        <div className="grid gap-4 mt-4">
+        <div className="flex flex-wrap gap-4 mt-4">
           {plans.map((plan) => (
-            <div key={plan.id} className="border rounded-md p-4 flex flex-col items-start">
-              <img src={plan.image} alt={plan.name} className="h-24 w-full object-cover rounded" />
+            <div
+              key={plan.id}
+              className="border rounded-md p-4 flex flex-col items-start w-full sm:w-1/3"
+            >
+              <img
+                src={plan.image}
+                alt={plan.name}
+                className="h-24 w-full object-cover rounded"
+              />
               <h3 className="mt-2 font-semibold">{plan.name}</h3>
-              <p className="text-sm text-muted-foreground">{plan.description}</p>
+              <p className="text-sm text-muted-foreground">
+                {plan.description}
+              </p>
               <p className="font-bold mt-2">{plan.price}</p>
-              <Button className="mt-2 w-full" onClick={() => checkout(plan.id)} disabled={loadingId === plan.id}>
+              <Button
+                className="mt-2 w-full"
+                onClick={() => checkout(plan.id)}
+                disabled={loadingId === plan.id}
+              >
                 {loadingId === plan.id ? 'Loading...' : 'Purchase'}
               </Button>
             </div>

--- a/lib/ai/entitlements.ts
+++ b/lib/ai/entitlements.ts
@@ -11,7 +11,7 @@ export const entitlementsByUserType: Record<UserType, Entitlements> = {
    * For users without an account
    */
   guest: {
-    maxMessagesPerDay: 10,
+    maxMessagesPerDay: 1,
     availableChatModelIds: ['chat-model'],
   },
 


### PR DESCRIPTION
## Summary
- add Stripe keys and base URL to `.env.example`
- limit guest users to 1 free message per day
- lay out upgrade plans horizontally

## Testing
- `npx biome format --write .env.example lib/ai/entitlements.ts components/ui/upgrade-dialog.tsx`
- `pnpm test` *(fails: browser executable missing)*

------
https://chatgpt.com/codex/tasks/task_e_6843f57b8544832abfd89236b076c368