### PR TITLE
Fix Next.js intl middleware compatibility

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -7,6 +7,8 @@ import { guestRegex, isDevelopmentEnvironment } from './lib/constants';
 const intlMiddleware = createIntlMiddleware(i18nConfig);
 
 export async function middleware(request: NextRequest) {
+  // Normalize potential non-string pathnames in Next.js 15
+  request.nextUrl.pathname = String(request.nextUrl.pathname);
   const { pathname } = request.nextUrl;
   const intlResponse = intlMiddleware(request);
 


### PR DESCRIPTION
## Summary
- normalize `request.nextUrl.pathname` before invoking intl middleware

## Testing
- `pnpm lint`
- `pnpm test` *(fails: no output)*

------
https://chatgpt.com/codex/tasks/task_e_68493e3320c4832a8a6ccb6212e21358