### PR TITLE
login redirect to upgrade

### DIFF
--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -26,6 +26,26 @@ export default function Page() {
   const chatIdToResume = searchParams.get('chatIdToResume');
   const guestUserId = searchParams.get('guestUserId');
   const unsentPrompt = searchParams.get('unsentPrompt');
+  const [planId, setPlanId] = useState<string | null>(
+    searchParams.get('planId'),
+  );
+
+  useEffect(() => {
+    if (!planId) {
+      try {
+        const stored = sessionStorage.getItem('pendingPlanId');
+        if (stored) setPlanId(stored);
+      } catch {
+        // ignore
+      }
+    } else {
+      try {
+        sessionStorage.setItem('pendingPlanId', planId);
+      } catch {
+        // ignore
+      }
+    }
+  }, [planId]);
 
   const [email, setEmail] = useState('');
   const [isSuccessful, setIsSuccessful] = useState(false);
@@ -38,7 +58,7 @@ export default function Page() {
     },
   );
 
-  const { update: updateSession } = useSession();
+  const { update: updateSession, data: session } = useSession();
 
   useEffect(() => {
     if (state.status === 'failed') {
@@ -57,10 +77,28 @@ export default function Page() {
       setIsSuccessful(true);
 
       const performRedirectAndRefresh = async () => {
-        await updateSession();
+        const newSession = await updateSession();
 
         await globalSWRMutate((key) => typeof key === 'string' && key.startsWith('/api/message-status'), undefined, { revalidate: true });
         await globalSWRMutate((key) => typeof key === 'string' && key.startsWith('/api/auth/session'), undefined, { revalidate: true });
+
+        if (planId && newSession?.user && newSession.user.type !== 'guest') {
+          const res = await fetch('/api/checkout', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ planId }),
+          });
+          const data = await res.json();
+          if (data.url) {
+            try {
+              sessionStorage.removeItem('pendingPlanId');
+            } catch {
+              // ignore
+            }
+            window.location.href = data.url as string;
+            return;
+          }
+        }
 
         if (state.redirectTo) {
           router.replace(state.redirectTo);
@@ -77,6 +115,33 @@ export default function Page() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [state]);
 
+  useEffect(() => {
+    if (session?.user && session.user.type !== 'guest' && planId && state.status === 'idle') {
+      const proceed = async () => {
+        const newSession = await updateSession();
+        if (newSession?.user && newSession.user.type !== 'guest') {
+          const res = await fetch('/api/checkout', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ planId }),
+          });
+          const data = await res.json();
+          if (data.url) {
+            try {
+              sessionStorage.removeItem('pendingPlanId');
+            } catch {
+              // ignore
+            }
+            window.location.href = data.url as string;
+          } else {
+            router.replace('/');
+          }
+        }
+      };
+      proceed();
+    }
+  }, [session, planId, updateSession, router, state.status]);
+
   const handleSubmit = (formData: FormData) => {
     setEmail(formData.get('email') as string);
     if (chatIdToResume) formData.append('chatIdToResume', chatIdToResume);
@@ -92,7 +157,8 @@ export default function Page() {
     if (chatIdToResume) params.set('chatIdToResume', chatIdToResume);
     if (guestUserId) params.set('guestUserId', guestUserId);
     if (unsentPrompt) params.set('unsentPrompt', unsentPrompt);
-    const callbackUrl = params.size ? `/?${params.toString()}` : '/';
+    if (planId) params.set('planId', planId);
+    const callbackUrl = `/login?${params.toString()}`;
     signIn('google', { callbackUrl });
   };
 
@@ -118,7 +184,12 @@ export default function Page() {
           <p className="text-center text-sm text-gray-600 mt-4 dark:text-zinc-400">
             {"Don't have an account? "}
             <Link
-              href={`/register${chatIdToResume ? `?chatIdToResume=${chatIdToResume}&guestUserId=${guestUserId || ''}&unsentPrompt=${encodeURIComponent(unsentPrompt || '')}` : ''}`}
+              href={`/register${chatIdToResume || guestUserId || unsentPrompt || planId ? `?${[
+                chatIdToResume ? `chatIdToResume=${chatIdToResume}` : null,
+                guestUserId ? `guestUserId=${guestUserId}` : null,
+                unsentPrompt ? `unsentPrompt=${encodeURIComponent(unsentPrompt)}` : null,
+                planId ? `planId=${planId}` : null,
+              ].filter(Boolean).join('&')}` : ''}`}
               className="font-semibold text-gray-800 hover:underline dark:text-zinc-200"
             >
               Sign up

--- a/app/(auth)/register/page.tsx
+++ b/app/(auth)/register/page.tsx
@@ -37,6 +37,26 @@ export default function Page() {
   const chatIdToResume = searchParams.get('chatIdToResume');
   const guestUserId = searchParams.get('guestUserId');
   const unsentPrompt = searchParams.get('unsentPrompt');
+  const [planId, setPlanId] = useState<string | null>(
+    searchParams.get('planId'),
+  );
+
+  useEffect(() => {
+    if (!planId) {
+      try {
+        const stored = sessionStorage.getItem('pendingPlanId');
+        if (stored) setPlanId(stored);
+      } catch {
+        // ignore
+      }
+    } else {
+      try {
+        sessionStorage.setItem('pendingPlanId', planId);
+      } catch {
+        // ignore
+      }
+    }
+  }, [planId]);
 
   const [email, setEmail] = useState('');
   const [isSuccessful, setIsSuccessful] = useState(false);
@@ -77,12 +97,29 @@ export default function Page() {
       setIsSuccessful(true);
       
       const performRedirectAndRefresh = async () => {
-        await updateSession(); 
+        const newSession = await updateSession();
         
         // Revalidate SWR caches that might depend on the new session
         await globalSWRMutate((key) => typeof key === 'string' && key.startsWith('/api/message-status'), undefined, { revalidate: true });
         await globalSWRMutate((key) => typeof key === 'string' && key.startsWith('/api/auth/session'), undefined, { revalidate: true });
 
+        if (planId && newSession?.user && newSession.user.type !== 'guest') {
+          const res = await fetch('/api/checkout', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ planId }),
+          });
+          const data = await res.json();
+          if (data.url) {
+            try {
+              sessionStorage.removeItem('pendingPlanId');
+            } catch {
+              // ignore
+            }
+            window.location.href = data.url as string;
+            return;
+          }
+        }
 
         if (state.redirectTo) {
           router.replace(state.redirectTo);
@@ -114,7 +151,8 @@ export default function Page() {
     if (chatIdToResume) params.set('chatIdToResume', chatIdToResume);
     if (guestUserId) params.set('guestUserId', guestUserId);
     if (unsentPrompt) params.set('unsentPrompt', unsentPrompt);
-    const callbackUrl = params.size ? `/?${params.toString()}` : '/';
+    if (planId) params.set('planId', planId);
+    const callbackUrl = `/login?${params.toString()}`;
     signIn('google', { callbackUrl });
   };
 
@@ -144,7 +182,12 @@ export default function Page() {
           <p className="text-center text-sm text-gray-600 mt-4 dark:text-zinc-400">
             {'Already have an account? '}
             <Link
-              href={`/login${chatIdToResume ? `?chatIdToResume=${chatIdToResume}&guestUserId=${guestUserId || ''}&unsentPrompt=${encodeURIComponent(unsentPrompt || '')}` : ''}`}
+              href={`/login${chatIdToResume || guestUserId || unsentPrompt || planId ? `?${[
+                chatIdToResume ? `chatIdToResume=${chatIdToResume}` : null,
+                guestUserId ? `guestUserId=${guestUserId}` : null,
+                unsentPrompt ? `unsentPrompt=${encodeURIComponent(unsentPrompt)}` : null,
+                planId ? `planId=${planId}` : null,
+              ].filter(Boolean).join('&')}` : ''}`}
               className="font-semibold text-gray-800 hover:underline dark:text-zinc-200"
             >
               Sign in

--- a/components/ui/upgrade-dialog.tsx
+++ b/components/ui/upgrade-dialog.tsx
@@ -12,6 +12,7 @@ import { Button } from '@/components/ui/button';
 import { useUpgradePopup } from '@/hooks/use-upgrade-popup';
 import { useState } from 'react';
 import { useSession } from 'next-auth/react';
+import { useRouter } from 'next/navigation';
 
 interface Plan {
   id: string;
@@ -49,10 +50,22 @@ export function UpgradeDialog() {
   const { isOpen, closePopup } = useUpgradePopup();
   const [loadingId, setLoadingId] = useState<string | null>(null);
   const { data: session } = useSession();
+  const router = useRouter();
 
   const ownedModels = session?.user?.models ?? [];
 
   async function checkout(planId: string) {
+    if (!session?.user || session.user.type === 'guest') {
+      closePopup();
+      try {
+        sessionStorage.setItem('pendingPlanId', planId);
+      } catch {
+        // ignore
+      }
+      router.push(`/login?planId=${planId}`);
+      return;
+    }
+
     setLoadingId(planId);
     const res = await fetch('/api/checkout', {
       method: 'POST',


### PR DESCRIPTION
## Summary
- store desired plan in sessionStorage when upgrade is triggered while not logged in
- read pending plan on login/register pages and restore it for the checkout
- clear the pending plan once the Stripe URL is obtained
- ensure checkout runs only after the session updates from guest to a real user

## Testing
- ❌ `pnpm lint` *(failed to download pnpm)*
- ❌ `pnpm test` *(failed to download pnpm)*

------
https://chatgpt.com/codex/tasks/task_e_6845628f5cb8832a88cbfb88601ee005