### PR TITLE
Ensure plan purchase redirects to checkout

### DIFF
--- a/app/(auth)/actions.ts
+++ b/app/(auth)/actions.ts
@@ -15,6 +15,7 @@ const authFormSchema = z.object({
 export interface LoginActionState {
   status: 'idle' | 'in_progress' | 'success' | 'failed' | 'invalid_data';
   redirectTo?: string;
+  planId?: string;
 }
 
 export const login = async (
@@ -22,14 +23,15 @@ export const login = async (
   formData: FormData,
 ): Promise<LoginActionState> => {
   try {
-    const validatedData = authFormSchema.parse({
-      email: formData.get('email'),
-      password: formData.get('password'),
-    });
+  const validatedData = authFormSchema.parse({
+    email: formData.get('email'),
+    password: formData.get('password'),
+  });
 
-    const chatIdToResume = formData.get('chatIdToResume') as string | null;
-    const guestUserId = formData.get('guestUserId') as string | null;
-    const unsentPrompt = formData.get('unsentPrompt') as string | null;
+  const chatIdToResume = formData.get('chatIdToResume') as string | null;
+  const guestUserId = formData.get('guestUserId') as string | null;
+  const unsentPrompt = formData.get('unsentPrompt') as string | null;
+  const planId = formData.get('planId') as string | null;
 
     // Attempt to sign in first. If successful, NextAuth.js will handle session creation.
     // The user object will be available in the session callback.
@@ -67,11 +69,11 @@ export const login = async (
       }
     }
     
-    const redirectTo = chatIdToResume 
-      ? `/chat/${chatIdToResume}${unsentPrompt ? `?prompt=${encodeURIComponent(unsentPrompt)}` : ''}`
-      : '/';
+  const redirectTo = chatIdToResume
+    ? `/chat/${chatIdToResume}${unsentPrompt ? `?prompt=${encodeURIComponent(unsentPrompt)}` : ''}`
+    : '/';
 
-    return { status: 'success', redirectTo };
+  return { status: 'success', redirectTo, planId: planId ?? undefined };
 
   } catch (error: any) {
     if (error instanceof z.ZodError) {
@@ -95,6 +97,7 @@ export interface RegisterActionState {
     | 'user_exists'
     | 'invalid_data';
   redirectTo?: string;
+  planId?: string;
 }
 
 export const register = async (
@@ -110,6 +113,7 @@ export const register = async (
     const chatIdToResume = formData.get('chatIdToResume') as string | null;
     const guestUserId = formData.get('guestUserId') as string | null;
     const unsentPrompt = formData.get('unsentPrompt') as string | null;
+    const planId = formData.get('planId') as string | null;
 
     const [existingUser] = await getUser(validatedData.email);
     if (existingUser) {
@@ -139,11 +143,11 @@ export const register = async (
       redirect: false,
     });
     
-    const redirectTo = chatIdToResume 
-      ? `/chat/${chatIdToResume}${unsentPrompt ? `?prompt=${encodeURIComponent(unsentPrompt)}` : ''}`
-      : '/';
+  const redirectTo = chatIdToResume
+    ? `/chat/${chatIdToResume}${unsentPrompt ? `?prompt=${encodeURIComponent(unsentPrompt)}` : ''}`
+    : '/';
 
-    return { status: 'success', redirectTo };
+  return { status: 'success', redirectTo, planId: planId ?? undefined };
   } catch (error) {
     if (error instanceof z.ZodError) {
       return { status: 'invalid_data' };

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -82,11 +82,12 @@ export default function Page() {
         await globalSWRMutate((key) => typeof key === 'string' && key.startsWith('/api/message-status'), undefined, { revalidate: true });
         await globalSWRMutate((key) => typeof key === 'string' && key.startsWith('/api/auth/session'), undefined, { revalidate: true });
 
-        if (planId && newSession?.user && newSession.user.type !== 'guest') {
+        const targetPlanId = state.planId ?? planId;
+        if (targetPlanId && newSession?.user && newSession.user.type !== 'guest') {
           const res = await fetch('/api/checkout', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ planId }),
+            body: JSON.stringify({ planId: targetPlanId }),
           });
           const data = await res.json();
           if (data.url) {
@@ -116,14 +117,15 @@ export default function Page() {
   }, [state]);
 
   useEffect(() => {
-    if (session?.user && session.user.type !== 'guest' && planId && state.status === 'idle') {
+    const targetPlanId = state.planId ?? planId;
+    if (session?.user && session.user.type !== 'guest' && targetPlanId && state.status === 'idle') {
       const proceed = async () => {
         const newSession = await updateSession();
         if (newSession?.user && newSession.user.type !== 'guest') {
           const res = await fetch('/api/checkout', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ planId }),
+            body: JSON.stringify({ planId: targetPlanId }),
           });
           const data = await res.json();
           if (data.url) {
@@ -140,13 +142,14 @@ export default function Page() {
       };
       proceed();
     }
-  }, [session, planId, updateSession, router, state.status]);
+  }, [session, planId, state.planId, updateSession, router, state.status]);
 
   const handleSubmit = (formData: FormData) => {
     setEmail(formData.get('email') as string);
     if (chatIdToResume) formData.append('chatIdToResume', chatIdToResume);
     if (guestUserId) formData.append('guestUserId', guestUserId);
     if (unsentPrompt) formData.append('unsentPrompt', unsentPrompt);
+    if (planId) formData.append('planId', planId);
     hasShownSuccessToastRef.current = false;
     setIsSuccessful(false);
     formAction(formData);

--- a/app/(auth)/register/page.tsx
+++ b/app/(auth)/register/page.tsx
@@ -103,11 +103,12 @@ export default function Page() {
         await globalSWRMutate((key) => typeof key === 'string' && key.startsWith('/api/message-status'), undefined, { revalidate: true });
         await globalSWRMutate((key) => typeof key === 'string' && key.startsWith('/api/auth/session'), undefined, { revalidate: true });
 
-        if (planId && newSession?.user && newSession.user.type !== 'guest') {
+        const targetPlanId = state.planId ?? planId;
+        if (targetPlanId && newSession?.user && newSession.user.type !== 'guest') {
           const res = await fetch('/api/checkout', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ planId }),
+            body: JSON.stringify({ planId: targetPlanId }),
           });
           const data = await res.json();
           if (data.url) {
@@ -136,11 +137,40 @@ export default function Page() {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [state]); // Simplified dependencies if router, updateSession, etc. are stable
 
+  useEffect(() => {
+    const targetPlanId = state.planId ?? planId;
+    if (session?.user && session.user.type !== 'guest' && targetPlanId && state.status === 'idle') {
+      const proceed = async () => {
+        const newSession = await updateSession();
+        if (newSession?.user && newSession.user.type !== 'guest') {
+          const res = await fetch('/api/checkout', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ planId: targetPlanId }),
+          });
+          const data = await res.json();
+          if (data.url) {
+            try {
+              sessionStorage.removeItem('pendingPlanId');
+            } catch {
+              // ignore
+            }
+            window.location.href = data.url as string;
+          } else {
+            router.replace('/');
+          }
+        }
+      };
+      proceed();
+    }
+  }, [session, planId, state.planId, updateSession, router, state.status]);
+
   const handleSubmit = (formData: FormData) => {
     setEmail(formData.get('email') as string);
     if (chatIdToResume) formData.append('chatIdToResume', chatIdToResume);
     if (guestUserId) formData.append('guestUserId', guestUserId);
     if (unsentPrompt) formData.append('unsentPrompt', unsentPrompt);
+    if (planId) formData.append('planId', planId);
     hasShownSuccessToastRef.current = false;
     setIsSuccessful(false); // Reset for new submission
     formAction(formData);

--- a/app/(auth)/register/page.tsx
+++ b/app/(auth)/register/page.tsx
@@ -79,6 +79,7 @@ export default function Page() {
         if (chatIdToResume) loginLink.searchParams.set('chatIdToResume', chatIdToResume);
         if (guestUserId) loginLink.searchParams.set('guestUserId', guestUserId);
         if (unsentPrompt) loginLink.searchParams.set('unsentPrompt', unsentPrompt);
+        if (planId) loginLink.searchParams.set('planId', planId);
         router.replace(loginLink.toString());
       }
     } else if (state.status === 'failed') {


### PR DESCRIPTION
## Summary
- include `planId` in login and register actions to remember the pending plan
- send `planId` when submitting auth forms
- after successful authentication, redirect users to Stripe checkout using the stored plan id

## Testing
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.12.3.tgz)*
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.12.3.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68456fed3f24832aa3a1bab8523c4219