### PR TITLE
Add language toggle with Dutch support

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,9 @@ import { Toaster } from 'sonner';
 import type { Metadata } from 'next';
 import { Geist, Geist_Mono } from 'next/font/google';
 import { ThemeProvider } from '@/components/theme-provider';
+import { cookies } from 'next/headers';
+import { LanguageProvider } from '@/components/language-provider';
+import type { Language } from '@/lib/i18n';
 
 import './globals.css';
 import { SessionProvider } from 'next-auth/react';
@@ -62,9 +65,12 @@ export default async function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const cookieStore = cookies();
+  const langCookie = cookieStore.get('language');
+  const lang = (langCookie?.value === 'nl' ? 'nl' : 'en') as Language;
   return (
     <html
-      lang="en"
+      lang={lang}
       suppressHydrationWarning
       className={`${geist.variable} ${geistMono.variable}`}
     >
@@ -76,6 +82,7 @@ export default async function RootLayout({
         />
       </head>
       <body className="antialiased">
+        <LanguageProvider defaultLang={lang}>
         <ThemeProvider
           attribute="class"
           defaultTheme="orange"
@@ -90,6 +97,7 @@ export default async function RootLayout({
             <UpgradeDialog />
           </SessionProvider>
         </ThemeProvider>
+        </LanguageProvider>
       </body>
     </html>
   );

--- a/components/chat-header.tsx
+++ b/components/chat-header.tsx
@@ -15,6 +15,7 @@ import { type VisibilityType, VisibilitySelector } from './visibility-selector';
 import type { Session } from 'next-auth';
 import { MessageLimitIndicator } from './message-limit-indicator'; // Added
 import { useUpgradePopup } from '@/hooks/use-upgrade-popup';
+import { useTranslation } from '@/lib/i18n';
 
 const plansLength = 3;
 
@@ -36,6 +37,7 @@ function PureChatHeader({
   const router = useRouter();
   const { open } = useSidebar();
   const { openPopup: openUpgradePopup } = useUpgradePopup();
+  const t = useTranslation();
 
   const { width: windowWidth } = useWindowSize();
 
@@ -56,10 +58,10 @@ function PureChatHeader({
               }}
             >
               <PlusIcon />
-              <span className="hidden md:inline ml-1">New Chat</span> {/* Changed sr-only to hidden md:inline */}
+              <span className="hidden md:inline ml-1">{t('newChat')}</span> {/* Changed sr-only to hidden md:inline */}
             </Button>
           </TooltipTrigger>
-          <TooltipContent>New Chat</TooltipContent>
+          <TooltipContent>{t('newChat')}</TooltipContent>
         </Tooltip>
       )}
 
@@ -93,7 +95,7 @@ function PureChatHeader({
           className="hidden md:flex py-1.5 px-2 h-fit md:h-[34px] order-last md:order-4 ml-2"
           onClick={() => openUpgradePopup()}
         >
-          Upgrade
+          {t('upgrade')}
         </Button>
       )}
 
@@ -106,7 +108,7 @@ function PureChatHeader({
           target="_blank" // Corrected target
         >
           <VercelIcon size={16} />
-          Deploy
+          {t('deploy')}
         </Link>
       </Button>
     </header>

--- a/components/language-provider.tsx
+++ b/components/language-provider.tsx
@@ -1,0 +1,52 @@
+'use client';
+import React from 'react';
+import type { Language } from '@/lib/i18n';
+
+const LANGUAGE_COOKIE_NAME = 'language';
+const LANGUAGE_COOKIE_MAX_AGE = 60 * 60 * 24 * 365;
+
+export type LanguageContextValue = {
+  lang: Language;
+  setLang: (lang: Language) => void;
+};
+
+const LanguageContext = React.createContext<LanguageContextValue | null>(null);
+
+export function useLanguage() {
+  const context = React.useContext(LanguageContext);
+  if (!context) {
+    throw new Error('useLanguage must be used within a LanguageProvider');
+  }
+  return context;
+}
+
+export function LanguageProvider({
+  children,
+  defaultLang,
+}: {
+  children: React.ReactNode;
+  defaultLang: Language;
+}) {
+  const [lang, setLangState] = React.useState<Language>(defaultLang);
+
+  React.useEffect(() => {
+    const value = document.cookie
+      .split('; ')
+      .find((row) => row.startsWith(`${LANGUAGE_COOKIE_NAME}=`))
+      ?.split('=')[1];
+    if (value === 'en' || value === 'nl') {
+      setLangState(value as Language);
+    }
+  }, []);
+
+  const setLang = React.useCallback((newLang: Language) => {
+    setLangState(newLang);
+    document.cookie = `${LANGUAGE_COOKIE_NAME}=${newLang}; path=/; max-age=${LANGUAGE_COOKIE_MAX_AGE}`;
+  }, []);
+
+  return (
+    <LanguageContext.Provider value={{ lang, setLang }}>
+      {children}
+    </LanguageContext.Provider>
+  );
+}

--- a/components/sidebar-user-nav.tsx
+++ b/components/sidebar-user-nav.tsx
@@ -5,6 +5,8 @@ import Image from 'next/image';
 import type { User } from 'next-auth';
 import { signOut, useSession } from 'next-auth/react';
 import { useTheme } from 'next-themes';
+import { useLanguage } from '@/components/language-provider';
+import { useTranslation } from '@/lib/i18n';
 
 import {
   DropdownMenu,
@@ -27,6 +29,8 @@ export function SidebarUserNav({ user }: { user: User }) {
   const router = useRouter();
   const { data, status } = useSession();
   const { setTheme, theme } = useTheme();
+  const { lang, setLang } = useLanguage();
+  const t = useTranslation();
 
   const isGuest = guestRegex.test(data?.user?.email ?? '');
 
@@ -40,7 +44,7 @@ export function SidebarUserNav({ user }: { user: User }) {
                 <div className="flex flex-row gap-2">
                   <div className="size-6 bg-zinc-500/30 rounded-full animate-pulse" />
                   <span className="bg-zinc-500/30 text-transparent rounded-md animate-pulse">
-                    Loading auth status
+                    {t('loadingAuthStatus')}
                   </span>
                 </div>
                 <div className="animate-spin text-zinc-500">
@@ -60,7 +64,7 @@ export function SidebarUserNav({ user }: { user: User }) {
                   className="rounded-full"
                 />
                 <span data-testid="user-email" className="truncate">
-                  {isGuest ? 'Guest' : user?.email}
+                  {isGuest ? t('guest') : user?.email}
                 </span>
                 <ChevronUp className="ml-auto" />
               </SidebarMenuButton>
@@ -79,7 +83,14 @@ export function SidebarUserNav({ user }: { user: User }) {
                 setTheme(next);
               }}
             >
-              {`Toggle ${theme === 'dark' ? 'light' : theme === 'light' ? 'orange' : 'dark'} mode`}
+              {t('toggleMode', { mode: theme === 'dark' ? 'light' : theme === 'light' ? 'orange' : 'dark' })}
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              data-testid="user-nav-item-lang"
+              className="cursor-pointer"
+              onSelect={() => setLang(lang === 'en' ? 'nl' : 'en')}
+            >
+              {lang === 'en' ? t('switchToDutch') : t('switchToEnglish')}
             </DropdownMenuItem>
             <DropdownMenuSeparator />
             <DropdownMenuItem asChild data-testid="user-nav-item-auth">
@@ -106,7 +117,7 @@ export function SidebarUserNav({ user }: { user: User }) {
                   }
                 }}
               >
-                {isGuest ? 'Login to your account' : 'Sign out'}
+                {isGuest ? t('loginToAccount') : t('signOut')}
               </button>
             </DropdownMenuItem>
           </DropdownMenuContent>

--- a/lib/i18n.tsx
+++ b/lib/i18n.tsx
@@ -1,0 +1,56 @@
+export type Language = 'en' | 'nl';
+
+export const translations = {
+  en: {
+    newChat: 'New Chat',
+    deploy: 'Deploy',
+    upgrade: 'Upgrade',
+    loadingAuthStatus: 'Loading auth status',
+    guest: 'Guest',
+    toggleMode: 'Toggle {mode} mode',
+    loginToAccount: 'Login to your account',
+    signOut: 'Sign out',
+    switchToDutch: 'Switch to Dutch',
+    switchToEnglish: 'Switch to English',
+  },
+  nl: {
+    newChat: 'Nieuw gesprek',
+    deploy: 'Deploy',
+    upgrade: 'Upgrade',
+    loadingAuthStatus: 'Authenticatiestatus laden',
+    guest: 'Gast',
+    toggleMode: 'Schakel naar {mode}-modus',
+    loginToAccount: 'Inloggen op je account',
+    signOut: 'Uitloggen',
+    switchToDutch: 'Schakel naar Nederlands',
+    switchToEnglish: 'Schakel naar Engels',
+  },
+} as const;
+
+export type TranslationKey = keyof typeof translations.en;
+
+export function translate(
+  lang: Language,
+  key: TranslationKey,
+  vars?: Record<string, string>,
+): string {
+  let text = translations[lang][key] as string;
+  if (vars) {
+    Object.entries(vars).forEach(([k, v]) => {
+      text = text.replace(`{${k}}`, v);
+    });
+  }
+  return text;
+}
+
+import { useLanguage } from '@/components/language-provider';
+import React from 'react';
+
+export function useTranslation() {
+  const { lang } = useLanguage();
+  return React.useCallback(
+    (key: TranslationKey, vars?: Record<string, string>) =>
+      translate(lang, key, vars),
+    [lang],
+  );
+}


### PR DESCRIPTION
## Summary
- introduce `LanguageProvider` and `useTranslation`
- keep language preference in a cookie
- update layout to initialize provider from cookie
- translate key UI labels and add language toggle in user nav

## Testing
- `pnpm exec playwright test` *(fails: missing Playwright browsers)*
- `pnpm exec next lint`
- `pnpm exec biome lint` *(fails: some errors emitted)*

------
https://chatgpt.com/codex/tasks/task_e_684948a5ea4c832a93ec062d5e4b6f36