### PR TITLE
Add language toggle with Dutch support

### DIFF
--- a/app/(auth)/auth.ts
+++ b/app/(auth)/auth.ts
@@ -123,7 +123,7 @@ export const {
   callbacks: {
     async signIn({ user, account }) {
       if ((user as any).id && (user as any).type === 'guest') {
-        const store = cookies();
+        const store = await cookies();
         store.set('guestUserId', (user as any).id, {
           path: '/',
           maxAge: 60 * 60 * 24,

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,9 @@ import { Toaster } from 'sonner';
 import type { Metadata } from 'next';
 import { Geist, Geist_Mono } from 'next/font/google';
 import { ThemeProvider } from '@/components/theme-provider';
+import { cookies } from 'next/headers';
+import { LanguageProvider } from '@/components/language-provider';
+import type { Language } from '@/lib/i18n';
 
 import './globals.css';
 import { SessionProvider } from 'next-auth/react';
@@ -62,9 +65,12 @@ export default async function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const cookieStore = cookies();
+  const langCookie = cookieStore.get('language');
+  const lang = (langCookie?.value === 'nl' ? 'nl' : 'en') as Language;
   return (
     <html
-      lang="en"
+      lang={lang}
       suppressHydrationWarning
       className={`${geist.variable} ${geistMono.variable}`}
     >
@@ -76,6 +82,7 @@ export default async function RootLayout({
         />
       </head>
       <body className="antialiased">
+        <LanguageProvider defaultLang={lang}>
         <ThemeProvider
           attribute="class"
           defaultTheme="orange"
@@ -90,6 +97,7 @@ export default async function RootLayout({
             <UpgradeDialog />
           </SessionProvider>
         </ThemeProvider>
+        </LanguageProvider>
       </body>
     </html>
   );

--- a/components/app-sidebar.tsx
+++ b/components/app-sidebar.tsx
@@ -17,10 +17,12 @@ import {
 } from '@/components/ui/sidebar';
 import Link from 'next/link';
 import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip';
+import { useTranslation } from '@/lib/i18n';
 
 export function AppSidebar({ user }: { user: User | undefined }) {
   const router = useRouter();
   const { setOpenMobile } = useSidebar();
+  const t = useTranslation();
 
   return (
     <Sidebar className="group-data-[side=left]:border-r-0">
@@ -53,7 +55,7 @@ export function AppSidebar({ user }: { user: User | undefined }) {
                   <PlusIcon />
                 </Button>
               </TooltipTrigger>
-              <TooltipContent align="end">New Chat</TooltipContent>
+              <TooltipContent align="end">{t('newChat')}</TooltipContent>
             </Tooltip>
           </div>
         </SidebarMenu>

--- a/components/chat-header.tsx
+++ b/components/chat-header.tsx
@@ -15,6 +15,7 @@ import { type VisibilityType, VisibilitySelector } from './visibility-selector';
 import type { Session } from 'next-auth';
 import { MessageLimitIndicator } from './message-limit-indicator'; // Added
 import { useUpgradePopup } from '@/hooks/use-upgrade-popup';
+import { useTranslation } from '@/lib/i18n';
 
 const plansLength = 3;
 
@@ -36,6 +37,7 @@ function PureChatHeader({
   const router = useRouter();
   const { open } = useSidebar();
   const { openPopup: openUpgradePopup } = useUpgradePopup();
+  const t = useTranslation();
 
   const { width: windowWidth } = useWindowSize();
 
@@ -56,10 +58,10 @@ function PureChatHeader({
               }}
             >
               <PlusIcon />
-              <span className="hidden md:inline ml-1">New Chat</span> {/* Changed sr-only to hidden md:inline */}
+              <span className="hidden md:inline ml-1">{t('newChat')}</span> {/* Changed sr-only to hidden md:inline */}
             </Button>
           </TooltipTrigger>
-          <TooltipContent>New Chat</TooltipContent>
+          <TooltipContent>{t('newChat')}</TooltipContent>
         </Tooltip>
       )}
 
@@ -93,7 +95,7 @@ function PureChatHeader({
           className="hidden md:flex py-1.5 px-2 h-fit md:h-[34px] order-last md:order-4 ml-2"
           onClick={() => openUpgradePopup()}
         >
-          Upgrade
+          {t('upgrade')}
         </Button>
       )}
 
@@ -106,7 +108,7 @@ function PureChatHeader({
           target="_blank" // Corrected target
         >
           <VercelIcon size={16} />
-          Deploy
+          {t('deploy')}
         </Link>
       </Button>
     </header>

--- a/components/console.tsx
+++ b/components/console.tsx
@@ -10,6 +10,7 @@ import {
 } from 'react';
 import { cn } from '@/lib/utils';
 import { useArtifactSelector } from '@/hooks/use-artifact';
+import { useTranslation } from '@/lib/i18n';
 
 export interface ConsoleOutputContent {
   type: 'text' | 'image';
@@ -31,6 +32,7 @@ export function Console({ consoleOutputs, setConsoleOutputs }: ConsoleProps) {
   const [height, setHeight] = useState<number>(300);
   const [isResizing, setIsResizing] = useState(false);
   const consoleEndRef = useRef<HTMLDivElement>(null);
+  const t = useTranslation();
 
   const isArtifactVisible = useArtifactSelector((state) => state.isVisible);
 
@@ -100,7 +102,7 @@ export function Console({ consoleOutputs, setConsoleOutputs }: ConsoleProps) {
             <div className="text-muted-foreground">
               <TerminalWindowIcon />
             </div>
-            <div>Console</div>
+            <div>{t('console')}</div>
           </div>
           <Button
             variant="ghost"

--- a/components/language-provider.tsx
+++ b/components/language-provider.tsx
@@ -1,0 +1,52 @@
+'use client';
+import React from 'react';
+import type { Language } from '@/lib/i18n';
+
+const LANGUAGE_COOKIE_NAME = 'language';
+const LANGUAGE_COOKIE_MAX_AGE = 60 * 60 * 24 * 365;
+
+export type LanguageContextValue = {
+  lang: Language;
+  setLang: (lang: Language) => void;
+};
+
+const LanguageContext = React.createContext<LanguageContextValue | null>(null);
+
+export function useLanguage() {
+  const context = React.useContext(LanguageContext);
+  if (!context) {
+    throw new Error('useLanguage must be used within a LanguageProvider');
+  }
+  return context;
+}
+
+export function LanguageProvider({
+  children,
+  defaultLang,
+}: {
+  children: React.ReactNode;
+  defaultLang: Language;
+}) {
+  const [lang, setLangState] = React.useState<Language>(defaultLang);
+
+  React.useEffect(() => {
+    const value = document.cookie
+      .split('; ')
+      .find((row) => row.startsWith(`${LANGUAGE_COOKIE_NAME}=`))
+      ?.split('=')[1];
+    if (value === 'en' || value === 'nl') {
+      setLangState(value as Language);
+    }
+  }, []);
+
+  const setLang = React.useCallback((newLang: Language) => {
+    setLangState(newLang);
+    document.cookie = `${LANGUAGE_COOKIE_NAME}=${newLang}; path=/; max-age=${LANGUAGE_COOKIE_MAX_AGE}`;
+  }, []);
+
+  return (
+    <LanguageContext.Provider value={{ lang, setLang }}>
+      {children}
+    </LanguageContext.Provider>
+  );
+}

--- a/components/message-actions.tsx
+++ b/components/message-actions.tsx
@@ -15,6 +15,7 @@ import {
 import { memo } from 'react';
 import equal from 'fast-deep-equal';
 import { toast } from 'sonner';
+import { useTranslation } from '@/lib/i18n';
 
 export function PureMessageActions({
   chatId,
@@ -29,6 +30,7 @@ export function PureMessageActions({
 }) {
   const { mutate } = useSWRConfig();
   const [_, copyToClipboard] = useCopyToClipboard();
+  const t = useTranslation();
 
   if (isLoading) return null;
   if (message.role === 'user') return null;
@@ -49,18 +51,18 @@ export function PureMessageActions({
                   .trim();
 
                 if (!textFromParts) {
-                  toast.error("There's no text to copy!");
+                  toast.error(t('copyToClipboardNoText'));
                   return;
                 }
 
                 await copyToClipboard(textFromParts);
-                toast.success('Copied to clipboard!');
+                toast.success(t('copiedToClipboard'));
               }}
             >
               <CopyIcon />
             </Button>
           </TooltipTrigger>
-          <TooltipContent>Copy</TooltipContent>
+          <TooltipContent>{t('copy')}</TooltipContent>
         </Tooltip>
 
         <Tooltip>
@@ -81,7 +83,7 @@ export function PureMessageActions({
                 });
 
                 toast.promise(upvote, {
-                  loading: 'Upvoting Response...',
+                  loading: t('upvotingResponse'),
                   success: () => {
                     mutate<Array<Vote>>(
                       `/api/vote?chatId=${chatId}`,
@@ -104,16 +106,16 @@ export function PureMessageActions({
                       { revalidate: false },
                     );
 
-                    return 'Upvoted Response!';
+                    return t('upvotedResponse');
                   },
-                  error: 'Failed to upvote response.',
+                  error: t('failedUpvote'),
                 });
               }}
             >
               <ThumbUpIcon />
             </Button>
           </TooltipTrigger>
-          <TooltipContent>Upvote Response</TooltipContent>
+          <TooltipContent>{t('upvoteResponse')}</TooltipContent>
         </Tooltip>
 
         <Tooltip>
@@ -134,7 +136,7 @@ export function PureMessageActions({
                 });
 
                 toast.promise(downvote, {
-                  loading: 'Downvoting Response...',
+                  loading: t('downvotingResponse'),
                   success: () => {
                     mutate<Array<Vote>>(
                       `/api/vote?chatId=${chatId}`,
@@ -157,16 +159,16 @@ export function PureMessageActions({
                       { revalidate: false },
                     );
 
-                    return 'Downvoted Response!';
+                    return t('downvotedResponse');
                   },
-                  error: 'Failed to downvote response.',
+                  error: t('failedDownvote'),
                 });
               }}
             >
               <ThumbDownIcon />
             </Button>
           </TooltipTrigger>
-          <TooltipContent>Downvote Response</TooltipContent>
+          <TooltipContent>{t('downvoteResponse')}</TooltipContent>
         </Tooltip>
       </div>
     </TooltipProvider>

--- a/components/message-editor.tsx
+++ b/components/message-editor.tsx
@@ -6,6 +6,7 @@ import { Dispatch, SetStateAction, useEffect, useRef, useState } from 'react';
 import { Textarea } from './ui/textarea';
 import { deleteTrailingMessages } from '@/app/(chat)/actions';
 import { UseChatHelpers } from '@ai-sdk/react';
+import { useTranslation } from '@/lib/i18n';
 
 export type MessageEditorProps = {
   message: Message;
@@ -21,6 +22,7 @@ export function MessageEditor({
   reload,
 }: MessageEditorProps) {
   const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
+  const t = useTranslation();
 
   const [draftContent, setDraftContent] = useState<string>(message.content);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -61,7 +63,7 @@ export function MessageEditor({
             setMode('view');
           }}
         >
-          Cancel
+          {t('cancel')}
         </Button>
         <Button
           data-testid="message-editor-send-button"
@@ -96,7 +98,7 @@ export function MessageEditor({
             reload();
           }}
         >
-          {isSubmitting ? 'Sending...' : 'Send'}
+          {isSubmitting ? t('sending') : t('send')}
         </Button>
       </div>
     </div>

--- a/components/message-limit-indicator.tsx
+++ b/components/message-limit-indicator.tsx
@@ -7,6 +7,7 @@ import { useEffect, useState } from 'react';
 import { formatDistanceToNowStrict, format, isPast } from 'date-fns';
 import type { UserType } from '@/lib/user-types';
 import { LoaderIcon } from './icons';
+import { useTranslation } from '@/lib/i18n';
 
 interface MessageStatus {
   messagesLeft: number;
@@ -32,37 +33,51 @@ export function MessageLimitIndicator({
   );
   const [tooltipContent, setTooltipContent] = useState<string>('');
   const [displayMessagesLeft, setDisplayMessagesLeft] = useState<string>('...');
+  const t = useTranslation();
 
   useEffect(() => {
     if (data) {
       const { messagesLeft, maxMessages, nextResetTimestamp, userType } = data;
 
       if (userType === 'guest') {
-        setDisplayMessagesLeft(`${messagesLeft} free message${messagesLeft === 1 ? '' : 's'} left`);
+        setDisplayMessagesLeft(
+          t('freeMessagesLeft', {
+            count: messagesLeft.toString(),
+            plural: messagesLeft === 1 ? '' : 's',
+          }),
+        );
         if (nextResetTimestamp) {
           if (isPast(new Date(nextResetTimestamp))) {
-            setTooltipContent('Messages have reset. You can send a message.');
+            setTooltipContent(t('messagesReset'));
           } else {
             setTooltipContent(
-              `Resets ${formatDistanceToNowStrict(new Date(nextResetTimestamp), { addSuffix: true })} (at ${format(new Date(nextResetTimestamp), 'p')})`,
+              t('resetsAt', {
+                duration: formatDistanceToNowStrict(new Date(nextResetTimestamp), { addSuffix: true }),
+                time: format(new Date(nextResetTimestamp), 'p'),
+              }),
             );
           }
         } else {
-           setTooltipContent(`1 free message per day. Resets daily.`);
+           setTooltipContent(t('oneFreeMessageInfo'));
         }
       } else {
-        setDisplayMessagesLeft(`${messagesLeft} of ${maxMessages} left`);
+        setDisplayMessagesLeft(
+          t('messagesLeftOf', {
+            count: messagesLeft.toString(),
+            max: maxMessages.toString(),
+          }),
+        );
         // For registered users, we might not have a precise 'nextResetTimestamp' if it's just "daily"
         // The API would need to provide a consistent timestamp for this if precise countdown is desired.
         // For now, a general message.
-        setTooltipContent(`Message limit resets daily.`);
+        setTooltipContent(t('messageLimitResets'));
       }
     } else if (error) {
-      setDisplayMessagesLeft('Limit N/A');
-      setTooltipContent('Could not load message limit.');
+      setDisplayMessagesLeft(t('limitNA'));
+      setTooltipContent(t('couldNotLoadMessageLimit'));
     } else if (isLoading) {
       setDisplayMessagesLeft('...');
-      setTooltipContent('Loading message limit...');
+      setTooltipContent(t('loadingMessageLimit'));
     }
   }, [data, error, isLoading]);
 
@@ -73,7 +88,7 @@ export function MessageLimitIndicator({
         'text-xs text-muted-foreground px-2 py-1 animate-pulse flex items-center gap-1',
         className,
       )}>
-        <LoaderIcon size={12} /> Loading...
+        <LoaderIcon size={12} /> {t('loading')}
       </div>
     );
   }
@@ -81,7 +96,7 @@ export function MessageLimitIndicator({
   if (error || !data) {
     return (
       <div className={cn('text-xs text-muted-foreground px-2 py-1', className)}>
-        Limit N/A
+        {t('limitNA')}
       </div>
     );
   }

--- a/components/message.tsx
+++ b/components/message.tsx
@@ -18,6 +18,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip';
 import { MessageEditor } from './message-editor';
 import { DocumentPreview } from './document-preview';
 import { MessageReasoning } from './message-reasoning';
+import { useTranslation } from '@/lib/i18n';
 import type { UseChatHelpers } from '@ai-sdk/react';
 
 const PurePreviewMessage = ({
@@ -40,6 +41,7 @@ const PurePreviewMessage = ({
   requiresScrollPadding: boolean;
 }) => {
   const [mode, setMode] = useState<'view' | 'edit'>('view');
+  const t = useTranslation();
 
   return (
     <AnimatePresence>
@@ -119,7 +121,7 @@ const PurePreviewMessage = ({
                               <PencilEditIcon />
                             </Button>
                           </TooltipTrigger>
-                          <TooltipContent>Edit message</TooltipContent>
+                          <TooltipContent>{t('editMessage')}</TooltipContent>
                         </Tooltip>
                       )}
 

--- a/components/sidebar-history-item.tsx
+++ b/components/sidebar-history-item.tsx
@@ -25,6 +25,7 @@ import {
 } from './icons';
 import { memo } from 'react';
 import { useChatVisibility } from '@/hooks/use-chat-visibility';
+import { useTranslation } from '@/lib/i18n';
 
 const PureChatItem = ({
   chat,
@@ -41,6 +42,7 @@ const PureChatItem = ({
     chatId: chat.id,
     initialVisibilityType: chat.visibility,
   });
+  const t = useTranslation();
 
   return (
     <SidebarMenuItem>
@@ -57,7 +59,7 @@ const PureChatItem = ({
             showOnHover={!isActive}
           >
             <MoreHorizontalIcon />
-            <span className="sr-only">More</span>
+            <span className="sr-only">{t('more')}</span>
           </SidebarMenuAction>
         </DropdownMenuTrigger>
 
@@ -65,7 +67,7 @@ const PureChatItem = ({
           <DropdownMenuSub>
             <DropdownMenuSubTrigger className="cursor-pointer">
               <ShareIcon />
-              <span>Share</span>
+              <span>{t('share')}</span>
             </DropdownMenuSubTrigger>
             <DropdownMenuPortal>
               <DropdownMenuSubContent>
@@ -77,7 +79,7 @@ const PureChatItem = ({
                 >
                   <div className="flex flex-row gap-2 items-center">
                     <LockIcon size={12} />
-                    <span>Private</span>
+                    <span>{t('private')}</span>
                   </div>
                   {visibilityType === 'private' ? (
                     <CheckCircleFillIcon />
@@ -91,7 +93,7 @@ const PureChatItem = ({
                 >
                   <div className="flex flex-row gap-2 items-center">
                     <GlobeIcon />
-                    <span>Public</span>
+                    <span>{t('public')}</span>
                   </div>
                   {visibilityType === 'public' ? <CheckCircleFillIcon /> : null}
                 </DropdownMenuItem>
@@ -104,7 +106,7 @@ const PureChatItem = ({
             onSelect={() => onDelete(chat.id)}
           >
             <TrashIcon />
-            <span>Delete</span>
+            <span>{t('delete')}</span>
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>

--- a/components/sidebar-history.tsx
+++ b/components/sidebar-history.tsx
@@ -27,6 +27,7 @@ import { fetcher } from '@/lib/utils';
 import { ChatItem } from './sidebar-history-item';
 import useSWRInfinite from 'swr/infinite';
 import { LoaderIcon } from './icons';
+import { useTranslation } from '@/lib/i18n';
 
 type GroupedChats = {
   today: Chat[];
@@ -96,6 +97,7 @@ export function getChatHistoryPaginationKey(
 export function SidebarHistory({ user }: { user: User | undefined }) {
   const { setOpenMobile } = useSidebar();
   const { id } = useParams();
+  const t = useTranslation();
 
   const {
     data: paginatedChatHistories,
@@ -153,7 +155,7 @@ export function SidebarHistory({ user }: { user: User | undefined }) {
       <SidebarGroup>
         <SidebarGroupContent>
           <div className="px-2 text-zinc-500 w-full flex flex-row justify-center items-center text-sm gap-2">
-            Login to save and revisit previous chats!
+            {t('loginHistoryNotice')}
           </div>
         </SidebarGroupContent>
       </SidebarGroup>
@@ -164,7 +166,7 @@ export function SidebarHistory({ user }: { user: User | undefined }) {
     return (
       <SidebarGroup>
         <div className="px-2 py-1 text-xs text-sidebar-foreground/50">
-          Today
+          {t('today')}
         </div>
         <SidebarGroupContent>
           <div className="flex flex-col">
@@ -194,7 +196,7 @@ export function SidebarHistory({ user }: { user: User | undefined }) {
       <SidebarGroup>
         <SidebarGroupContent>
           <div className="px-2 text-zinc-500 w-full flex flex-row justify-center items-center text-sm gap-2">
-            Your conversations will appear here once you start chatting!
+            {t('conversationsAppearHere')}
           </div>
         </SidebarGroupContent>
       </SidebarGroup>
@@ -219,7 +221,7 @@ export function SidebarHistory({ user }: { user: User | undefined }) {
                     {groupedChats.today.length > 0 && (
                       <div>
                         <div className="px-2 py-1 text-xs text-sidebar-foreground/50">
-                          Today
+                          {t('today')}
                         </div>
                         {groupedChats.today.map((chat) => (
                           <ChatItem
@@ -239,7 +241,7 @@ export function SidebarHistory({ user }: { user: User | undefined }) {
                     {groupedChats.yesterday.length > 0 && (
                       <div>
                         <div className="px-2 py-1 text-xs text-sidebar-foreground/50">
-                          Yesterday
+                          {t('yesterday')}
                         </div>
                         {groupedChats.yesterday.map((chat) => (
                           <ChatItem
@@ -259,7 +261,7 @@ export function SidebarHistory({ user }: { user: User | undefined }) {
                     {groupedChats.lastWeek.length > 0 && (
                       <div>
                         <div className="px-2 py-1 text-xs text-sidebar-foreground/50">
-                          Last 7 days
+                          {t('last7days')}
                         </div>
                         {groupedChats.lastWeek.map((chat) => (
                           <ChatItem
@@ -279,7 +281,7 @@ export function SidebarHistory({ user }: { user: User | undefined }) {
                     {groupedChats.lastMonth.length > 0 && (
                       <div>
                         <div className="px-2 py-1 text-xs text-sidebar-foreground/50">
-                          Last 30 days
+                          {t('last30days')}
                         </div>
                         {groupedChats.lastMonth.map((chat) => (
                           <ChatItem
@@ -299,7 +301,7 @@ export function SidebarHistory({ user }: { user: User | undefined }) {
                     {groupedChats.older.length > 0 && (
                       <div>
                         <div className="px-2 py-1 text-xs text-sidebar-foreground/50">
-                          Older than last month
+                          {t('olderThanLastMonth')}
                         </div>
                         {groupedChats.older.map((chat) => (
                           <ChatItem
@@ -330,14 +332,14 @@ export function SidebarHistory({ user }: { user: User | undefined }) {
 
           {hasReachedEnd ? (
             <div className="px-2 text-zinc-500 w-full flex flex-row justify-center items-center text-sm gap-2 mt-8">
-              You have reached the end of your chat history.
+              {t('reachedEndHistory')}
             </div>
           ) : (
             <div className="p-2 text-zinc-500 dark:text-zinc-400 flex flex-row gap-2 items-center mt-8">
               <div className="animate-spin">
                 <LoaderIcon />
               </div>
-              <div>Loading Chats...</div>
+              <div>{t('loadingChats')}</div>
             </div>
           )}
         </SidebarGroupContent>
@@ -346,16 +348,15 @@ export function SidebarHistory({ user }: { user: User | undefined }) {
       <AlertDialog open={showDeleteDialog} onOpenChange={setShowDeleteDialog}>
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>Are you absolutely sure?</AlertDialogTitle>
+            <AlertDialogTitle>{t('areYouSure')}</AlertDialogTitle>
             <AlertDialogDescription>
-              This action cannot be undone. This will permanently delete your
-              chat and remove it from our servers.
+              {t('deleteWarning')}
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogCancel>{t('cancel')}</AlertDialogCancel>
             <AlertDialogAction onClick={handleDelete}>
-              Continue
+              {t('continue')}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/components/sidebar-toggle.tsx
+++ b/components/sidebar-toggle.tsx
@@ -9,11 +9,13 @@ import {
 
 import { SidebarLeftIcon } from './icons';
 import { Button } from './ui/button';
+import { useTranslation } from '@/lib/i18n';
 
 export function SidebarToggle({
   className,
 }: ComponentProps<typeof SidebarTrigger>) {
   const { toggleSidebar } = useSidebar();
+  const t = useTranslation();
 
   return (
     <Tooltip>
@@ -27,7 +29,7 @@ export function SidebarToggle({
           <SidebarLeftIcon size={16} />
         </Button>
       </TooltipTrigger>
-      <TooltipContent align="start">Toggle Sidebar</TooltipContent>
+      <TooltipContent align="start">{t('toggleSidebar')}</TooltipContent>
     </Tooltip>
   );
 }

--- a/components/sidebar-user-nav.tsx
+++ b/components/sidebar-user-nav.tsx
@@ -5,6 +5,8 @@ import Image from 'next/image';
 import type { User } from 'next-auth';
 import { signOut, useSession } from 'next-auth/react';
 import { useTheme } from 'next-themes';
+import { useLanguage } from '@/components/language-provider';
+import { useTranslation } from '@/lib/i18n';
 
 import {
   DropdownMenu,
@@ -27,6 +29,8 @@ export function SidebarUserNav({ user }: { user: User }) {
   const router = useRouter();
   const { data, status } = useSession();
   const { setTheme, theme } = useTheme();
+  const { lang, setLang } = useLanguage();
+  const t = useTranslation();
 
   const isGuest = guestRegex.test(data?.user?.email ?? '');
 
@@ -40,7 +44,7 @@ export function SidebarUserNav({ user }: { user: User }) {
                 <div className="flex flex-row gap-2">
                   <div className="size-6 bg-zinc-500/30 rounded-full animate-pulse" />
                   <span className="bg-zinc-500/30 text-transparent rounded-md animate-pulse">
-                    Loading auth status
+                    {t('loadingAuthStatus')}
                   </span>
                 </div>
                 <div className="animate-spin text-zinc-500">
@@ -60,7 +64,7 @@ export function SidebarUserNav({ user }: { user: User }) {
                   className="rounded-full"
                 />
                 <span data-testid="user-email" className="truncate">
-                  {isGuest ? 'Guest' : user?.email}
+                  {isGuest ? t('guest') : user?.email}
                 </span>
                 <ChevronUp className="ml-auto" />
               </SidebarMenuButton>
@@ -79,7 +83,14 @@ export function SidebarUserNav({ user }: { user: User }) {
                 setTheme(next);
               }}
             >
-              {`Toggle ${theme === 'dark' ? 'light' : theme === 'light' ? 'orange' : 'dark'} mode`}
+              {t('toggleMode', { mode: theme === 'dark' ? 'light' : theme === 'light' ? 'orange' : 'dark' })}
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              data-testid="user-nav-item-lang"
+              className="cursor-pointer"
+              onSelect={() => setLang(lang === 'en' ? 'nl' : 'en')}
+            >
+              {lang === 'en' ? t('switchToDutch') : t('switchToEnglish')}
             </DropdownMenuItem>
             <DropdownMenuSeparator />
             <DropdownMenuItem asChild data-testid="user-nav-item-auth">
@@ -106,7 +117,7 @@ export function SidebarUserNav({ user }: { user: User }) {
                   }
                 }}
               >
-                {isGuest ? 'Login to your account' : 'Sign out'}
+                {isGuest ? t('loginToAccount') : t('signOut')}
               </button>
             </DropdownMenuItem>
           </DropdownMenuContent>

--- a/components/suggestion.tsx
+++ b/components/suggestion.tsx
@@ -10,6 +10,7 @@ import { CrossIcon, MessageIcon } from './icons';
 import { Button } from './ui/button';
 import { cn } from '@/lib/utils';
 import { ArtifactKind } from './artifact';
+import { useTranslation } from '@/lib/i18n';
 
 export const Suggestion = ({
   suggestion,
@@ -22,6 +23,7 @@ export const Suggestion = ({
 }) => {
   const [isExpanded, setIsExpanded] = useState(false);
   const { width: windowWidth } = useWindowSize();
+  const t = useTranslation();
 
   return (
     <AnimatePresence>
@@ -51,7 +53,7 @@ export const Suggestion = ({
           <div className="flex flex-row items-center justify-between">
             <div className="flex flex-row items-center gap-2">
               <div className="size-4 bg-muted-foreground/25 rounded-full" />
-              <div className="font-medium">Assistant</div>
+              <div className="font-medium">{t('assistant')}</div>
             </div>
             <button
               type="button"
@@ -69,7 +71,7 @@ export const Suggestion = ({
             className="w-fit py-1.5 px-3 rounded-full"
             onClick={onApply}
           >
-            Apply
+            {t('apply')}
           </Button>
         </motion.div>
       )}

--- a/components/ui/login-signup-dialog.tsx
+++ b/components/ui/login-signup-dialog.tsx
@@ -16,11 +16,13 @@ import { LogoGoogle } from '@/components/icons';
 import Link from 'next/link';
 import { useLoginSignupPopup } from '@/hooks/use-login-signup-popup';
 import { signIn } from 'next-auth/react';
+import { useTranslation } from '@/lib/i18n';
 // import { X } from 'lucide-react'; // No longer needed here if DialogContent provides it
 // import { useEffect } from 'react'; // No longer needed for body blur
 
 export function LoginSignupDialog() {
   const { isOpen, closePopup, chatContext } = useLoginSignupPopup();
+  const t = useTranslation();
 
   // Removed useEffect for body class manipulation
 
@@ -67,9 +69,9 @@ export function LoginSignupDialog() {
         onEscapeKeyDown={closePopup} // This will be handled by DialogPrimitive.Content now
       >
         <DialogHeader>
-          <DialogTitle>Continue Chatting</DialogTitle>
+          <DialogTitle>{t('continueChatting')}</DialogTitle>
           <DialogDescription>
-            You've used your free message for today. Please log in or create an account to continue chatting.
+            {t('usedFreeMessage')}
           </DialogDescription>
         </DialogHeader>
         <DialogFooter className="flex-col gap-2 sm:flex-col sm:gap-2 pt-4">
@@ -81,13 +83,13 @@ export function LoginSignupDialog() {
               closePopup();
             }}
           >
-            <LogoGoogle /> Continue with Google
+            <LogoGoogle /> {t('continueWithGoogle')}
           </Button>
           <Button asChild onClick={closePopup} className="w-full">
-            <Link href={getAuthLink('/login')}>Login</Link>
+            <Link href={getAuthLink('/login')}>{t('login')}</Link>
           </Button>
           <Button variant="outline" asChild onClick={closePopup} className="w-full">
-            <Link href={getAuthLink('/register')}>Create Account</Link>
+            <Link href={getAuthLink('/register')}>{t('createAccount')}</Link>
           </Button>
         </DialogFooter>
         {/* The DialogClose button is now implicitly part of DialogContent from shadcn/ui */}

--- a/components/ui/upgrade-dialog.tsx
+++ b/components/ui/upgrade-dialog.tsx
@@ -14,6 +14,7 @@ import { useUpgradePopup } from '@/hooks/use-upgrade-popup'
 import { useState } from 'react'
 import { useSession } from 'next-auth/react'
 import { useRouter } from 'next/navigation'
+import { useTranslation } from '@/lib/i18n'
 
 interface Plan {
   id: string
@@ -58,6 +59,7 @@ export function UpgradeDialog() {
   const [loadingId, setLoadingId] = useState<string | null>(null)
   const { data: session } = useSession()
   const router = useRouter()
+  const t = useTranslation()
 
   const ownedModels = session?.user?.models ?? []
 
@@ -93,8 +95,8 @@ export function UpgradeDialog() {
       <DialogContent className="bg-transparent shadow-none border-none p-0 max-w-none rounded-none sm:rounded-none">
         <div className="mx-auto mb-10 bg-white/90 dark:bg-gray-900/90 px-6 py-3 rounded-full backdrop-blur-md shadow transition-transform duration-200 hover:scale-105 w-full max-w-lg flex flex-col items-center justify-center text-center">
           <DialogHeader className="upgrade-header space-y-1 text-center">
-            <DialogTitle className="text-xl font-medium">Upgrade Account</DialogTitle>
-            <DialogDescription className="text-sm text-muted-foreground">Select a model to unlock unlimited access.</DialogDescription>
+            <DialogTitle className="text-xl font-medium">{t('upgradeAccount')}</DialogTitle>
+            <DialogDescription className="text-sm text-muted-foreground">{t('selectModel')}</DialogDescription>
           </DialogHeader>
         </div>
         <div className="w-full grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-12 px-10 py-10">
@@ -127,17 +129,17 @@ export function UpgradeDialog() {
                       onClick={() => checkout(plan.id)}
                       disabled={loadingId === plan.id}
                     >
-                      {loadingId === plan.id ? 'Loading...' : 'Purchase'}
+                      {loadingId === plan.id ? t('loading') : t('purchase')}
                     </Button>
                     <Link
                       href="/compare"
                       className="mt-2 text-center text-sm font-semibold text-gray-800 hover:underline dark:text-zinc-200"
                     >
-                      Compare models
+                      {t('compareModels')}
                     </Link>
                   </>
                 ) : (
-                  <p className="mt-4 text-center text-sm text-muted-foreground font-semibold">COMING SOON</p>
+                  <p className="mt-4 text-center text-sm text-muted-foreground font-semibold">{t('comingSoon')}</p>
                 )}
               </div>
             )

--- a/lib/i18n.tsx
+++ b/lib/i18n.tsx
@@ -1,0 +1,174 @@
+export type Language = 'en' | 'nl';
+
+export const translations = {
+  en: {
+    newChat: 'New Chat',
+    deploy: 'Deploy',
+    upgrade: 'Upgrade',
+    loadingAuthStatus: 'Loading auth status',
+    guest: 'Guest',
+    toggleMode: 'Toggle {mode} mode',
+    loginToAccount: 'Login to your account',
+    signOut: 'Sign out',
+    switchToDutch: 'Switch to Dutch',
+    switchToEnglish: 'Switch to English',
+    editMessage: 'Edit message',
+    copyToClipboardNoText: "There's no text to copy!",
+    copiedToClipboard: 'Copied to clipboard!',
+    copy: 'Copy',
+    upvotingResponse: 'Upvoting Response...',
+    upvoteResponse: 'Upvote Response',
+    failedUpvote: 'Failed to upvote response.',
+    upvotedResponse: 'Upvoted Response!',
+    downvotingResponse: 'Downvoting Response...',
+    downvoteResponse: 'Downvote Response',
+    failedDownvote: 'Failed to downvote response.',
+    downvotedResponse: 'Downvoted Response!',
+    toggleSidebar: 'Toggle Sidebar',
+    reachedEndHistory: 'You have reached the end of your chat history.',
+    loadingChats: 'Loading Chats...',
+    areYouSure: 'Are you absolutely sure?',
+    deleteWarning:
+      'This action cannot be undone. This will permanently delete your chat and remove it from our servers.',
+    cancel: 'Cancel',
+    continue: 'Continue',
+    loginHistoryNotice: 'Login to save and revisit previous chats!',
+    conversationsAppearHere:
+      'Your conversations will appear here once you start chatting!',
+    today: 'Today',
+    yesterday: 'Yesterday',
+    last7days: 'Last 7 days',
+    last30days: 'Last 30 days',
+    olderThanLastMonth: 'Older than last month',
+    login: 'Login',
+    createAccount: 'Create Account',
+    continueChatting: 'Continue Chatting',
+    usedFreeMessage:
+      "You've used your free message for today. Please log in or create an account to continue chatting.",
+    continueWithGoogle: 'Continue with Google',
+    sending: 'Sending...',
+    send: 'Send',
+    upgradeAccount: 'Upgrade Account',
+    selectModel: 'Select a model to unlock unlimited access.',
+    loading: 'Loading...',
+    purchase: 'Purchase',
+    compareModels: 'Compare models',
+    comingSoon: 'COMING SOON',
+    freeMessagesLeft: '{count} free message{plural} left',
+    messagesReset: 'Messages have reset. You can send a message.',
+    resetsAt: 'Resets {duration} (at {time})',
+    oneFreeMessageInfo: '1 free message per day. Resets daily.',
+    messagesLeftOf: '{count} of {max} left',
+    messageLimitResets: 'Message limit resets daily.',
+    couldNotLoadMessageLimit: 'Could not load message limit.',
+    loadingMessageLimit: 'Loading message limit...',
+    limitNA: 'Limit N/A',
+    console: 'Console',
+    apply: 'Apply',
+    assistant: 'Assistant',
+    share: 'Share',
+    more: 'More',
+    private: 'Private',
+    public: 'Public',
+    delete: 'Delete',
+  },
+  nl: {
+    newChat: 'Nieuw gesprek',
+    deploy: 'Deploy',
+    upgrade: 'Upgrade',
+    loadingAuthStatus: 'Authenticatiestatus laden',
+    guest: 'Gast',
+    toggleMode: 'Schakel naar {mode}-modus',
+    loginToAccount: 'Inloggen op je account',
+    signOut: 'Uitloggen',
+    switchToDutch: 'Schakel naar Nederlands',
+    switchToEnglish: 'Schakel naar Engels',
+    editMessage: 'Bericht bewerken',
+    copyToClipboardNoText: 'Er is geen tekst om te kopiëren!',
+    copiedToClipboard: 'Gekopieerd naar klembord!',
+    copy: 'Kopiëren',
+    upvotingResponse: 'Antwoord omhoogstemmen...',
+    upvoteResponse: 'Stem antwoord omhoog',
+    failedUpvote: 'Upvoten mislukt.',
+    upvotedResponse: 'Antwoord omhooggestemd!',
+    downvotingResponse: 'Antwoord omlaagstemmen...',
+    downvoteResponse: 'Stem antwoord omlaag',
+    failedDownvote: 'Downvoten mislukt.',
+    downvotedResponse: 'Antwoord omlaaggestemd!',
+    toggleSidebar: 'Zijbalk tonen/verbergen',
+    reachedEndHistory: 'Je hebt het einde van je chathistorie bereikt.',
+    loadingChats: 'Chats laden...',
+    areYouSure: 'Weet je het zeker?',
+    deleteWarning:
+      'Deze actie kan niet ongedaan worden gemaakt. Dit verwijdert je chat permanent van onze servers.',
+    cancel: 'Annuleren',
+    continue: 'Doorgaan',
+    loginHistoryNotice: 'Log in om eerdere chats op te slaan en te bekijken!',
+    conversationsAppearHere:
+      'Je gesprekken verschijnen hier zodra je begint te chatten!',
+    today: 'Vandaag',
+    yesterday: 'Gisteren',
+    last7days: 'Laatste 7 dagen',
+    last30days: 'Laatste 30 dagen',
+    olderThanLastMonth: 'Ouder dan afgelopen maand',
+    login: 'Inloggen',
+    createAccount: 'Account aanmaken',
+    continueChatting: 'Verder chatten',
+    usedFreeMessage:
+      'Je hebt je gratis bericht voor vandaag gebruikt. Log in of maak een account om verder te chatten.',
+    continueWithGoogle: 'Verder met Google',
+    sending: 'Verzenden...',
+    send: 'Verzenden',
+    upgradeAccount: 'Account upgraden',
+    selectModel: 'Selecteer een model voor onbeperkte toegang.',
+    loading: 'Laden...',
+    purchase: 'Kopen',
+    compareModels: 'Vergelijk modellen',
+    comingSoon: 'BINNENKORT',
+    freeMessagesLeft: '{count} gratis bericht{plural} over',
+    messagesReset: 'Berichten zijn gereset. Je kunt een bericht sturen.',
+    resetsAt: 'Reset {duration} (om {time})',
+    oneFreeMessageInfo: '1 gratis bericht per dag. Resets elke dag.',
+    messagesLeftOf: '{count} van {max} over',
+    messageLimitResets: 'Berichtlimiet wordt dagelijks gereset.',
+    couldNotLoadMessageLimit: 'Kan berichtlimiet niet laden.',
+    loadingMessageLimit: 'Berichtlimiet laden...',
+    limitNA: 'Limiet N/B',
+    console: 'Console',
+    apply: 'Toepassen',
+    assistant: 'Assistent',
+    share: 'Delen',
+    more: 'Meer',
+    private: 'Privé',
+    public: 'Publiek',
+    delete: 'Verwijderen',
+  },
+} as const;
+
+export type TranslationKey = keyof typeof translations.en;
+
+export function translate(
+  lang: Language,
+  key: TranslationKey,
+  vars?: Record<string, string>,
+): string {
+  let text = translations[lang][key] as string;
+  if (vars) {
+    Object.entries(vars).forEach(([k, v]) => {
+      text = text.replace(`{${k}}`, v);
+    });
+  }
+  return text;
+}
+
+import { useLanguage } from '@/components/language-provider';
+import React from 'react';
+
+export function useTranslation() {
+  const { lang } = useLanguage();
+  return React.useCallback(
+    (key: TranslationKey, vars?: Record<string, string>) =>
+      translate(lang, key, vars),
+    [lang],
+  );
+}


### PR DESCRIPTION
## Summary
- introduce `LanguageProvider` and `useTranslation`
- keep language preference in a cookie
- update layout to initialize provider from cookie
- translate key UI labels and add language toggle in user nav
- expand translations across the UI and fix cookie call in auth

## Testing
- `pnpm exec next lint`
- `pnpm exec biome lint` *(fails: some errors emitted)*

------
https://chatgpt.com/codex/tasks/task_e_684948a5ea4c832a93ec062d5e4b6f36