### PR TITLE
login redirect to upgrade

### DIFF
--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -26,6 +26,7 @@ export default function Page() {
   const chatIdToResume = searchParams.get('chatIdToResume');
   const guestUserId = searchParams.get('guestUserId');
   const unsentPrompt = searchParams.get('unsentPrompt');
+  const planId = searchParams.get('planId');
 
   const [email, setEmail] = useState('');
   const [isSuccessful, setIsSuccessful] = useState(false);
@@ -38,7 +39,7 @@ export default function Page() {
     },
   );
 
-  const { update: updateSession } = useSession();
+  const { update: updateSession, data: session } = useSession();
 
   useEffect(() => {
     if (state.status === 'failed') {
@@ -62,6 +63,19 @@ export default function Page() {
         await globalSWRMutate((key) => typeof key === 'string' && key.startsWith('/api/message-status'), undefined, { revalidate: true });
         await globalSWRMutate((key) => typeof key === 'string' && key.startsWith('/api/auth/session'), undefined, { revalidate: true });
 
+        if (planId) {
+          const res = await fetch('/api/checkout', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ planId }),
+          });
+          const data = await res.json();
+          if (data.url) {
+            window.location.href = data.url as string;
+            return;
+          }
+        }
+
         if (state.redirectTo) {
           router.replace(state.redirectTo);
         } else {
@@ -76,6 +90,26 @@ export default function Page() {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [state]);
+
+  useEffect(() => {
+    if (session?.user && session.user.type !== 'guest' && planId && state.status === 'idle') {
+      const proceed = async () => {
+        await updateSession();
+        const res = await fetch('/api/checkout', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ planId }),
+        });
+        const data = await res.json();
+        if (data.url) {
+          window.location.href = data.url as string;
+        } else {
+          router.replace('/');
+        }
+      };
+      proceed();
+    }
+  }, [session, planId, updateSession, router, state.status]);
 
   const handleSubmit = (formData: FormData) => {
     setEmail(formData.get('email') as string);
@@ -92,7 +126,8 @@ export default function Page() {
     if (chatIdToResume) params.set('chatIdToResume', chatIdToResume);
     if (guestUserId) params.set('guestUserId', guestUserId);
     if (unsentPrompt) params.set('unsentPrompt', unsentPrompt);
-    const callbackUrl = params.size ? `/?${params.toString()}` : '/';
+    if (planId) params.set('planId', planId);
+    const callbackUrl = `/login?${params.toString()}`;
     signIn('google', { callbackUrl });
   };
 
@@ -118,7 +153,12 @@ export default function Page() {
           <p className="text-center text-sm text-gray-600 mt-4 dark:text-zinc-400">
             {"Don't have an account? "}
             <Link
-              href={`/register${chatIdToResume ? `?chatIdToResume=${chatIdToResume}&guestUserId=${guestUserId || ''}&unsentPrompt=${encodeURIComponent(unsentPrompt || '')}` : ''}`}
+              href={`/register${chatIdToResume || guestUserId || unsentPrompt || planId ? `?${[
+                chatIdToResume ? `chatIdToResume=${chatIdToResume}` : null,
+                guestUserId ? `guestUserId=${guestUserId}` : null,
+                unsentPrompt ? `unsentPrompt=${encodeURIComponent(unsentPrompt)}` : null,
+                planId ? `planId=${planId}` : null,
+              ].filter(Boolean).join('&')}` : ''}`}
               className="font-semibold text-gray-800 hover:underline dark:text-zinc-200"
             >
               Sign up

--- a/app/(auth)/register/page.tsx
+++ b/app/(auth)/register/page.tsx
@@ -37,6 +37,7 @@ export default function Page() {
   const chatIdToResume = searchParams.get('chatIdToResume');
   const guestUserId = searchParams.get('guestUserId');
   const unsentPrompt = searchParams.get('unsentPrompt');
+  const planId = searchParams.get('planId');
 
   const [email, setEmail] = useState('');
   const [isSuccessful, setIsSuccessful] = useState(false);
@@ -83,6 +84,18 @@ export default function Page() {
         await globalSWRMutate((key) => typeof key === 'string' && key.startsWith('/api/message-status'), undefined, { revalidate: true });
         await globalSWRMutate((key) => typeof key === 'string' && key.startsWith('/api/auth/session'), undefined, { revalidate: true });
 
+        if (planId) {
+          const res = await fetch('/api/checkout', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ planId }),
+          });
+          const data = await res.json();
+          if (data.url) {
+            window.location.href = data.url as string;
+            return;
+          }
+        }
 
         if (state.redirectTo) {
           router.replace(state.redirectTo);
@@ -114,7 +127,8 @@ export default function Page() {
     if (chatIdToResume) params.set('chatIdToResume', chatIdToResume);
     if (guestUserId) params.set('guestUserId', guestUserId);
     if (unsentPrompt) params.set('unsentPrompt', unsentPrompt);
-    const callbackUrl = params.size ? `/?${params.toString()}` : '/';
+    if (planId) params.set('planId', planId);
+    const callbackUrl = `/login?${params.toString()}`;
     signIn('google', { callbackUrl });
   };
 
@@ -144,7 +158,12 @@ export default function Page() {
           <p className="text-center text-sm text-gray-600 mt-4 dark:text-zinc-400">
             {'Already have an account? '}
             <Link
-              href={`/login${chatIdToResume ? `?chatIdToResume=${chatIdToResume}&guestUserId=${guestUserId || ''}&unsentPrompt=${encodeURIComponent(unsentPrompt || '')}` : ''}`}
+              href={`/login${chatIdToResume || guestUserId || unsentPrompt || planId ? `?${[
+                chatIdToResume ? `chatIdToResume=${chatIdToResume}` : null,
+                guestUserId ? `guestUserId=${guestUserId}` : null,
+                unsentPrompt ? `unsentPrompt=${encodeURIComponent(unsentPrompt)}` : null,
+                planId ? `planId=${planId}` : null,
+              ].filter(Boolean).join('&')}` : ''}`}
               className="font-semibold text-gray-800 hover:underline dark:text-zinc-200"
             >
               Sign in

--- a/components/ui/upgrade-dialog.tsx
+++ b/components/ui/upgrade-dialog.tsx
@@ -12,6 +12,7 @@ import { Button } from '@/components/ui/button';
 import { useUpgradePopup } from '@/hooks/use-upgrade-popup';
 import { useState } from 'react';
 import { useSession } from 'next-auth/react';
+import { useRouter } from 'next/navigation';
 
 interface Plan {
   id: string;
@@ -49,10 +50,17 @@ export function UpgradeDialog() {
   const { isOpen, closePopup } = useUpgradePopup();
   const [loadingId, setLoadingId] = useState<string | null>(null);
   const { data: session } = useSession();
+  const router = useRouter();
 
   const ownedModels = session?.user?.models ?? [];
 
   async function checkout(planId: string) {
+    if (!session?.user || session.user.type === 'guest') {
+      closePopup();
+      router.push(`/login?planId=${planId}`);
+      return;
+    }
+
     setLoadingId(planId);
     const res = await fetch('/api/checkout', {
       method: 'POST',


### PR DESCRIPTION
## Summary
- redirect unauthenticated users to login before checkout
- after signing in or registering, automatically create the Stripe checkout session
- preserve selected plan in Google auth and sign-in/sign-up links
- avoid triggering checkout while using a guest account

## Testing
- `pnpm lint` *(fails: Request was cancelled)*
- `pnpm test` *(fails: Request was cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_6845628f5cb8832a88cbfb88601ee005