### PR TITLE
Switch Stripe checkout to subscription mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,7 @@ REDIS_URL=****
 
 # Stripe Credentials
 STRIPE_SECRET_KEY=****
+# Use subscription price IDs for the plans below
 STRIPE_PRICE_BASIC_ID=****
 STRIPE_PRICE_GEMIDDELD_ID=****
 STRIPE_PRICE_TOP_ID=****

--- a/app/(chat)/api/checkout/route.ts
+++ b/app/(chat)/api/checkout/route.ts
@@ -21,7 +21,7 @@ export async function POST(req: Request) {
   }
 
   const checkout = await stripe.checkout.sessions.create({
-    mode: 'payment',
+    mode: 'subscription',
     line_items: [{ price: priceId, quantity: 1 }],
     success_url: `${process.env.NEXT_PUBLIC_APP_URL}/?success=true`,
     cancel_url: `${process.env.NEXT_PUBLIC_APP_URL}/?canceled=true`,


### PR DESCRIPTION
## Summary
- switch Stripe checkout to `subscription` mode
- note that price IDs must be subscription prices in `.env.example`

## Testing
- `pnpm exec playwright test` *(fails: browser download missing)*

------
https://chatgpt.com/codex/tasks/task_e_6844a5647ed4832a9b0853743dde824c