### PR TITLE
Increase chat layout width

### DIFF
--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -267,7 +267,7 @@ export function Chat({
           // is designed to be used directly as a form's onSubmit handler.
           // Our wrapped `handleSubmit` also supports this.
           onSubmit={handleSubmit}
-          className="flex mx-auto px-4 bg-background pb-4 md:pb-6 gap-2 w-full md:max-w-3xl"
+          className="flex mx-auto px-4 bg-background pb-4 md:pb-6 gap-2 w-full md:max-w-[60rem]"
         >
           {!isReadonly && (
             <MultimodalInput

--- a/components/greeting.tsx
+++ b/components/greeting.tsx
@@ -4,7 +4,7 @@ export const Greeting = () => {
   return (
     <div
       key="overview"
-      className="max-w-3xl mx-auto md:mt-20 px-8 size-full flex flex-col justify-center"
+      className="max-w-[60rem] mx-auto md:mt-20 px-8 size-full flex flex-col justify-center"
     >
       <motion.div
         initial={{ opacity: 0, y: 10 }}

--- a/components/message.tsx
+++ b/components/message.tsx
@@ -45,14 +45,14 @@ const PurePreviewMessage = ({
     <AnimatePresence>
       <motion.div
         data-testid={`message-${message.role}`}
-        className="w-full mx-auto max-w-3xl px-4 group/message"
+        className="w-full mx-auto max-w-[60rem] px-4 group/message"
         initial={{ y: 5, opacity: 0 }}
         animate={{ y: 0, opacity: 1 }}
         data-role={message.role}
       >
         <div
           className={cn(
-            'flex gap-4 w-full group-data-[role=user]/message:ml-auto group-data-[role=user]/message:max-w-2xl',
+            'flex gap-4 w-full group-data-[role=user]/message:ml-auto group-data-[role=user]/message:max-w-[52.5rem]',
             {
               'w-full': mode === 'edit',
               'group-data-[role=user]/message:w-fit': mode !== 'edit',
@@ -258,14 +258,14 @@ export const ThinkingMessage = () => {
   return (
     <motion.div
       data-testid="message-assistant-loading"
-      className="w-full mx-auto max-w-3xl px-4 group/message min-h-96"
+      className="w-full mx-auto max-w-[60rem] px-4 group/message min-h-96"
       initial={{ y: 5, opacity: 0 }}
       animate={{ y: 0, opacity: 1, transition: { delay: 1 } }}
       data-role={role}
     >
       <div
         className={cx(
-          'flex gap-4 group-data-[role=user]/message:px-3 w-full group-data-[role=user]/message:w-fit group-data-[role=user]/message:ml-auto group-data-[role=user]/message:max-w-2xl group-data-[role=user]/message:py-2 rounded-xl',
+          'flex gap-4 group-data-[role=user]/message:px-3 w-full group-data-[role=user]/message:w-fit group-data-[role=user]/message:ml-auto group-data-[role=user]/message:max-w-[52.5rem] group-data-[role=user]/message:py-2 rounded-xl',
           {
             'group-data-[role=user]/message:bg-muted': true,
           },

--- a/components/messages.tsx
+++ b/components/messages.tsx
@@ -42,7 +42,7 @@ function PureMessages({
   return (
     <div
       ref={messagesContainerRef}
-      className="flex flex-col min-w-0 gap-6 flex-1 overflow-y-scroll pt-4 relative"
+      className="flex flex-col min-w-0 gap-6 flex-1 overflow-y-scroll pt-4 pb-20 relative"
     >
       {messages.length === 0 && <Greeting />}
 


### PR DESCRIPTION
## Summary
- widen chat containers to 60rem
- widen user message wrappers
- add more padding to scrolling region

## Testing
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm)*
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm)*

------
https://chatgpt.com/codex/tasks/task_e_68486398bc44832a9416833cf5cc4a3c