### PR TITLE
Add logo link only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,7 @@ yarn-error.log*
 /playwright-report/
 /blob-report/
 /playwright/*
+
+# local images not included in repository
+public/images/ChatGPT Image Jun 11, 2025, 12_27_46 PM.png
+public/images/ChatGPT Image Jun 11, 2025, 12_30_18 PM.png

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -15,6 +15,9 @@ export const metadata: Metadata = {
   metadataBase: new URL('https://chat.vercel.ai'),
   title: 'Next.js Chatbot Template',
   description: 'Next.js chatbot template using the AI SDK.',
+  icons: {
+    icon: '/images/ChatGPT Image Jun 11, 2025, 12_27_46 PM.png',
+  },
 };
 
 export const viewport = {

--- a/components/app-sidebar.tsx
+++ b/components/app-sidebar.tsx
@@ -16,6 +16,7 @@ import {
   useSidebar,
 } from '@/components/ui/sidebar';
 import Link from 'next/link';
+import Image from 'next/image';
 import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip';
 import { useTranslation } from '@/lib/i18n';
 
@@ -36,9 +37,13 @@ export function AppSidebar({ user }: { user: User | undefined }) {
               }}
               className="flex flex-row gap-3 items-center"
             >
-              <span className="text-lg font-semibold px-2 hover:bg-muted rounded-md cursor-pointer">
-                Chatbot
-              </span>
+              <Image
+                src="/images/ChatGPT Image Jun 11, 2025, 12_30_18 PM.png"
+                alt="NLmodel"
+                width={32}
+                height={32}
+                className="w-8 h-8 object-contain"
+              />
             </Link>
             <Tooltip>
               <TooltipTrigger asChild>


### PR DESCRIPTION
## Summary
- exclude user-provided PNG images from repository via .gitignore
- keep favicon and sidebar logo paths referencing user's files

## Testing
- `pnpm exec biome lint` *(fails: found 62 errors)*
- `pnpm exec next lint`
- `pnpm exec playwright test` *(failed to complete)*


------
https://chatgpt.com/codex/tasks/task_e_68495b8abe74832a9d5c6c77b8176938