### PR TITLE
Enable multiple model purchases

### DIFF
--- a/app/(auth)/auth.ts
+++ b/app/(auth)/auth.ts
@@ -19,6 +19,7 @@ declare module 'next-auth' {
     user: {
       id: string;
       type: UserType;
+      models: string[];
     } & DefaultSession['user'];
   }
 
@@ -26,6 +27,7 @@ declare module 'next-auth' {
     id?: string;
     email?: string | null;
     type: UserType;
+    models: string[];
   }
 }
 
@@ -33,6 +35,7 @@ declare module 'next-auth/jwt' {
   interface JWT extends DefaultJWT {
     id: string;
     type: UserType;
+    models: string[];
   }
 }
 
@@ -111,10 +114,12 @@ export const {
         if (existingUser) {
           user.id = existingUser.id;
           (user as any).type = existingUser.type;
+          (user as any).models = existingUser.models;
         } else {
           const newUser = await createUser(user.email, randomUUID());
           user.id = newUser.id;
           (user as any).type = newUser.type;
+          (user as any).models = newUser.models;
         }
       }
       return true;
@@ -123,6 +128,7 @@ export const {
       if (user) {
         token.id = (user as any).id;
         token.type = (user as any).type;
+        token.models = (user as any).models || [];
       }
       return token;
     },
@@ -130,6 +136,7 @@ export const {
       if (session.user) {
         session.user.id = token.id as string;
         session.user.type = token.type as UserType;
+        (session.user as any).models = (token.models as string[]) || [];
       }
       return session;
     },

--- a/app/(chat)/actions.ts
+++ b/app/(chat)/actions.ts
@@ -74,6 +74,16 @@ export async function updateUserTypeAfterCheckout({
   const type = PLAN_MAP[planId];
   if (!type) return;
 
-  await db.update(userTable).set({ type }).where(eq(userTable.id, userId));
-  await unstable_update({ user: { type } });
+  const [existing] = await db
+    .select({ models: userTable.models })
+    .from(userTable)
+    .where(eq(userTable.id, userId));
+
+  const models = Array.from(new Set([...(existing?.models ?? []), planId]));
+
+  await db
+    .update(userTable)
+    .set({ type, models })
+    .where(eq(userTable.id, userId));
+  await unstable_update({ user: { type, models } });
 }

--- a/app/(chat)/api/plan/route.ts
+++ b/app/(chat)/api/plan/route.ts
@@ -21,8 +21,17 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: 'Invalid plan' }, { status: 400 });
   }
 
-  await db.update(user).set({ type }).where(eq(user.id, session.user.id));
-  await unstable_update({ user: { type } });
+  const [existing] = await db
+    .select({ models: user.models })
+    .from(user)
+    .where(eq(user.id, session.user.id));
+  const models = Array.from(new Set([...(existing?.models ?? []), planId]));
+
+  await db
+    .update(user)
+    .set({ type, models })
+    .where(eq(user.id, session.user.id));
+  await unstable_update({ user: { type, models } });
 
   return NextResponse.json({ success: true });
 }

--- a/components/chat-header.tsx
+++ b/components/chat-header.tsx
@@ -33,6 +33,11 @@ function PureChatHeader({
   const { open } = useSidebar();
   const { openPopup: openUpgradePopup } = useUpgradePopup();
 
+  const purchasedModels = (session?.user as any)?.models as string[] | undefined;
+  const remainingPlans = ['basic-model', 'gemiddeld-model', 'top-model'].filter(
+    (id) => !purchasedModels?.includes(id),
+  );
+
   const { width: windowWidth } = useWindowSize();
 
   return (
@@ -81,7 +86,7 @@ function PureChatHeader({
 
       <div className="flex-grow md:flex-grow-0" /> {/* Pushes elements to the right more effectively */}
 
-      {session?.user?.type === 'regular' && (
+      {remainingPlans.length > 0 && (
         <Button
           variant="outline"
           className="hidden md:flex py-1.5 px-2 h-fit md:h-[34px] order-last md:order-4 ml-2"

--- a/components/model-selector.tsx
+++ b/components/model-selector.tsx
@@ -14,7 +14,10 @@ import { chatModels } from '@/lib/ai/models';
 import { cn } from '@/lib/utils';
 
 import { CheckCircleFillIcon, ChevronDownIcon } from './icons';
-import { entitlementsByUserType } from '@/lib/ai/entitlements';
+import {
+  entitlementsByUserType,
+  getAvailableChatModels,
+} from '@/lib/ai/entitlements';
 import type { Session } from 'next-auth';
 
 export function ModelSelector({
@@ -30,7 +33,11 @@ export function ModelSelector({
     useOptimistic(selectedModelId);
 
   const userType = session.user.type;
-  const { availableChatModelIds } = entitlementsByUserType[userType];
+  const purchasedModels = (session.user as any).models as string[] | undefined;
+  const availableChatModelIds = getAvailableChatModels(
+    userType,
+    purchasedModels,
+  );
 
   const availableChatModels = chatModels.filter((chatModel) =>
     availableChatModelIds.includes(chatModel.id),

--- a/components/ui/upgrade-dialog.tsx
+++ b/components/ui/upgrade-dialog.tsx
@@ -50,12 +50,7 @@ export function UpgradeDialog() {
   const [loadingId, setLoadingId] = useState<string | null>(null);
   const { data: session } = useSession();
 
-  const currentType = session?.user?.type;
-  const PLAN_TYPE_MAP: Record<string, string> = {
-    'basic-model': 'basic',
-    'gemiddeld-model': 'gemiddeld',
-    'top-model': 'top',
-  };
+  const purchasedModels = (session?.user as any)?.models as string[] | undefined;
 
   async function checkout(planId: string) {
     setLoadingId(planId);
@@ -85,7 +80,7 @@ export function UpgradeDialog() {
         </DialogHeader>
         <div className="flex flex-wrap gap-4 mt-4">
           {plans.map((plan) => {
-            if (PLAN_TYPE_MAP[plan.id] === currentType) return null;
+            if (purchasedModels?.includes(plan.id)) return null;
             return (
               <div
                 key={plan.id}
@@ -106,7 +101,7 @@ export function UpgradeDialog() {
                 onClick={() => checkout(plan.id)}
                 disabled={loadingId === plan.id}
               >
-                {loadingId === plan.id ? 'Loading...' : 'Purchase'}
+                {loadingId === plan.id ? 'Loading...' : 'Upgrade'}
               </Button>
               </div>
             );

--- a/lib/ai/entitlements.ts
+++ b/lib/ai/entitlements.ts
@@ -42,3 +42,12 @@ export const entitlementsByUserType: Record<UserType, Entitlements> = {
    * TODO: For users with an account and a paid membership
    */
 };
+
+export function getAvailableChatModels(
+  userType: UserType,
+  purchasedModels: Array<ChatModel['id']> | undefined,
+): Array<ChatModel['id']> {
+  const defaults = entitlementsByUserType[userType].availableChatModelIds;
+  if (!purchasedModels || purchasedModels.length === 0) return defaults;
+  return Array.from(new Set(['chat-model', ...purchasedModels]));
+}

--- a/lib/ai/entitlements.ts
+++ b/lib/ai/entitlements.ts
@@ -47,7 +47,9 @@ export function getAvailableChatModels(
   userType: UserType,
   purchasedModels: Array<ChatModel['id']> | undefined,
 ): Array<ChatModel['id']> {
-  const defaults = entitlementsByUserType[userType].availableChatModelIds;
-  if (!purchasedModels || purchasedModels.length === 0) return defaults;
-  return Array.from(new Set(['chat-model', ...purchasedModels]));
+  if (purchasedModels && purchasedModels.length > 0) {
+    return Array.from(new Set(purchasedModels));
+  }
+
+  return entitlementsByUserType[userType].availableChatModelIds;
 }

--- a/lib/db/queries.ts
+++ b/lib/db/queries.ts
@@ -107,7 +107,7 @@ export async function createUser(email: string, password: string): Promise<User>
   try {
     const [createdUser] = await db
       .insert(user)
-      .values({ email, password: hashedPassword, type: 'regular' })
+      .values({ email, password: hashedPassword, type: 'regular', models: [] })
       .returning();
     if (!createdUser) {
         throw new Error('User creation failed to return the created user.');
@@ -126,7 +126,7 @@ export async function createGuestUser(): Promise<Array<Pick<User, 'id' | 'email'
   try {
     return await db
       .insert(user)
-      .values({ email, password, type: 'guest' })
+      .values({ email, password, type: 'guest', models: [] })
       .returning({
         id: user.id,
         email: user.email,

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -20,6 +20,7 @@ export const user = pgTable('User', {
   })
     .notNull()
     .default('regular'),
+  models: json('models').$type<string[]>().notNull().default('[]'),
 });
 
 export type User = InferSelectModel<typeof user>;


### PR DESCRIPTION
## Summary
- support storing purchased models in the user schema
- persist purchased models during authentication and after checkout
- expose available models based on purchases
- show upgrade options for unowned models
- allow upgrading from the chat header

## Testing
- `npx biome format --write ...` *(fails: 403 Forbidden)*
- `pnpm test` *(fails: Request was cancelled due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6844b90d8384832aa90f1880431d2364