### PR TITLE
Fix session update after checkout

### DIFF
--- a/app/(chat)/actions.ts
+++ b/app/(chat)/actions.ts
@@ -51,3 +51,29 @@ export async function updateChatVisibility({
 }) {
   await updateChatVisiblityById({ chatId, visibility });
 }
+
+export async function updateUserTypeAfterCheckout({
+  userId,
+  planId,
+}: {
+  userId: string;
+  planId: string;
+}) {
+  const { db } = await import('@/lib/db/drizzle-client');
+  const schemaModule = await import('@/lib/db/schema');
+  const userTable = schemaModule.user;
+  const { eq } = await import('drizzle-orm');
+  const { unstable_update } = await import('@/app/(auth)/auth');
+
+  const PLAN_MAP: Record<string, 'basic' | 'gemiddeld' | 'top' | undefined> = {
+    'basic-model': 'basic',
+    'gemiddeld-model': 'gemiddeld',
+    'top-model': 'top',
+  };
+
+  const type = PLAN_MAP[planId];
+  if (!type) return;
+
+  await db.update(userTable).set({ type }).where(eq(userTable.id, userId));
+  await unstable_update({ user: { type } });
+}

--- a/app/(chat)/page.tsx
+++ b/app/(chat)/page.tsx
@@ -23,13 +23,8 @@ export default async function Page({
       : null;
 
   if (success && planId && session?.user?.id) {
-    const { updateUserTypeAfterCheckout } = await import('./actions');
-    await updateUserTypeAfterCheckout({
-      userId: session.user.id,
-      planId,
-    });
-
-    redirect('/');
+    const { PostCheckoutUpdater } = await import('@/components/post-checkout-updater');
+    return <PostCheckoutUpdater userId={session.user.id} planId={planId} />;
   }
 
   if (!session) {

--- a/app/(chat)/page.tsx
+++ b/app/(chat)/page.tsx
@@ -23,23 +23,11 @@ export default async function Page({
       : null;
 
   if (success && planId && session?.user?.id) {
-    const { db } = await import('@/lib/db/drizzle-client');
-    const schemaModule = await import('@/lib/db/schema');
-    const userTable = schemaModule.user;
-    const { eq } = await import('drizzle-orm');
-    const { unstable_update } = await import('@/app/(auth)/auth');
-
-    const PLAN_MAP: Record<string, 'basic' | 'gemiddeld' | 'top' | undefined> = {
-      'basic-model': 'basic',
-      'gemiddeld-model': 'gemiddeld',
-      'top-model': 'top',
-    };
-
-    const type = PLAN_MAP[planId];
-    if (type) {
-      await db.update(userTable).set({ type }).where(eq(userTable.id, session.user.id));
-      await unstable_update({ user: { type } });
-    }
+    const { updateUserTypeAfterCheckout } = await import('./actions');
+    await updateUserTypeAfterCheckout({
+      userId: session.user.id,
+      planId,
+    });
 
     redirect('/');
   }

--- a/components/post-checkout-updater.tsx
+++ b/components/post-checkout-updater.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useEffect } from 'react';
+import { updateUserTypeAfterCheckout } from '@/app/(chat)/actions';
+
+export function PostCheckoutUpdater({
+  userId,
+  planId,
+}: {
+  userId: string;
+  planId: string;
+}) {
+  const router = useRouter();
+
+  useEffect(() => {
+    async function update() {
+      try {
+        await updateUserTypeAfterCheckout({ userId, planId });
+      } finally {
+        router.replace('/');
+      }
+    }
+
+    update();
+  }, [userId, planId, router]);
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- introduce `updateUserTypeAfterCheckout` server action
- use new action in chat page to update subscriptions

## Testing
- `pnpm test` *(fails: unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6844b33f148c832a9451931e3b552c17