### PR TITLE
Fix optimistic model update warning

### DIFF
--- a/components/model-selector.tsx
+++ b/components/model-selector.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo, useOptimistic, useState } from 'react';
+import { useMemo, useOptimistic, useState, startTransition } from 'react';
 import { Button } from '@/components/ui/button';
 import {
   DropdownMenu,
@@ -76,7 +76,7 @@ export function ModelSelector({
               onSelect={() => {
                 setOpen(false);
 
-                setOptimisticModelId(id);
+                startTransition(() => setOptimisticModelId(id));
                 onModelChange?.(id);
                 document.cookie = `chat-model=${id}; path=/`;
               }}


### PR DESCRIPTION
## Summary
- avoid calling `setOptimisticModelId` outside a transition

## Testing
- `pnpm lint` *(fails: fetch failed)*
- `pnpm test` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_684743180a2c832abdb108e73e872de6