### PR TITLE
Fix guest session persistence

### DIFF
--- a/app/(auth)/api/auth/guest/route.ts
+++ b/app/(auth)/api/auth/guest/route.ts
@@ -2,6 +2,8 @@ import { signIn } from '@/app/(auth)/auth';
 import { isDevelopmentEnvironment } from '@/lib/constants';
 import { getToken } from 'next-auth/jwt';
 import { NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+import { isValidUUID } from '@/lib/utils';
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
@@ -17,5 +19,13 @@ export async function GET(request: Request) {
     return NextResponse.redirect(new URL('/', request.url));
   }
 
-  return signIn('guest', { redirect: true, redirectTo: redirectUrl });
+  const cookieStore = await cookies();
+  const storedId = cookieStore.get('guestUserId')?.value ?? null;
+  const guestUserId = isValidUUID(storedId) ? storedId : undefined;
+
+  return signIn('guest', {
+    redirect: true,
+    redirectTo: redirectUrl,
+    guestUserId,
+  });
 }

--- a/app/(auth)/auth.ts
+++ b/app/(auth)/auth.ts
@@ -5,6 +5,7 @@ import GoogleProvider from 'next-auth/providers/google';
 import { randomUUID } from 'node:crypto';
 import {
   createGuestUser,
+  getUserById,
   getUser,
   createUser,
   getUserModelIds,
@@ -12,6 +13,7 @@ import {
 } from '@/lib/db/queries';
 import { authConfig } from './auth.config';
 import { DUMMY_PASSWORD } from '@/lib/constants';
+import { isValidUUID } from '@/lib/utils';
 import type { DefaultJWT } from 'next-auth/jwt';
 import type { UserType } from '@/lib/user-types';
 
@@ -77,10 +79,17 @@ const providers = [
   Credentials({
     id: 'guest', // matches signIn('guest')
     name: 'Guest account',
-    credentials: {},
-    async authorize() {
+    credentials: { guestUserId: { label: 'guestUserId', type: 'text' } },
+    async authorize(credentials) {
+      if (isValidUUID(credentials?.guestUserId)) {
+        const existing = await getUserById(credentials!.guestUserId);
+        if (existing) {
+          return { ...existing, type: 'guest', models: [] } as any;
+        }
+      }
+
       const [guestUser] = await createGuestUser();
-      return { ...guestUser, type: 'guest', models: [] };
+      return { ...guestUser, type: 'guest', models: [] } as any;
     },
   }),
 ];

--- a/app/(chat)/layout.tsx
+++ b/app/(chat)/layout.tsx
@@ -15,6 +15,13 @@ export default async function Layout({
   const [session, cookieStore] = await Promise.all([auth(), cookies()]);
   const isCollapsed = cookieStore.get('sidebar:state')?.value === 'false';
 
+  if (session?.user?.type === 'guest') {
+    cookieStore.set('guestUserId', session.user.id, {
+      path: '/',
+      maxAge: 60 * 60 * 24,
+    });
+  }
+
   return (
     <>
       <Script

--- a/lib/db/queries.ts
+++ b/lib/db/queries.ts
@@ -140,6 +140,15 @@ export async function createGuestUser(): Promise<Array<Pick<User, 'id' | 'email'
   }
 }
 
+export async function getUserById(id: string): Promise<User | null> {
+  try {
+    const [foundUser] = await db.select().from(user).where(eq(user.id, id)).limit(1);
+    return foundUser ?? null;
+  } catch (error) {
+    throw new ChatSDKError('bad_request:database', 'Failed to get user by id');
+  }
+}
+
 export async function saveChat({
   id,
   userId,

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -56,6 +56,13 @@ export function generateUUID(): string {
   });
 }
 
+export function isValidUUID(value: string | null | undefined): value is string {
+  if (!value) return false;
+  return /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$/.test(
+    value,
+  );
+}
+
 type ResponseMessageWithoutId = CoreToolMessage | CoreAssistantMessage;
 type ResponseMessage = ResponseMessageWithoutId & { id: string };
 


### PR DESCRIPTION
## Summary
- persist guest user IDs between sign-ins
- reuse guest ID when signing in again
- record guest ID in auth cookie
- fix cookies API usage in guest auth route
- validate guest ID before querying the database

## Testing
- `pnpm lint` *(fails: fetch failed)*
- `pnpm test` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_684804659a30832a8a713cbbb296c5b5