### PR TITLE
Fix chat API model validation

### DIFF
--- a/app/(chat)/actions.ts
+++ b/app/(chat)/actions.ts
@@ -79,4 +79,5 @@ export async function updateUserTypeAfterCheckout({
   await addUserModel({ userId, modelId: planId });
   const models = await getUserModelIds({ userId });
   await unstable_update({ user: { type, models } });
+  await saveChatModelAsCookie(planId);
 }

--- a/app/(chat)/api/chat/schema.ts
+++ b/app/(chat)/api/chat/schema.ts
@@ -23,7 +23,13 @@ export const postRequestBodySchema = z.object({
       )
       .optional(),
   }),
-  selectedChatModel: z.enum(['chat-model', 'chat-model-reasoning']),
+  selectedChatModel: z.enum([
+    'chat-model',
+    'chat-model-reasoning',
+    'basic-model',
+    'gemiddeld-model',
+    'top-model',
+  ]),
   selectedVisibilityType: z.enum(['public', 'private']),
 });
 

--- a/components/model-selector.tsx
+++ b/components/model-selector.tsx
@@ -61,7 +61,7 @@ export function ModelSelector({
           variant="outline"
           className="md:px-2 md:h-[34px]"
         >
-          {selectedChatModel?.name}
+          <span className="mr-1">{selectedChatModel?.name}</span>
           <ChevronDownIcon />
         </Button>
       </DropdownMenuTrigger>


### PR DESCRIPTION
## Summary
- allow additional chat models in POST `/api/chat` request body schema

## Testing
- `pnpm test` *(fails: Request was cancelled due to missing network access)*

------
https://chatgpt.com/codex/tasks/task_e_68454a323bb8832a996085c7606d9051