### PR TITLE
Switch theme to orange

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -25,6 +25,77 @@
 
 @layer base {
     :root {
+        --background: 0 0% 100%;
+        --foreground: 240 10% 3.9%;
+        --card: 0 0% 100%;
+        --card-foreground: 240 10% 3.9%;
+        --popover: 0 0% 100%;
+        --popover-foreground: 240 10% 3.9%;
+        --primary: 240 5.9% 10%;
+        --primary-foreground: 0 0% 98%;
+        --secondary: 240 4.8% 95.9%;
+        --secondary-foreground: 240 5.9% 10%;
+        --muted: 240 4.8% 95.9%;
+        --muted-foreground: 240 3.8% 46.1%;
+        --accent: 240 4.8% 95.9%;
+        --accent-foreground: 240 5.9% 10%;
+        --destructive: 0 84.2% 60.2%;
+        --destructive-foreground: 0 0% 98%;
+        --border: 240 5.9% 90%;
+        --input: 240 5.9% 90%;
+        --ring: 240 10% 3.9%;
+        --chart-1: 12 76% 61%;
+        --chart-2: 173 58% 39%;
+        --chart-3: 197 37% 24%;
+        --chart-4: 43 74% 66%;
+        --chart-5: 27 87% 67%;
+        --radius: 0.5rem;
+        --sidebar-background: 0 0% 98%;
+        --sidebar-foreground: 240 5.3% 26.1%;
+        --sidebar-primary: 240 5.9% 10%;
+        --sidebar-primary-foreground: 0 0% 98%;
+        --sidebar-accent: 240 4.8% 95.9%;
+        --sidebar-accent-foreground: 240 5.9% 10%;
+        --sidebar-border: 220 13% 91%;
+        --sidebar-ring: 217.2 91.2% 59.8%;
+    }
+
+    .dark {
+        --background: 240 10% 3.9%;
+        --foreground: 0 0% 98%;
+        --card: 240 10% 3.9%;
+        --card-foreground: 0 0% 98%;
+        --popover: 240 10% 3.9%;
+        --popover-foreground: 0 0% 98%;
+        --primary: 0 0% 98%;
+        --primary-foreground: 240 5.9% 10%;
+        --secondary: 240 3.7% 15.9%;
+        --secondary-foreground: 0 0% 98%;
+        --muted: 240 3.7% 15.9%;
+        --muted-foreground: 240 5% 64.9%;
+        --accent: 240 3.7% 15.9%;
+        --accent-foreground: 0 0% 98%;
+        --destructive: 0 62.8% 30.6%;
+        --destructive-foreground: 0 0% 98%;
+        --border: 240 3.7% 15.9%;
+        --input: 240 3.7% 15.9%;
+        --ring: 240 4.9% 83.9%;
+        --chart-1: 220 70% 50%;
+        --chart-2: 160 60% 45%;
+        --chart-3: 30 80% 55%;
+        --chart-4: 280 65% 60%;
+        --chart-5: 340 75% 55%;
+        --sidebar-background: 240 5.9% 10%;
+        --sidebar-foreground: 240 4.8% 95.9%;
+        --sidebar-primary: 224.3 76.3% 48%;
+        --sidebar-primary-foreground: 0 0% 100%;
+        --sidebar-accent: 240 3.7% 15.9%;
+        --sidebar-accent-foreground: 240 4.8% 95.9%;
+        --sidebar-border: 240 3.7% 15.9%;
+        --sidebar-ring: 217.2 91.2% 59.8%;
+    }
+
+    .orange {
         --background: 30 40% 98%;
         --foreground: 24 37% 8%;
         --card: 23 37% 93%;
@@ -43,56 +114,21 @@
         --destructive-foreground: 0 0% 98%;
         --border: 30 10% 90%;
         --input: 23 37% 93%;
-        --ring: 24 37% 8%;
+        --ring: 25 90% 55%;
         --chart-1: 12 76% 61%;
         --chart-2: 173 58% 39%;
         --chart-3: 197 37% 24%;
         --chart-4: 43 74% 66%;
         --chart-5: 27 87% 67%;
         --radius: 0.5rem;
-        --sidebar-background: 0 0% 98%;
-        --sidebar-foreground: 240 5.3% 26.1%;
-        --sidebar-primary: 240 5.9% 10%;
-        --sidebar-primary-foreground: 0 0% 98%;
-        --sidebar-accent: 240 4.8% 95.9%;
-        --sidebar-accent-foreground: 240 5.9% 10%;
-        --sidebar-border: 220 13% 91%;
-        --sidebar-ring: 217.2 91.2% 59.8%;
-    }
-
-    .dark {
-        --background: 25 60% 10%;
-        --foreground: 0 0% 98%;
-        --card: 25 60% 12%;
-        --card-foreground: 0 0% 98%;
-        --popover: 25 60% 12%;
-        --popover-foreground: 0 0% 98%;
-        --primary: 25 90% 55%;
-        --primary-foreground: 0 0% 100%;
-        --secondary: 25 60% 15%;
-        --secondary-foreground: 0 0% 100%;
-        --muted: 25 60% 15%;
-        --muted-foreground: 25 36% 45%;
-        --accent: 25 60% 15%;
-        --accent-foreground: 0 0% 100%;
-        --destructive: 0 62.8% 30.6%;
-        --destructive-foreground: 0 0% 98%;
-        --border: 25 60% 15%;
-        --input: 25 60% 15%;
-        --ring: 25 90% 55%;
-        --chart-1: 220 70% 50%;
-        --chart-2: 160 60% 45%;
-        --chart-3: 30 80% 55%;
-        --chart-4: 280 65% 60%;
-        --chart-5: 340 75% 55%;
-        --sidebar-background: 240 5.9% 10%;
-        --sidebar-foreground: 240 4.8% 95.9%;
-        --sidebar-primary: 224.3 76.3% 48%;
+        --sidebar-background: 23 37% 93%;
+        --sidebar-foreground: 24 37% 8%;
+        --sidebar-primary: 25 90% 55%;
         --sidebar-primary-foreground: 0 0% 100%;
-        --sidebar-accent: 240 3.7% 15.9%;
-        --sidebar-accent-foreground: 240 4.8% 95.9%;
-        --sidebar-border: 240 3.7% 15.9%;
-        --sidebar-ring: 217.2 91.2% 59.8%;
+        --sidebar-accent: 23 37% 93%;
+        --sidebar-accent-foreground: 24 37% 8%;
+        --sidebar-border: 30 10% 90%;
+        --sidebar-ring: 25 90% 55%;
     }
 }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -25,25 +25,25 @@
 
 @layer base {
     :root {
-        --background: 0 0% 100%;
-        --foreground: 240 10% 3.9%;
-        --card: 0 0% 100%;
-        --card-foreground: 240 10% 3.9%;
-        --popover: 0 0% 100%;
-        --popover-foreground: 240 10% 3.9%;
-        --primary: 240 5.9% 10%;
-        --primary-foreground: 0 0% 98%;
-        --secondary: 240 4.8% 95.9%;
-        --secondary-foreground: 240 5.9% 10%;
-        --muted: 240 4.8% 95.9%;
-        --muted-foreground: 240 3.8% 46.1%;
-        --accent: 240 4.8% 95.9%;
-        --accent-foreground: 240 5.9% 10%;
+        --background: 30 40% 98%;
+        --foreground: 24 37% 8%;
+        --card: 23 37% 93%;
+        --card-foreground: 24 37% 8%;
+        --popover: 23 37% 93%;
+        --popover-foreground: 24 37% 8%;
+        --primary: 25 90% 55%;
+        --primary-foreground: 0 0% 100%;
+        --secondary: 23 37% 93%;
+        --secondary-foreground: 24 37% 8%;
+        --muted: 23 37% 93%;
+        --muted-foreground: 25 36% 45%;
+        --accent: 23 37% 93%;
+        --accent-foreground: 24 37% 8%;
         --destructive: 0 84.2% 60.2%;
         --destructive-foreground: 0 0% 98%;
-        --border: 240 5.9% 90%;
-        --input: 240 5.9% 90%;
-        --ring: 240 10% 3.9%;
+        --border: 30 10% 90%;
+        --input: 23 37% 93%;
+        --ring: 24 37% 8%;
         --chart-1: 12 76% 61%;
         --chart-2: 173 58% 39%;
         --chart-3: 197 37% 24%;
@@ -61,25 +61,25 @@
     }
 
     .dark {
-        --background: 240 10% 3.9%;
+        --background: 25 60% 10%;
         --foreground: 0 0% 98%;
-        --card: 240 10% 3.9%;
+        --card: 25 60% 12%;
         --card-foreground: 0 0% 98%;
-        --popover: 240 10% 3.9%;
+        --popover: 25 60% 12%;
         --popover-foreground: 0 0% 98%;
-        --primary: 0 0% 98%;
-        --primary-foreground: 240 5.9% 10%;
-        --secondary: 240 3.7% 15.9%;
-        --secondary-foreground: 0 0% 98%;
-        --muted: 240 3.7% 15.9%;
-        --muted-foreground: 240 5% 64.9%;
-        --accent: 240 3.7% 15.9%;
-        --accent-foreground: 0 0% 98%;
+        --primary: 25 90% 55%;
+        --primary-foreground: 0 0% 100%;
+        --secondary: 25 60% 15%;
+        --secondary-foreground: 0 0% 100%;
+        --muted: 25 60% 15%;
+        --muted-foreground: 25 36% 45%;
+        --accent: 25 60% 15%;
+        --accent-foreground: 0 0% 100%;
         --destructive: 0 62.8% 30.6%;
         --destructive-foreground: 0 0% 98%;
-        --border: 240 3.7% 15.9%;
-        --input: 240 3.7% 15.9%;
-        --ring: 240 4.9% 83.9%;
+        --border: 25 60% 15%;
+        --input: 25 60% 15%;
+        --ring: 25 90% 55%;
         --chart-1: 220 70% 50%;
         --chart-2: 160 60% 45%;
         --chart-3: 30 80% 55%;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -32,6 +32,7 @@ const geistMono = Geist_Mono({
 
 const LIGHT_THEME_COLOR = 'hsl(0 0% 100%)';
 const DARK_THEME_COLOR = 'hsl(240deg 10% 3.92%)';
+const ORANGE_THEME_COLOR = 'hsl(30 40% 98%)';
 const THEME_COLOR_SCRIPT = `\
 (function() {
   var html = document.documentElement;
@@ -42,8 +43,14 @@ const THEME_COLOR_SCRIPT = `\
     document.head.appendChild(meta);
   }
   function updateThemeColor() {
-    var isDark = html.classList.contains('dark');
-    meta.setAttribute('content', isDark ? '${DARK_THEME_COLOR}' : '${LIGHT_THEME_COLOR}');
+    var classes = html.classList;
+    if (classes.contains('dark')) {
+      meta.setAttribute('content', '${DARK_THEME_COLOR}');
+    } else if (classes.contains('orange')) {
+      meta.setAttribute('content', '${ORANGE_THEME_COLOR}');
+    } else {
+      meta.setAttribute('content', '${LIGHT_THEME_COLOR}');
+    }
   }
   var observer = new MutationObserver(updateThemeColor);
   observer.observe(html, { attributes: true, attributeFilter: ['class'] });
@@ -71,9 +78,10 @@ export default async function RootLayout({
       <body className="antialiased">
         <ThemeProvider
           attribute="class"
-          defaultTheme="system"
+          defaultTheme="orange"
           enableSystem
           disableTransitionOnChange
+          themes={["light", "dark", "orange"]}
         >
           <Toaster position="top-center" />
           <SessionProvider>

--- a/components/sidebar-user-nav.tsx
+++ b/components/sidebar-user-nav.tsx
@@ -74,9 +74,12 @@ export function SidebarUserNav({ user }: { user: User }) {
             <DropdownMenuItem
               data-testid="user-nav-item-theme"
               className="cursor-pointer"
-              onSelect={() => setTheme(theme === 'dark' ? 'light' : 'dark')}
+              onSelect={() => {
+                const next = theme === 'dark' ? 'light' : theme === 'light' ? 'orange' : 'dark';
+                setTheme(next);
+              }}
             >
-              {`Toggle ${theme === 'light' ? 'dark' : 'light'} mode`}
+              {`Toggle ${theme === 'dark' ? 'light' : theme === 'light' ? 'orange' : 'dark'} mode`}
             </DropdownMenuItem>
             <DropdownMenuSeparator />
             <DropdownMenuItem asChild data-testid="user-nav-item-auth">


### PR DESCRIPTION
## Summary
- default palette uses orange HSL values
- dark mode colors use the matching orange-dark shades

## Testing
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.12.3.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_6847d379d0ec832a994e12be80c23a4d