### PR TITLE
Increase spacing after user messages

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -58,6 +58,8 @@
         --sidebar-accent-foreground: 240 5.9% 10%;
         --sidebar-border: 220 13% 91%;
         --sidebar-ring: 217.2 91.2% 59.8%;
+        --gap-user-to-assistant: 140px;
+        --gap-assistant-to-user: 0px;
     }
 
     .dark {
@@ -93,6 +95,8 @@
         --sidebar-accent-foreground: 240 4.8% 95.9%;
         --sidebar-border: 240 3.7% 15.9%;
         --sidebar-ring: 217.2 91.2% 59.8%;
+        --gap-user-to-assistant: 140px;
+        --gap-assistant-to-user: 0px;
     }
 
     .orange {
@@ -130,6 +134,8 @@
         --sidebar-accent-foreground: 24 37% 8%;
         --sidebar-border: 30 10% 90%;
         --sidebar-ring: 25 90% 55%;
+        --gap-user-to-assistant: 140px;
+        --gap-assistant-to-user: 0px;
     }
 }
 

--- a/components/message.tsx
+++ b/components/message.tsx
@@ -45,7 +45,7 @@ const PurePreviewMessage = ({
     <AnimatePresence>
       <motion.div
         data-testid={`message-${message.role}`}
-        className="w-full mx-auto max-w-[52rem] px-4 group/message group-data-[role=user]/message:mb-10"
+        className="w-full mx-auto max-w-[52rem] px-4 group/message group-data-[role=user]/message:mb-[var(--gap-user-to-assistant)] group-data-[role=assistant]/message:mb-[var(--gap-assistant-to-user)]"
         initial={{ y: 5, opacity: 0 }}
         animate={{ y: 0, opacity: 1 }}
         data-role={message.role}


### PR DESCRIPTION
## Summary
- add CSS variables for message spacing
- apply user->assistant margin using the new variable

## Testing
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.12.3.tgz)*
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.12.3.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_684890025488832ab83da7e27ed09f66