### PR TITLE
Allow switching between owned models

### DIFF
--- a/components/chat-header.tsx
+++ b/components/chat-header.tsx
@@ -24,12 +24,14 @@ function PureChatHeader({
   selectedVisibilityType,
   isReadonly,
   session, // Added session prop
+  onModelChange,
 }: {
   chatId: string;
   selectedModelId: string;
   selectedVisibilityType: VisibilityType;
   isReadonly: boolean;
   session: Session; // Added session prop type
+  onModelChange?: (modelId: string) => void;
 }) {
   const router = useRouter();
   const { open } = useSidebar();
@@ -65,6 +67,7 @@ function PureChatHeader({
         <ModelSelector
           session={session}
           selectedModelId={selectedModelId}
+          onModelChange={onModelChange}
           className="order-1 md:order-2"
         />
       )}

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -58,6 +58,16 @@ export function Chat({
   const { openPopup: openUpgradePopup } = useUpgradePopup();
   const hasSetInitialInputRef = useRef(false);
 
+  const [chatModelId, setChatModelId] = useState(initialChatModel);
+
+  useEffect(() => {
+    const url = new URL(window.location.href);
+    if (url.searchParams.get('modelId') !== chatModelId) {
+      url.searchParams.set('modelId', chatModelId);
+      window.history.replaceState({}, '', url.toString());
+    }
+  }, [chatModelId]);
+
   const { visibilityType } = useChatVisibility({
     chatId: id,
     initialVisibilityType,
@@ -100,7 +110,7 @@ export function Chat({
     experimental_prepareRequestBody: (body) => ({
       id,
       message: body.messages.at(-1),
-      selectedChatModel: initialChatModel,
+      selectedChatModel: chatModelId,
       selectedVisibilityType: visibilityType,
     }),
     onFinish: () => {
@@ -234,7 +244,8 @@ export function Chat({
       <div className="flex flex-col min-w-0 h-dvh bg-background">
         <ChatHeader
           chatId={id}
-          selectedModelId={initialChatModel}
+          selectedModelId={chatModelId}
+          onModelChange={setChatModelId}
           selectedVisibilityType={visibilityType}
           isReadonly={isReadonly}
           session={session}

--- a/components/model-selector.tsx
+++ b/components/model-selector.tsx
@@ -1,8 +1,6 @@
 'use client';
 
-import { startTransition, useMemo, useOptimistic, useState } from 'react';
-
-import { saveChatModelAsCookie } from '@/app/(chat)/actions';
+import { useMemo, useOptimistic, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import {
   DropdownMenu,
@@ -20,10 +18,12 @@ import type { Session } from 'next-auth';
 export function ModelSelector({
   session,
   selectedModelId,
+  onModelChange,
   className,
 }: {
   session: Session;
   selectedModelId: string;
+  onModelChange?: (modelId: string) => void;
 } & React.ComponentProps<typeof Button>) {
   const [open, setOpen] = useState(false);
   const [optimisticModelId, setOptimisticModelId] =
@@ -76,10 +76,9 @@ export function ModelSelector({
               onSelect={() => {
                 setOpen(false);
 
-                startTransition(() => {
-                  setOptimisticModelId(id);
-                  saveChatModelAsCookie(id);
-                });
+                setOptimisticModelId(id);
+                onModelChange?.(id);
+                document.cookie = `chat-model=${id}; path=/`;
               }}
               data-active={id === optimisticModelId}
               asChild


### PR DESCRIPTION
## Summary
- handle model selector change on the client and store cookie locally
- sync selected model with URL so it persists on refresh

## Testing
- `pnpm run format` *(fails: unable to download pnpm)*
- `pnpm test` *(fails: unable to download pnpm)*

------
https://chatgpt.com/codex/tasks/task_e_684733a37f24832aaee71070815033b1