### PR TITLE
Improve model selection visibility

### DIFF
--- a/app/(chat)/page.tsx
+++ b/app/(chat)/page.tsx
@@ -21,6 +21,10 @@ export default async function Page({
     typeof resolvedSearchParams?.planId === 'string'
       ? resolvedSearchParams.planId
       : null;
+  const selectedModelIdParam =
+    typeof resolvedSearchParams?.modelId === 'string'
+      ? resolvedSearchParams.modelId
+      : null;
 
   if (success && planId && session?.user?.id) {
     const { PostCheckoutUpdater } = await import('@/components/post-checkout-updater');
@@ -54,24 +58,7 @@ export default async function Page({
 
   const id = generateUUID();
   const modelIdFromCookie = cookieStore.get('chat-model');
-
-  if (!modelIdFromCookie) {
-    return (
-      <>
-        <Chat
-          key={id}
-          id={id}
-          initialMessages={[]}
-          initialChatModel={DEFAULT_CHAT_MODEL}
-          initialVisibilityType="private"
-          isReadonly={false}
-          session={session}
-          autoResume={false}
-        />
-        <DataStreamHandler id={id} />
-      </>
-    );
-  }
+  const initialModelId = selectedModelIdParam ?? modelIdFromCookie?.value ?? DEFAULT_CHAT_MODEL;
 
   return (
     <>
@@ -79,7 +66,7 @@ export default async function Page({
         key={id}
         id={id}
         initialMessages={[]}
-        initialChatModel={modelIdFromCookie.value}
+        initialChatModel={initialModelId}
         initialVisibilityType="private"
         isReadonly={false}
         session={session}

--- a/components/model-selector.tsx
+++ b/components/model-selector.tsx
@@ -61,7 +61,7 @@ export function ModelSelector({
           variant="outline"
           className="md:px-2 md:h-[34px]"
         >
-          <span className="mr-1">{selectedChatModel?.name}</span>
+          <span className="mr-1 truncate max-w-[8rem]">{selectedChatModel?.name}</span>
           <ChevronDownIcon />
         </Button>
       </DropdownMenuTrigger>

--- a/components/post-checkout-updater.tsx
+++ b/components/post-checkout-updater.tsx
@@ -17,8 +17,9 @@ export function PostCheckoutUpdater({
     async function update() {
       try {
         await updateUserTypeAfterCheckout({ userId, planId });
+        document.cookie = `chat-model=${planId}; path=/`;
       } finally {
-        router.replace('/');
+        router.replace(`/?modelId=${planId}`);
       }
     }
 


### PR DESCRIPTION
## Summary
- always show the selected model name in the dropdown
- keep newly purchased model selected by updating the cookie and passing it back via query param

## Testing
- `npx biome check` *(fails: 403 Forbidden)*
- `pnpm exec playwright test` *(fails: fetch failed when installing pnpm)*

------
https://chatgpt.com/codex/tasks/task_e_68455eab1f98832aaa41052d8d873340