### PR TITLE
Refine default orange theme

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -25,74 +25,110 @@
 
 @layer base {
     :root {
-        --background: 0 0% 100%;
-        --foreground: 240 10% 3.9%;
-        --card: 0 0% 100%;
-        --card-foreground: 240 10% 3.9%;
-        --popover: 0 0% 100%;
-        --popover-foreground: 240 10% 3.9%;
-        --primary: 240 5.9% 10%;
-        --primary-foreground: 0 0% 98%;
-        --secondary: 240 4.8% 95.9%;
-        --secondary-foreground: 240 5.9% 10%;
-        --muted: 240 4.8% 95.9%;
-        --muted-foreground: 240 3.8% 46.1%;
-        --accent: 240 4.8% 95.9%;
-        --accent-foreground: 240 5.9% 10%;
+        --background: 30 40% 98%;
+        --foreground: 24 37% 8%;
+        --card: 23 37% 93%;
+        --card-foreground: 24 37% 8%;
+        --popover: 23 37% 93%;
+        --popover-foreground: 24 37% 8%;
+        --primary: 25 90% 55%;
+        --primary-foreground: 0 0% 100%;
+        --secondary: 23 37% 93%;
+        --secondary-foreground: 24 37% 8%;
+        --muted: 23 37% 93%;
+        --muted-foreground: 25 36% 45%;
+        --accent: 23 37% 93%;
+        --accent-foreground: 24 37% 8%;
         --destructive: 0 84.2% 60.2%;
         --destructive-foreground: 0 0% 98%;
-        --border: 240 5.9% 90%;
-        --input: 240 5.9% 90%;
-        --ring: 240 10% 3.9%;
+        --border: 30 10% 90%;
+        --input: 23 37% 93%;
+        --ring: 24 37% 8%;
         --chart-1: 12 76% 61%;
         --chart-2: 173 58% 39%;
         --chart-3: 197 37% 24%;
         --chart-4: 43 74% 66%;
         --chart-5: 27 87% 67%;
         --radius: 0.5rem;
-        --sidebar-background: 0 0% 98%;
-        --sidebar-foreground: 240 5.3% 26.1%;
-        --sidebar-primary: 240 5.9% 10%;
-        --sidebar-primary-foreground: 0 0% 98%;
-        --sidebar-accent: 240 4.8% 95.9%;
-        --sidebar-accent-foreground: 240 5.9% 10%;
-        --sidebar-border: 220 13% 91%;
-        --sidebar-ring: 217.2 91.2% 59.8%;
+        --sidebar-background: #F6E9DD;
+        --sidebar-foreground: 24 37% 8%;
+        --sidebar-primary: 25 90% 55%;
+        --sidebar-primary-foreground: 0 0% 100%;
+        --sidebar-accent: 23 37% 93%;
+        --sidebar-accent-foreground: 24 37% 8%;
+        --sidebar-border: 30 10% 90%;
+        --sidebar-ring: 25 90% 55%;
     }
 
     .dark {
-        --background: 240 10% 3.9%;
+        --background: 25 60% 10%;
         --foreground: 0 0% 98%;
-        --card: 240 10% 3.9%;
+        --card: 25 60% 12%;
         --card-foreground: 0 0% 98%;
-        --popover: 240 10% 3.9%;
+        --popover: 25 60% 12%;
         --popover-foreground: 0 0% 98%;
-        --primary: 0 0% 98%;
-        --primary-foreground: 240 5.9% 10%;
-        --secondary: 240 3.7% 15.9%;
-        --secondary-foreground: 0 0% 98%;
-        --muted: 240 3.7% 15.9%;
-        --muted-foreground: 240 5% 64.9%;
-        --accent: 240 3.7% 15.9%;
-        --accent-foreground: 0 0% 98%;
+        --primary: 25 90% 55%;
+        --primary-foreground: 0 0% 100%;
+        --secondary: 25 60% 15%;
+        --secondary-foreground: 0 0% 100%;
+        --muted: 25 60% 15%;
+        --muted-foreground: 25 36% 45%;
+        --accent: 25 60% 15%;
+        --accent-foreground: 0 0% 100%;
         --destructive: 0 62.8% 30.6%;
         --destructive-foreground: 0 0% 98%;
-        --border: 240 3.7% 15.9%;
-        --input: 240 3.7% 15.9%;
-        --ring: 240 4.9% 83.9%;
+        --border: 25 60% 15%;
+        --input: 25 60% 15%;
+        --ring: 25 90% 55%;
         --chart-1: 220 70% 50%;
         --chart-2: 160 60% 45%;
         --chart-3: 30 80% 55%;
         --chart-4: 280 65% 60%;
         --chart-5: 340 75% 55%;
-        --sidebar-background: 240 5.9% 10%;
-        --sidebar-foreground: 240 4.8% 95.9%;
-        --sidebar-primary: 224.3 76.3% 48%;
+        --sidebar-background: 25 60% 10%;
+        --sidebar-foreground: 0 0% 98%;
+        --sidebar-primary: 25 90% 55%;
         --sidebar-primary-foreground: 0 0% 100%;
-        --sidebar-accent: 240 3.7% 15.9%;
-        --sidebar-accent-foreground: 240 4.8% 95.9%;
-        --sidebar-border: 240 3.7% 15.9%;
-        --sidebar-ring: 217.2 91.2% 59.8%;
+        --sidebar-accent: 25 60% 15%;
+        --sidebar-accent-foreground: 0 0% 100%;
+        --sidebar-border: 25 60% 15%;
+        --sidebar-ring: 25 90% 55%;
+    }
+
+    .orange {
+        --background: 30 40% 98%;
+        --foreground: 24 37% 8%;
+        --card: 23 37% 93%;
+        --card-foreground: 24 37% 8%;
+        --popover: 23 37% 93%;
+        --popover-foreground: 24 37% 8%;
+        --primary: 25 90% 55%;
+        --primary-foreground: 0 0% 100%;
+        --secondary: 23 37% 93%;
+        --secondary-foreground: 24 37% 8%;
+        --muted: 23 37% 93%;
+        --muted-foreground: 25 36% 45%;
+        --accent: 23 37% 93%;
+        --accent-foreground: 24 37% 8%;
+        --destructive: 0 84.2% 60.2%;
+        --destructive-foreground: 0 0% 98%;
+        --border: 30 10% 90%;
+        --input: 23 37% 93%;
+        --ring: 25 90% 55%;
+        --chart-1: 12 76% 61%;
+        --chart-2: 173 58% 39%;
+        --chart-3: 197 37% 24%;
+        --chart-4: 43 74% 66%;
+        --chart-5: 27 87% 67%;
+        --radius: 0.5rem;
+        --sidebar-background: #F6E9DD;
+        --sidebar-foreground: 24 37% 8%;
+        --sidebar-primary: 25 90% 55%;
+        --sidebar-primary-foreground: 0 0% 100%;
+        --sidebar-accent: 23 37% 93%;
+        --sidebar-accent-foreground: 24 37% 8%;
+        --sidebar-border: 30 10% 90%;
+        --sidebar-ring: 25 90% 55%;
     }
 }
 
@@ -185,5 +221,47 @@
 
     .model-card img {
         @apply block w-full object-cover rounded-t-lg;
+    }
+
+    /* Orange theme component tweaks */
+    .orange [data-role="assistant"] [data-testid="message-content"] {
+        background-color: #F3ECE8;
+        padding: 0.5rem 0.75rem;
+        border-radius: 0.75rem;
+    }
+
+    .orange [data-testid="attachments-button"] svg {
+        color: hsl(var(--primary));
+    }
+
+    .orange header button,
+    .orange [data-testid="message-upvote"],
+    .orange [data-testid="message-downvote"] {
+        border-color: hsl(var(--primary));
+        color: hsl(var(--primary));
+    }
+
+    .orange header button:hover,
+    .orange [data-testid="message-upvote"]:hover,
+    .orange [data-testid="message-downvote"]:hover {
+        background-color: hsl(25 90% 55%);
+        color: hsl(var(--primary-foreground));
+    }
+
+    .orange [data-testid="upgrade-button"] {
+        background-color: hsl(25 100% 60%);
+        color: #fff;
+        border-color: hsl(25 100% 60%);
+    }
+
+    .orange [data-testid="new-chat-button"] {
+        background-color: hsl(var(--primary));
+        color: hsl(var(--primary-foreground));
+        border-color: hsl(var(--primary));
+    }
+
+    .orange [data-testid="upgrade-button"]:hover {
+        background-color: hsl(25 90% 55%);
+        border-color: hsl(25 90% 55%);
     }
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -32,6 +32,7 @@ const geistMono = Geist_Mono({
 
 const LIGHT_THEME_COLOR = 'hsl(0 0% 100%)';
 const DARK_THEME_COLOR = 'hsl(240deg 10% 3.92%)';
+const ORANGE_THEME_COLOR = 'hsl(30 40% 98%)';
 const THEME_COLOR_SCRIPT = `\
 (function() {
   var html = document.documentElement;
@@ -42,8 +43,14 @@ const THEME_COLOR_SCRIPT = `\
     document.head.appendChild(meta);
   }
   function updateThemeColor() {
-    var isDark = html.classList.contains('dark');
-    meta.setAttribute('content', isDark ? '${DARK_THEME_COLOR}' : '${LIGHT_THEME_COLOR}');
+    var classes = html.classList;
+    if (classes.contains('dark')) {
+      meta.setAttribute('content', '${DARK_THEME_COLOR}');
+    } else if (classes.contains('orange')) {
+      meta.setAttribute('content', '${ORANGE_THEME_COLOR}');
+    } else {
+      meta.setAttribute('content', '${LIGHT_THEME_COLOR}');
+    }
   }
   var observer = new MutationObserver(updateThemeColor);
   observer.observe(html, { attributes: true, attributeFilter: ['class'] });
@@ -71,9 +78,10 @@ export default async function RootLayout({
       <body className="antialiased">
         <ThemeProvider
           attribute="class"
-          defaultTheme="system"
+          defaultTheme="orange"
           enableSystem
           disableTransitionOnChange
+          themes={["light", "dark", "orange"]}
         >
           <Toaster position="top-center" />
           <SessionProvider>

--- a/components/chat-header.tsx
+++ b/components/chat-header.tsx
@@ -47,6 +47,7 @@ function PureChatHeader({
         <Tooltip>
           <TooltipTrigger asChild>
             <Button
+              data-testid="new-chat-button"
               variant="outline"
               type="button"
               className="order-2 md:order-1 md:px-2 px-2 md:h-[34px] ml-auto md:ml-0" // md:h-fit changed to md:h-[34px] for consistency
@@ -88,6 +89,7 @@ function PureChatHeader({
 
       {session?.user && session.user.models?.length !== plansLength && (
         <Button
+          data-testid="upgrade-button"
           variant="outline"
           className="hidden md:flex py-1.5 px-2 h-fit md:h-[34px] order-last md:order-4 ml-2"
           onClick={() => openUpgradePopup()}

--- a/components/sidebar-user-nav.tsx
+++ b/components/sidebar-user-nav.tsx
@@ -74,9 +74,12 @@ export function SidebarUserNav({ user }: { user: User }) {
             <DropdownMenuItem
               data-testid="user-nav-item-theme"
               className="cursor-pointer"
-              onSelect={() => setTheme(theme === 'dark' ? 'light' : 'dark')}
+              onSelect={() => {
+                const next = theme === 'dark' ? 'light' : theme === 'light' ? 'orange' : 'dark';
+                setTheme(next);
+              }}
             >
-              {`Toggle ${theme === 'light' ? 'dark' : 'light'} mode`}
+              {`Toggle ${theme === 'dark' ? 'light' : theme === 'light' ? 'orange' : 'dark'} mode`}
             </DropdownMenuItem>
             <DropdownMenuSeparator />
             <DropdownMenuItem asChild data-testid="user-nav-item-auth">


### PR DESCRIPTION
## Summary
- use orange palette for :root and dark mode variables
- set warmer sidebar color and pale assistant bubble in orange mode
- color attachment icon and new chat button orange
- mark new chat button with data-testid for targeting

## Testing
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.12.3.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_6847d379d0ec832a994e12be80c23a4d