### PR TITLE
Enable multiple model purchases

### DIFF
--- a/app/(auth)/auth.ts
+++ b/app/(auth)/auth.ts
@@ -8,6 +8,7 @@ import {
   getUser,
   createUser,
   getUserModelIds,
+  getUserTypeById,
 } from '@/lib/db/queries';
 import { authConfig } from './auth.config';
 import { DUMMY_PASSWORD } from '@/lib/constants';
@@ -130,11 +131,13 @@ export const {
     async jwt({ token, user }) {
       if (user) {
         token.id = (user as any).id;
-        token.type = (user as any).type;
-        token.models = (user as any).models ?? [];
-      } else if (token.id && token.models === undefined) {
+      }
+
+      if (token.id) {
+        token.type = await getUserTypeById({ userId: token.id as string });
         token.models = await getUserModelIds({ userId: token.id as string });
       }
+
       return token;
     },
     async session({ session, token }) {

--- a/app/(auth)/auth.ts
+++ b/app/(auth)/auth.ts
@@ -7,6 +7,7 @@ import {
   createGuestUser,
   getUser,
   createUser,
+  getUserModelIds,
 } from '@/lib/db/queries';
 import { authConfig } from './auth.config';
 import { DUMMY_PASSWORD } from '@/lib/constants';
@@ -19,6 +20,7 @@ declare module 'next-auth' {
     user: {
       id: string;
       type: UserType;
+      models: string[];
     } & DefaultSession['user'];
   }
 
@@ -26,6 +28,7 @@ declare module 'next-auth' {
     id?: string;
     email?: string | null;
     type: UserType;
+    models?: string[];
   }
 }
 
@@ -33,6 +36,7 @@ declare module 'next-auth/jwt' {
   interface JWT extends DefaultJWT {
     id: string;
     type: UserType;
+    models: string[];
   }
 }
 
@@ -62,7 +66,9 @@ const providers = [
       const passwordsMatch = await compare(password, dbUser.password);
       if (!passwordsMatch) return null;
 
-      return { ...dbUser };
+      const models = await getUserModelIds({ userId: dbUser.id });
+
+      return { ...dbUser, models };
     },
   }),
 
@@ -73,7 +79,7 @@ const providers = [
     credentials: {},
     async authorize() {
       const [guestUser] = await createGuestUser();
-      return { ...guestUser, type: 'guest' };
+      return { ...guestUser, type: 'guest', models: [] };
     },
   }),
 ];
@@ -111,10 +117,12 @@ export const {
         if (existingUser) {
           user.id = existingUser.id;
           (user as any).type = existingUser.type;
+          (user as any).models = await getUserModelIds({ userId: existingUser.id });
         } else {
           const newUser = await createUser(user.email, randomUUID());
           user.id = newUser.id;
           (user as any).type = newUser.type;
+          (user as any).models = [];
         }
       }
       return true;
@@ -123,6 +131,9 @@ export const {
       if (user) {
         token.id = (user as any).id;
         token.type = (user as any).type;
+        token.models = (user as any).models ?? [];
+      } else if (token.id && token.models === undefined) {
+        token.models = await getUserModelIds({ userId: token.id as string });
       }
       return token;
     },
@@ -130,6 +141,7 @@ export const {
       if (session.user) {
         session.user.id = token.id as string;
         session.user.type = token.type as UserType;
+        session.user.models = (token.models as string[]) ?? [];
       }
       return session;
     },

--- a/app/(chat)/actions.ts
+++ b/app/(chat)/actions.ts
@@ -64,6 +64,7 @@ export async function updateUserTypeAfterCheckout({
   const userTable = schemaModule.user;
   const { eq } = await import('drizzle-orm');
   const { unstable_update } = await import('@/app/(auth)/auth');
+  const { addUserModel, getUserModelIds } = await import('@/lib/db/queries');
 
   const PLAN_MAP: Record<string, 'basic' | 'gemiddeld' | 'top' | undefined> = {
     'basic-model': 'basic',
@@ -75,5 +76,7 @@ export async function updateUserTypeAfterCheckout({
   if (!type) return;
 
   await db.update(userTable).set({ type }).where(eq(userTable.id, userId));
-  await unstable_update({ user: { type } });
+  await addUserModel({ userId, modelId: planId });
+  const models = await getUserModelIds({ userId });
+  await unstable_update({ user: { type, models } });
 }

--- a/components/chat-header.tsx
+++ b/components/chat-header.tsx
@@ -16,6 +16,8 @@ import type { Session } from 'next-auth';
 import { MessageLimitIndicator } from './message-limit-indicator'; // Added
 import { useUpgradePopup } from '@/hooks/use-upgrade-popup';
 
+const plansLength = 3;
+
 function PureChatHeader({
   chatId,
   selectedModelId,
@@ -81,7 +83,7 @@ function PureChatHeader({
 
       <div className="flex-grow md:flex-grow-0" /> {/* Pushes elements to the right more effectively */}
 
-      {session?.user?.type === 'regular' && (
+      {session?.user && session.user.models?.length !== plansLength && (
         <Button
           variant="outline"
           className="hidden md:flex py-1.5 px-2 h-fit md:h-[34px] order-last md:order-4 ml-2"

--- a/components/model-selector.tsx
+++ b/components/model-selector.tsx
@@ -30,7 +30,10 @@ export function ModelSelector({
     useOptimistic(selectedModelId);
 
   const userType = session.user.type;
-  const { availableChatModelIds } = entitlementsByUserType[userType];
+  const userModels = session.user.models ?? [];
+  const baseModels = entitlementsByUserType[userType].availableChatModelIds;
+  const availableChatModelIds =
+    userModels.length > 0 ? userModels : baseModels;
 
   const availableChatModels = chatModels.filter((chatModel) =>
     availableChatModelIds.includes(chatModel.id),

--- a/components/ui/upgrade-dialog.tsx
+++ b/components/ui/upgrade-dialog.tsx
@@ -50,12 +50,7 @@ export function UpgradeDialog() {
   const [loadingId, setLoadingId] = useState<string | null>(null);
   const { data: session } = useSession();
 
-  const currentType = session?.user?.type;
-  const PLAN_TYPE_MAP: Record<string, string> = {
-    'basic-model': 'basic',
-    'gemiddeld-model': 'gemiddeld',
-    'top-model': 'top',
-  };
+  const ownedModels = session?.user?.models ?? [];
 
   async function checkout(planId: string) {
     setLoadingId(planId);
@@ -85,7 +80,7 @@ export function UpgradeDialog() {
         </DialogHeader>
         <div className="flex flex-wrap gap-4 mt-4">
           {plans.map((plan) => {
-            if (PLAN_TYPE_MAP[plan.id] === currentType) return null;
+            if (ownedModels.includes(plan.id)) return null;
             return (
               <div
                 key={plan.id}

--- a/lib/db/migrations/0008_add_user_model_table.sql
+++ b/lib/db/migrations/0008_add_user_model_table.sql
@@ -1,0 +1,5 @@
+CREATE TABLE IF NOT EXISTS "UserModel" (
+    "userId" uuid NOT NULL REFERENCES "User"("id") ON DELETE CASCADE,
+    "modelId" varchar(64) NOT NULL,
+    PRIMARY KEY ("userId", "modelId")
+);

--- a/lib/db/queries.ts
+++ b/lib/db/queries.ts
@@ -684,3 +684,18 @@ export async function getUserModelIds({ userId }: { userId: string }) {
     );
   }
 }
+
+export async function getUserTypeById({ userId }: { userId: string }) {
+  try {
+    const [row] = await db
+      .select({ type: user.type })
+      .from(user)
+      .where(eq(user.id, userId));
+    return row?.type ?? 'regular';
+  } catch (error) {
+    throw new ChatSDKError(
+      'bad_request:database',
+      'Failed to get user type',
+    );
+  }
+}

--- a/lib/db/queries.ts
+++ b/lib/db/queries.ts
@@ -29,6 +29,7 @@ import {
   type DBMessage,
   type Chat,
   stream,
+  userModel,
 } from './schema';
 import type { ArtifactKind } from '@/components/artifact';
 import { generateUUID } from '../utils';
@@ -647,4 +648,39 @@ export async function getStreamIdsByChatId({ chatId }: { chatId: string }) {
 
     return inserted;
   });
+}
+
+export async function addUserModel({
+  userId,
+  modelId,
+}: {
+  userId: string;
+  modelId: string;
+}) {
+  try {
+    await db
+      .insert(userModel)
+      .values({ userId, modelId })
+      .onConflictDoNothing();
+  } catch (error) {
+    throw new ChatSDKError(
+      'bad_request:database',
+      'Failed to add user model',
+    );
+  }
+}
+
+export async function getUserModelIds({ userId }: { userId: string }) {
+  try {
+    const rows = await db
+      .select({ modelId: userModel.modelId })
+      .from(userModel)
+      .where(eq(userModel.userId, userId));
+    return rows.map((r) => r.modelId);
+  } catch (error) {
+    throw new ChatSDKError(
+      'bad_request:database',
+      'Failed to get user models',
+    );
+  }
 }

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -173,3 +173,18 @@ export const stream = pgTable(
 );
 
 export type Stream = InferSelectModel<typeof stream>;
+
+export const userModel = pgTable(
+  'UserModel',
+  {
+    userId: uuid('userId')
+      .notNull()
+      .references(() => user.id),
+    modelId: varchar('modelId', { length: 64 }).notNull(),
+  },
+  (table) => ({
+    pk: primaryKey({ columns: [table.userId, table.modelId] }),
+  }),
+);
+
+export type UserModel = InferSelectModel<typeof userModel>;


### PR DESCRIPTION
## Summary
- track purchased models per user with a new `UserModel` table
- load model list in auth session and JWT
- update `updateUserTypeAfterCheckout` to save purchased model and refresh session
- use session model list for model selector and upgrade dialog
- show upgrade button while models remain

## Testing
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.12.3.tgz)*
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.12.3.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68453afb8594832aa016d4804042be11