### PR TITLE
Add subscription model upgrades

### DIFF
--- a/app/(auth)/auth.ts
+++ b/app/(auth)/auth.ts
@@ -11,8 +11,7 @@ import {
 import { authConfig } from './auth.config';
 import { DUMMY_PASSWORD } from '@/lib/constants';
 import type { DefaultJWT } from 'next-auth/jwt';
-
-export type UserType = 'guest' | 'regular' | 'basic' | 'gemiddeld' | 'top';
+import type { UserType } from '@/lib/user-types';
 
 /* ─── Type augmentations ───────────────────────────────────────────── */
 declare module 'next-auth' {
@@ -54,16 +53,16 @@ const providers = [
         return null;
       }
 
-      const [user] = users;
-      if (!user.password) {
+      const [dbUser] = users;
+      if (!dbUser.password) {
         await compare(password, DUMMY_PASSWORD);
         return null;
       }
 
-      const passwordsMatch = await compare(password, user.password);
+      const passwordsMatch = await compare(password, dbUser.password);
       if (!passwordsMatch) return null;
 
-      return { ...user, type: 'regular' };
+      return { ...dbUser };
     },
   }),
 
@@ -94,6 +93,7 @@ export const {
   auth,
   signIn,
   signOut,
+  unstable_update,
 } = NextAuth({
   /** ENV: set AUTH_SECRET & (optionally) AUTH_URL  */
   trustHost:
@@ -110,11 +110,12 @@ export const {
         const [existingUser] = await getUser(user.email);
         if (existingUser) {
           user.id = existingUser.id;
+          (user as any).type = existingUser.type;
         } else {
           const newUser = await createUser(user.email, randomUUID());
           user.id = newUser.id;
+          (user as any).type = newUser.type;
         }
-        (user as any).type = 'regular';
       }
       return true;
     },

--- a/app/(chat)/actions.ts
+++ b/app/(chat)/actions.ts
@@ -51,3 +51,29 @@ export async function updateChatVisibility({
 }) {
   await updateChatVisiblityById({ chatId, visibility });
 }
+
+export async function updateUserTypeAfterCheckout({
+  userId,
+  planId,
+}: {
+  userId: string;
+  planId: string;
+}) {
+  const { db } = await import('@/lib/db/drizzle-client');
+  const schemaModule = await import('@/lib/db/schema');
+  const userTable = schemaModule.user;
+  const { eq } = await import('drizzle-orm');
+  const { unstable_update } = await import('@/app/(auth)/auth');
+
+  const PLAN_MAP: Record<string, 'basic' | 'gemiddeld' | 'top' | undefined> = {
+    'basic-model': 'basic',
+    'gemiddeld-model': 'gemiddeld',
+    'top-model': 'top',
+  };
+
+  const type = PLAN_MAP[planId];
+  if (!type) return;
+
+  await db.update(userTable).set({ type }).where(eq(userTable.id, userId));
+  await unstable_update({ user: { type } });
+}

--- a/app/(chat)/api/chat/route.ts
+++ b/app/(chat)/api/chat/route.ts
@@ -6,7 +6,8 @@ import {
   streamText,
   StreamData, // Use StreamData directly
 } from 'ai';
-import { auth, type UserType } from '@/app/(auth)/auth';
+import { auth } from '@/app/(auth)/auth';
+import type { UserType } from '@/lib/user-types';
 import { type RequestHints, systemPrompt } from '@/lib/ai/prompts';
 import {
   createStreamId,

--- a/app/(chat)/api/checkout/route.ts
+++ b/app/(chat)/api/checkout/route.ts
@@ -23,7 +23,7 @@ export async function POST(req: Request) {
   const checkout = await stripe.checkout.sessions.create({
     mode: 'subscription',
     line_items: [{ price: priceId, quantity: 1 }],
-    success_url: `${process.env.NEXT_PUBLIC_APP_URL}/?success=true`,
+    success_url: `${process.env.NEXT_PUBLIC_APP_URL}/?success=true&planId=${planId}`,
     cancel_url: `${process.env.NEXT_PUBLIC_APP_URL}/?canceled=true`,
     customer_email: session.user.email ?? undefined,
     metadata: { userId: session.user.id, planId },

--- a/app/(chat)/api/message-status/route.ts
+++ b/app/(chat)/api/message-status/route.ts
@@ -1,8 +1,9 @@
 import { NextResponse } from 'next/server';
-import { auth, type UserType } from '@/app/(auth)/auth';
+import { auth } from '@/app/(auth)/auth';
+import type { UserType } from '@/lib/user-types';
 import { getMessageCountByUserId } from '@/lib/db/queries';
 import { entitlementsByUserType } from '@/lib/ai/entitlements';
-import { addHours, isAfter, subHours } from 'date-fns';
+import { addHours, subHours } from 'date-fns';
 import { db } from '@/lib/db/drizzle-client'; // Assuming you'll create a central db client
 import { message, chat } from '@/lib/db/schema';
 import { and, eq, gte, asc } from 'drizzle-orm';

--- a/app/(chat)/api/plan/route.ts
+++ b/app/(chat)/api/plan/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from 'next/server';
+import { auth, unstable_update } from '@/app/(auth)/auth';
+import { db } from '@/lib/db/drizzle-client';
+import { user } from '@/lib/db/schema';
+import { eq } from 'drizzle-orm';
+
+const PLAN_MAP: Record<string, 'basic' | 'gemiddeld' | 'top' | undefined> = {
+  'basic-model': 'basic',
+  'gemiddeld-model': 'gemiddeld',
+  'top-model': 'top',
+};
+
+export async function POST(req: Request) {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const { planId } = await req.json();
+  const type = PLAN_MAP[planId];
+  if (!type) {
+    return NextResponse.json({ error: 'Invalid plan' }, { status: 400 });
+  }
+
+  await db.update(user).set({ type }).where(eq(user.id, session.user.id));
+  await unstable_update({ user: { type } });
+
+  return NextResponse.json({ success: true });
+}

--- a/app/(chat)/page.tsx
+++ b/app/(chat)/page.tsx
@@ -23,13 +23,8 @@ export default async function Page({
       : null;
 
   if (success && planId && session?.user?.id) {
-    const { updateUserTypeAfterCheckout } = await import('./actions');
-    await updateUserTypeAfterCheckout({
-      userId: session.user.id,
-      planId,
-    });
-
-    redirect('/');
+    const { PostCheckoutUpdater } = await import('@/components/post-checkout-updater');
+    return <PostCheckoutUpdater userId={session.user.id} planId={planId} />;
   }
 
   if (!session) {

--- a/app/(chat)/page.tsx
+++ b/app/(chat)/page.tsx
@@ -23,23 +23,11 @@ export default async function Page({
       : null;
 
   if (success && planId && session?.user?.id) {
-    const { db } = await import('@/lib/db/drizzle-client');
-    const schemaModule = await import('@/lib/db/schema');
-    const userTable = schemaModule.user;
-    const { eq } = await import('drizzle-orm');
-    const { unstable_update } = await import('@/app/(auth)/auth');
-
-    const PLAN_MAP: Record<string, 'basic' | 'gemiddeld' | 'top' | undefined> = {
-      'basic-model': 'basic',
-      'gemiddeld-model': 'gemiddeld',
-      'top-model': 'top',
-    };
-
-    const type = PLAN_MAP[planId];
-    if (type) {
-      await db.update(userTable).set({ type }).where(eq(userTable.id, session.user.id));
-      await unstable_update({ user: { type } });
-    }
+    const { updateUserTypeAfterCheckout } = await import('./actions');
+    await updateUserTypeAfterCheckout({
+      userId: session.user.id,
+      planId,
+    });
 
     redirect('/');
   }

--- a/app/(chat)/page.tsx
+++ b/app/(chat)/page.tsx
@@ -16,6 +16,34 @@ export default async function Page({
 
   const [session, cookieStore] = await Promise.all([auth(), cookies()]);
 
+  const success = resolvedSearchParams?.success === 'true';
+  const planId =
+    typeof resolvedSearchParams?.planId === 'string'
+      ? resolvedSearchParams.planId
+      : null;
+
+  if (success && planId && session?.user?.id) {
+    const { db } = await import('@/lib/db/drizzle-client');
+    const schemaModule = await import('@/lib/db/schema');
+    const userTable = schemaModule.user;
+    const { eq } = await import('drizzle-orm');
+    const { unstable_update } = await import('@/app/(auth)/auth');
+
+    const PLAN_MAP: Record<string, 'basic' | 'gemiddeld' | 'top' | undefined> = {
+      'basic-model': 'basic',
+      'gemiddeld-model': 'gemiddeld',
+      'top-model': 'top',
+    };
+
+    const type = PLAN_MAP[planId];
+    if (type) {
+      await db.update(userTable).set({ type }).where(eq(userTable.id, session.user.id));
+      await unstable_update({ user: { type } });
+    }
+
+    redirect('/');
+  }
+
   if (!session) {
     redirect('/api/auth/guest');
   }

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -23,7 +23,7 @@ import { useAutoResume } from '@/hooks/use-auto-resume';
 import { ChatSDKError } from '@/lib/errors';
 import { useLoginSignupPopup } from '@/hooks/use-login-signup-popup';
 import { useUpgradePopup } from '@/hooks/use-upgrade-popup';
-import type { UserType } from '@/app/(auth)/auth';
+import type { UserType } from '@/lib/user-types';
 
 type ChatRequestOptions = CoreChatRequestOptions;
 

--- a/components/message-limit-indicator.tsx
+++ b/components/message-limit-indicator.tsx
@@ -5,7 +5,7 @@ import { cn, fetcher } from '@/lib/utils';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'; // Ensure this path is correct
 import { useEffect, useState } from 'react';
 import { formatDistanceToNowStrict, format, isPast } from 'date-fns';
-import type { UserType } from '@/app/(auth)/auth';
+import type { UserType } from '@/lib/user-types';
 import { LoaderIcon } from './icons';
 
 interface MessageStatus {

--- a/components/post-checkout-updater.tsx
+++ b/components/post-checkout-updater.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useEffect } from 'react';
+import { updateUserTypeAfterCheckout } from '@/app/(chat)/actions';
+
+export function PostCheckoutUpdater({
+  userId,
+  planId,
+}: {
+  userId: string;
+  planId: string;
+}) {
+  const router = useRouter();
+
+  useEffect(() => {
+    async function update() {
+      try {
+        await updateUserTypeAfterCheckout({ userId, planId });
+      } finally {
+        router.replace('/');
+      }
+    }
+
+    update();
+  }, [userId, planId, router]);
+
+  return null;
+}

--- a/components/ui/upgrade-dialog.tsx
+++ b/components/ui/upgrade-dialog.tsx
@@ -11,6 +11,7 @@ import {
 import { Button } from '@/components/ui/button';
 import { useUpgradePopup } from '@/hooks/use-upgrade-popup';
 import { useState } from 'react';
+import { useSession } from 'next-auth/react';
 
 interface Plan {
   id: string;
@@ -47,6 +48,14 @@ const plans: Array<Plan> = [
 export function UpgradeDialog() {
   const { isOpen, closePopup } = useUpgradePopup();
   const [loadingId, setLoadingId] = useState<string | null>(null);
+  const { data: session } = useSession();
+
+  const currentType = session?.user?.type;
+  const PLAN_TYPE_MAP: Record<string, string> = {
+    'basic-model': 'basic',
+    'gemiddeld-model': 'gemiddeld',
+    'top-model': 'top',
+  };
 
   async function checkout(planId: string) {
     setLoadingId(planId);
@@ -75,16 +84,18 @@ export function UpgradeDialog() {
           </DialogDescription>
         </DialogHeader>
         <div className="flex flex-wrap gap-4 mt-4">
-          {plans.map((plan) => (
-            <div
-              key={plan.id}
-              className="border rounded-md p-4 flex flex-col items-start w-full sm:w-1/3"
-            >
-              <img
-                src={plan.image}
-                alt={plan.name}
-                className="h-24 w-full object-cover rounded"
-              />
+          {plans.map((plan) => {
+            if (PLAN_TYPE_MAP[plan.id] === currentType) return null;
+            return (
+              <div
+                key={plan.id}
+                className="border rounded-md p-4 flex flex-col items-start w-full sm:w-1/3"
+              >
+                <img
+                  src={plan.image}
+                  alt={plan.name}
+                  className="h-24 w-full object-cover rounded"
+                />
               <h3 className="mt-2 font-semibold">{plan.name}</h3>
               <p className="text-sm text-muted-foreground">
                 {plan.description}
@@ -97,8 +108,9 @@ export function UpgradeDialog() {
               >
                 {loadingId === plan.id ? 'Loading...' : 'Purchase'}
               </Button>
-            </div>
-          ))}
+              </div>
+            );
+          })}
         </div>
       </DialogContent>
     </Dialog>

--- a/lib/ai/entitlements.ts
+++ b/lib/ai/entitlements.ts
@@ -1,4 +1,4 @@
-import type { UserType } from '@/app/(auth)/auth';
+import type { UserType } from '@/lib/user-types';
 import type { ChatModel } from './models';
 
 interface Entitlements {

--- a/lib/db/migrations/0007_add_user_type.sql
+++ b/lib/db/migrations/0007_add_user_type.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "User" ADD COLUMN IF NOT EXISTS "type" varchar(32) NOT NULL DEFAULT 'regular';

--- a/lib/db/queries.ts
+++ b/lib/db/queries.ts
@@ -107,7 +107,7 @@ export async function createUser(email: string, password: string): Promise<User>
   try {
     const [createdUser] = await db
       .insert(user)
-      .values({ email, password: hashedPassword })
+      .values({ email, password: hashedPassword, type: 'regular' })
       .returning();
     if (!createdUser) {
         throw new Error('User creation failed to return the created user.');
@@ -124,10 +124,13 @@ export async function createGuestUser(): Promise<Array<Pick<User, 'id' | 'email'
   const password = generateHashedPassword(generateUUID());
 
   try {
-    return await db.insert(user).values({ email, password }).returning({
-      id: user.id,
-      email: user.email,
-    });
+    return await db
+      .insert(user)
+      .values({ email, password, type: 'guest' })
+      .returning({
+        id: user.id,
+        email: user.email,
+      });
   } catch (error) {
     throw new ChatSDKError(
       'bad_request:database',

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -15,6 +15,11 @@ export const user = pgTable('User', {
   id: uuid('id').primaryKey().notNull().defaultRandom(),
   email: varchar('email', { length: 64 }).notNull(),
   password: varchar('password', { length: 64 }),
+  type: varchar('type', {
+    enum: ['guest', 'regular', 'basic', 'gemiddeld', 'top'],
+  })
+    .notNull()
+    .default('regular'),
 });
 
 export type User = InferSelectModel<typeof user>;

--- a/lib/user-types.ts
+++ b/lib/user-types.ts
@@ -1,0 +1,1 @@
+export type UserType = 'guest' | 'regular' | 'basic' | 'gemiddeld' | 'top';


### PR DESCRIPTION
## Summary
- add shared `UserType` definition
- track user type in database and migrations
- expose API route to update user plan
- update session handling to persist purchased models
- hide purchased plan in upgrade dialog
- auto-apply subscription on checkout success

## Testing
- `pnpm lint`
- `pnpm test` *(fails: tests require browsers)*

------
https://chatgpt.com/codex/tasks/task_e_6844abb75f94832abbfe79fa8f60a5ff