### PR TITLE
Fix next-intl runtime setup

### DIFF
--- a/i18n/request.ts
+++ b/i18n/request.ts
@@ -1,0 +1,5 @@
+import { getRequestConfig } from 'next-intl/server';
+
+export default getRequestConfig(async ({ locale }) => ({
+  messages: (await import(`../locales/${locale}.json`)).default,
+}));

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,20 +1,27 @@
 import { NextResponse, type NextRequest } from 'next/server';
 import { getToken } from 'next-auth/jwt';
+import createIntlMiddleware from 'next-intl/middleware';
+import i18nConfig from './next-intl.config';
 import { guestRegex, isDevelopmentEnvironment } from './lib/constants';
+
+const intlMiddleware = createIntlMiddleware(i18nConfig);
 
 export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
+  const intlResponse = intlMiddleware(request);
 
   /*
    * Playwright starts the dev server and requires a 200 status to
    * begin the tests, so this ensures that the tests can start
    */
   if (pathname.startsWith('/ping')) {
-    return new Response('pong', { status: 200 });
+    const res = new Response('pong', { status: 200 });
+    res.headers.set('X-NEXT-INTL-LOCALE', intlResponse.headers.get('X-NEXT-INTL-LOCALE') ?? '');
+    return res;
   }
 
   if (pathname.startsWith('/api/auth')) {
-    return NextResponse.next();
+    return intlResponse;
   }
 
   const token = await getToken({
@@ -26,18 +33,21 @@ export async function middleware(request: NextRequest) {
   if (!token) {
     const redirectUrl = encodeURIComponent(request.url);
 
-    return NextResponse.redirect(
+    const res = NextResponse.redirect(
       new URL(`/api/auth/guest?redirectUrl=${redirectUrl}`, request.url),
     );
+    res.headers.set('X-NEXT-INTL-LOCALE', intlResponse.headers.get('X-NEXT-INTL-LOCALE') ?? '');
+    return res;
   }
 
   const isGuest = guestRegex.test(token?.email ?? '');
 
   if (token && !isGuest && ['/login', '/register'].includes(pathname)) {
-    return NextResponse.redirect(new URL('/', request.url));
+    const res = NextResponse.redirect(new URL('/', request.url));
+    res.headers.set('X-NEXT-INTL-LOCALE', intlResponse.headers.get('X-NEXT-INTL-LOCALE') ?? '');
+    return res;
   }
-
-  return NextResponse.next();
+  return intlResponse;
 }
 
 export const config = {

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,12 +1,10 @@
 import type { NextConfig } from 'next';
+import createNextIntlPlugin from 'next-intl/plugin';
 
 const nextConfig: NextConfig = {
   experimental: {
     ppr: true,
-  },
-  i18n: {
-    locales: ['en', 'nl'],
-    defaultLocale: 'en',
+    turbo: {},
   },
   env: {
     NEXT_PUBLIC_GOOGLE_AUTH_ENABLED: process.env.GOOGLE_CLIENT_ID &&
@@ -26,4 +24,6 @@ const nextConfig: NextConfig = {
   },
 };
 
-export default nextConfig;
+const withNextIntl = createNextIntlPlugin();
+
+export default withNextIntl(nextConfig);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,7 +27,9 @@
     "**/*.ts",
     "**/*.tsx",
     ".next/types/**/*.ts",
-    "next.config.js"
+    "next.config.ts",
+    "next-intl.config.ts",
+    "i18n/request.ts"
   ],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Summary
- use the default request config path for `next-intl`
- rename request and config files back to TypeScript
- remove custom path from `createNextIntlPlugin`

## Testing
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.12.3.tgz)*
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.12.3.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68492bbd5a2c832a8aaf1e93869114cc