### PR TITLE
Add compare models link and page

### DIFF
--- a/app/compare/page.tsx
+++ b/app/compare/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <h1>Hello world</h1>;
+}

--- a/components/ui/upgrade-dialog.tsx
+++ b/components/ui/upgrade-dialog.tsx
@@ -8,6 +8,7 @@ import {
   DialogDescription,
 } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
+import Link from 'next/link'
 import Image from 'next/image'
 import { useUpgradePopup } from '@/hooks/use-upgrade-popup'
 import { useState } from 'react'
@@ -120,13 +121,21 @@ export function UpgradeDialog() {
                   )}
                 </div>
                 {!comingSoon ? (
-                  <Button
-                    className="mt-4 w-full"
-                    onClick={() => checkout(plan.id)}
-                    disabled={loadingId === plan.id}
-                  >
-                    {loadingId === plan.id ? 'Loading...' : 'Purchase'}
-                  </Button>
+                  <>
+                    <Button
+                      className="mt-4 w-full"
+                      onClick={() => checkout(plan.id)}
+                      disabled={loadingId === plan.id}
+                    >
+                      {loadingId === plan.id ? 'Loading...' : 'Purchase'}
+                    </Button>
+                    <Link
+                      href="/compare"
+                      className="mt-2 text-center text-sm font-semibold text-gray-800 hover:underline dark:text-zinc-200"
+                    >
+                      Compare models
+                    </Link>
+                  </>
                 ) : (
                   <p className="mt-4 text-center text-sm text-muted-foreground font-semibold">COMING SOON</p>
                 )}


### PR DESCRIPTION
## Summary
- include `next/link` in `UpgradeDialog`
- add a "Compare models" link under each purchasable model
- create a `/compare` page with placeholder text

## Testing
- `pnpm exec playwright test` *(fails: package install blocked)*

------
https://chatgpt.com/codex/tasks/task_e_684730cd1c78832aa9934b17a012b91d