### PR TITLE
Add Gemini client and rename subscription plan

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,7 @@ AUTH_SECRET=****
 
 # Get your xAI API Key here for chat and image models: https://console.x.ai/
 XAI_API_KEY=****
+GOOGLE_API_KEY=****
 
 # Instructions to create a Vercel Blob Store here: https://vercel.com/docs/storage/vercel-blob
 BLOB_READ_WRITE_TOKEN=****
@@ -26,7 +27,7 @@ REDIS_URL=****
 STRIPE_SECRET_KEY=****
 # Use subscription price IDs for the plans below
 STRIPE_PRICE_BASIC_ID=****
-STRIPE_PRICE_GEMIDDELD_ID=****
+STRIPE_PRICE_PLUS_ID=****
 STRIPE_PRICE_TOP_ID=****
 
 # Base URL of your deployed application

--- a/app/(chat)/actions.ts
+++ b/app/(chat)/actions.ts
@@ -66,9 +66,9 @@ export async function updateUserTypeAfterCheckout({
   const { unstable_update } = await import('@/app/(auth)/auth');
   const { addUserModel, getUserModelIds } = await import('@/lib/db/queries');
 
-  const PLAN_MAP: Record<string, 'basic' | 'gemiddeld' | 'top' | undefined> = {
+  const PLAN_MAP: Record<string, 'basic' | 'plus' | 'top' | undefined> = {
     'basic-model': 'basic',
-    'gemiddeld-model': 'gemiddeld',
+    'plus-model': 'plus',
     'top-model': 'top',
   };
 

--- a/app/(chat)/api/chat/schema.ts
+++ b/app/(chat)/api/chat/schema.ts
@@ -27,7 +27,7 @@ export const postRequestBodySchema = z.object({
     'chat-model',
     'chat-model-reasoning',
     'basic-model',
-    'gemiddeld-model',
+    'plus-model',
     'top-model',
   ]),
   selectedVisibilityType: z.enum(['public', 'private']),

--- a/app/(chat)/api/checkout/route.ts
+++ b/app/(chat)/api/checkout/route.ts
@@ -4,7 +4,7 @@ import { auth } from '@/app/(auth)/auth';
 
 const PRICE_MAP: Record<string, string | undefined> = {
   'basic-model': process.env.STRIPE_PRICE_BASIC_ID,
-  'gemiddeld-model': process.env.STRIPE_PRICE_GEMIDDELD_ID,
+  'plus-model': process.env.STRIPE_PRICE_PLUS_ID,
   'top-model': process.env.STRIPE_PRICE_TOP_ID,
 };
 

--- a/app/(chat)/api/plan/route.ts
+++ b/app/(chat)/api/plan/route.ts
@@ -4,9 +4,9 @@ import { db } from '@/lib/db/drizzle-client';
 import { user } from '@/lib/db/schema';
 import { eq } from 'drizzle-orm';
 
-const PLAN_MAP: Record<string, 'basic' | 'gemiddeld' | 'top' | undefined> = {
+const PLAN_MAP: Record<string, 'basic' | 'plus' | 'top' | undefined> = {
   'basic-model': 'basic',
-  'gemiddeld-model': 'gemiddeld',
+  'plus-model': 'plus',
   'top-model': 'top',
 };
 

--- a/components/ui/upgrade-dialog.tsx
+++ b/components/ui/upgrade-dialog.tsx
@@ -33,8 +33,8 @@ const plans: Plan[] = [
     image: '/images/ChatGPT Image Jun 8, 2025, 04_07_35 PM.png',
   },
   {
-    id: 'gemiddeld-model',
-    name: 'GEMMIDDELD MODEL',
+    id: 'plus-model',
+    name: 'PLUS MODEL',
     description: 'Very good model capable of most tasks.',
     price: '€9.99',
     image: '/images/ChatGPT Image Jun 8, 2025, 04_08_58 PM.png',

--- a/geminiClient.ts
+++ b/geminiClient.ts
@@ -1,0 +1,58 @@
+import 'dotenv/config';
+import { GoogleGenerativeAI, type GenerationConfig, type SafetySetting } from '@google/genai';
+
+/* ------------------------------------------------------------------ */
+/* 0. Bootstrapping                                                   */
+/* ------------------------------------------------------------------ */
+const genAI = new GoogleGenerativeAI({
+  apiKey: process.env.GOOGLE_API_KEY ?? '',
+  // For Vertex AI replace with { projectId, location }
+});
+
+const MODEL_BASE = 'gemini-2.5-flash-preview-05-20';
+const MODEL_THINKING_ID = `${MODEL_BASE}:thinking`;
+
+/**
+ * Retrieve a handle to the Gemini model.
+ * @param useThinking Enable reasoning by switching to the :thinking variant.
+ * @returns Gemini GenerativeModel instance.
+ */
+export function getModel(useThinking = false) {
+  const modelId = useThinking ? MODEL_THINKING_ID : MODEL_BASE;
+  return genAI.getGenerativeModel({ model: modelId });
+}
+
+/** Default generation options mirroring Google defaults.
+ *  - temperature: 0–2 randomness
+ *  - topP:       0–1 nucleus sampling cut-off
+ *  - topK:       1–40 token shortlist size
+ *  - maxOutputTokens: ≤65_536 for 05-20
+ *  - thinkingBudget: 0–24_576 tokens; undefined = "Auto"
+ *  - enableThoughts: include hidden CoT JSON if true
+ */
+export const defaultGenerationConfig: GenerationConfig = {
+  temperature: 0.7,
+  topP: 1,
+  topK: 1,
+  maxOutputTokens: 2048,
+};
+
+/** Optional: override Google's default safety filters here */
+export const defaultSafety: SafetySetting[] = [];
+
+/**
+ * Example usage demonstrating the wiring.
+ * @param topic Topic to explain
+ * @param deep  If true enables reasoning via thinkingBudget
+ */
+export async function explainTopic(topic: string, deep = false) {
+  const model = getModel(deep);
+  const config = { ...defaultGenerationConfig };
+  if (!deep) config.thinkingBudget = 0;
+  const res = await model.generateContent({
+    contents: [{ role: 'user', parts: [{ text: `Explain ${topic}` }]}],
+    generationConfig: config,
+    safetySettings: defaultSafety,
+  });
+  return res.text();
+}

--- a/lib/ai/entitlements.ts
+++ b/lib/ai/entitlements.ts
@@ -28,9 +28,9 @@ export const entitlementsByUserType: Record<UserType, Entitlements> = {
     availableChatModelIds: ['basic-model'],
   },
 
-  gemiddeld: {
+  plus: {
     maxMessagesPerDay: Number.MAX_SAFE_INTEGER,
-    availableChatModelIds: ['gemiddeld-model'],
+    availableChatModelIds: ['plus-model'],
   },
 
   top: {

--- a/lib/ai/models.ts
+++ b/lib/ai/models.ts
@@ -23,8 +23,8 @@ export const chatModels: Array<ChatModel> = [
     description: 'The fast and reliable model. Unlimited access.',
   },
   {
-    id: 'gemiddeld-model',
-    name: 'GEMMIDDELD MODEL',
+    id: 'plus-model',
+    name: 'PLUS MODEL',
     description: 'Very good model capable of most tasks. Unlimited access.',
   },
   {

--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -4,6 +4,12 @@ import {
   wrapLanguageModel,
 } from 'ai';
 import { openai } from '@ai-sdk/openai';         // 👈 switched from xai
+import type {
+  LanguageModelV1,
+  LanguageModelV1CallOptions,
+  LanguageModelV1StreamPart,
+} from 'ai';
+import { getModel, defaultGenerationConfig, defaultSafety } from '@/geminiClient';
 import { isTestEnvironment } from '../constants';
 import {
   artifactModel,
@@ -12,6 +18,47 @@ import {
   titleModel,
 } from './models.test';
 
+function geminiLanguageModel(useThinking: boolean): LanguageModelV1 {
+  const modelId = useThinking
+    ? 'gemini-2.5-flash-preview-05-20:thinking'
+    : 'gemini-2.5-flash-preview-05-20';
+  return {
+    specificationVersion: 'v1',
+    provider: 'google',
+    modelId,
+    async doGenerate({ prompt }: LanguageModelV1CallOptions) {
+      const genModel = getModel(useThinking);
+      const config = { ...defaultGenerationConfig };
+      if (!useThinking) config.thinkingBudget = 0;
+      const contents = prompt.map(({ role, content }) => ({
+        role,
+        parts: [{ text: content }],
+      }));
+      const res = await genModel.generateContent({
+        contents,
+        generationConfig: config,
+        safetySettings: defaultSafety,
+      });
+      return {
+        text: res.text(),
+        finishReason: 'stop',
+        usage: { promptTokens: 0, completionTokens: 0 },
+        rawCall: { rawPrompt: contents, rawSettings: config },
+      };
+    },
+    async doStream(options: LanguageModelV1CallOptions) {
+      const { text } = await this.doGenerate(options);
+      const stream = new ReadableStream<LanguageModelV1StreamPart>({
+        start(controller) {
+          if (text) controller.enqueue({ type: 'text-delta', textDelta: text });
+          controller.close();
+        },
+      });
+      return { stream };
+    },
+  };
+}
+
 export const myProvider = isTestEnvironment
   /* ——————————————————————  MOCKS FOR AUTOMATED TESTS  ——————————————————— */
   ? customProvider({
@@ -19,7 +66,7 @@ export const myProvider = isTestEnvironment
         'chat-model': chatModel,
         'chat-model-reasoning': reasoningModel,
         'basic-model': chatModel,
-        'gemiddeld-model': chatModel,
+        'plus-model': chatModel,
         'top-model': chatModel,
         'title-model': titleModel,
         'artifact-model': artifactModel,
@@ -32,8 +79,8 @@ export const myProvider = isTestEnvironment
         'chat-model': openai('gpt-4.1'),             // GPT‑4.1 :contentReference[oaicite:4]{index=4}
 
         'basic-model': openai('gpt-4.1'),
-        'gemiddeld-model': openai('gpt-4.1'),
-        'top-model': openai('gpt-4.1'),
+        'plus-model': geminiLanguageModel(false),
+        'top-model': geminiLanguageModel(true),
 
         /* reasoning stream with <think> traces, using 4o‑mini           */
         'chat-model-reasoning': wrapLanguageModel({

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -16,7 +16,7 @@ export const user = pgTable('User', {
   email: varchar('email', { length: 64 }).notNull(),
   password: varchar('password', { length: 64 }),
   type: varchar('type', {
-    enum: ['guest', 'regular', 'basic', 'gemiddeld', 'top'],
+    enum: ['guest', 'regular', 'basic', 'plus', 'top'],
   })
     .notNull()
     .default('regular'),

--- a/lib/user-types.ts
+++ b/lib/user-types.ts
@@ -1,1 +1,1 @@
-export type UserType = 'guest' | 'regular' | 'basic' | 'gemiddeld' | 'top';
+export type UserType = 'guest' | 'regular' | 'basic' | 'plus' | 'top';

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@ai-sdk/openai": "^1.3.22",
     "@ai-sdk/react": "^1.2.12",
     "@ai-sdk/xai": "^1.2.15",
+    "@google/genai": "^0.9.0",
     "@codemirror/lang-javascript": "^6.2.2",
     "@codemirror/lang-python": "^6.1.6",
     "@codemirror/state": "^6.5.0",


### PR DESCRIPTION
## Summary
- rename `gemiddeld` plan to `plus` throughout
- integrate Google Gemini via new `geminiClient.ts`
- map plus/top plans to Gemini models
- expose `GOOGLE_API_KEY` and new Stripe env var in `.env.example`
- add Google Gemini dependency

## Testing
- `pnpm lint`
- `pnpm test` *(fails: E2E tests require network access)*

------
https://chatgpt.com/codex/tasks/task_e_684a8aeb37c0832a847ce29d653db40c