### PR TITLE
Update sidebar and input colors in orange theme

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -121,11 +121,11 @@
         --chart-4: 43 74% 66%;
         --chart-5: 27 87% 67%;
         --radius: 0.5rem;
-        --sidebar-background: 25 60% 88%;
+        --sidebar-background: 30 73.68% 92.55%;
         --sidebar-foreground: 24 37% 8%;
         --sidebar-primary: 25 90% 55%;
         --sidebar-primary-foreground: 0 0% 100%;
-        --sidebar-accent: 23 37% 93%;
+        --sidebar-accent: 29 100% 77%;
         --sidebar-accent-foreground: 24 37% 8%;
         --sidebar-border: 30 10% 90%;
         --sidebar-ring: 25 90% 55%;
@@ -224,14 +224,15 @@
     }
 
     /* Orange theme component tweaks */
-    .orange [data-role="assistant"] [data-testid="message-content"] {
-        background-color: hsl(30 40% 90%);
+    .orange [data-role="assistant"] [data-testid="message-content"],
+    .orange .chat-response {
+        background-color: #ffd4ad;
         padding: 0.5rem 0.75rem;
         border-radius: 0.75rem;
     }
 
     .orange [data-testid="attachments-button"] svg {
-        color: hsl(25 80% 50%);
+        color: hsl(var(--primary));
     }
 
     .orange header button,
@@ -257,5 +258,15 @@
     .orange [data-testid="upgrade-button"]:hover {
         background-color: hsl(25 90% 55%);
         border-color: hsl(25 90% 55%);
+    }
+
+    .orange .sidebar .new-chat-button {
+        background-color: hsl(var(--primary));
+        color: hsl(var(--primary-foreground));
+        border-color: hsl(var(--primary));
+    }
+
+    .orange [data-testid="multimodal-input"] {
+        background-color: #ffdfc2;
     }
 }

--- a/components/app-sidebar.tsx
+++ b/components/app-sidebar.tsx
@@ -43,7 +43,7 @@ export function AppSidebar({ user }: { user: User | undefined }) {
                 <Button
                   variant="ghost"
                   type="button"
-                  className="p-2 h-fit"
+                  className="new-chat-button p-2 h-fit"
                   onClick={() => {
                     setOpenMobile(false);
                     router.push('/');

--- a/components/message.tsx
+++ b/components/message.tsx
@@ -128,6 +128,7 @@ const PurePreviewMessage = ({
                         className={cn('flex flex-col gap-4', {
                           'bg-primary text-primary-foreground px-3 py-2 rounded-xl':
                             message.role === 'user',
+                          'chat-response': message.role === 'assistant',
                         })}
                       >
                         <Markdown>{sanitizeText(part.text)}</Markdown>


### PR DESCRIPTION
## Summary
- refine sidebar background variable for orange theme
- lighten the send-message input box

## Testing
- `pnpm lint` *(fails: Request was cancelled)*
- `pnpm test` *(fails: Request was cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_6847eb1a2824832a9bdab0b77695729f