### PR TITLE
Fix Gemini payload

### DIFF
--- a/app/(chat)/api/chat/route.ts
+++ b/app/(chat)/api/chat/route.ts
@@ -18,7 +18,11 @@ import {
   saveUserMessageWithLimit,
   saveMessages,
 } from '@/lib/db/queries';
-import { generateUUID, getTrailingMessageId } from '@/lib/utils';
+import {
+  generateUUID,
+  getTrailingMessageId,
+  convertDBMessagesToUIMessages,
+} from '@/lib/utils';
 import { generateTitleFromUserMessage } from '../../actions';
 import { createDocument } from '@/lib/ai/tools/create-document';
 import { updateDocument } from '@/lib/ai/tools/update-document';
@@ -88,8 +92,7 @@ export async function POST(request: Request) {
 
     const previousMessages = await getMessagesByChatId({ id });
     const messages = appendClientMessage({
-      // @ts-expect-error: conversion from DB → UI shape
-      messages: previousMessages,
+      messages: convertDBMessagesToUIMessages(previousMessages),
       message,
     });
 
@@ -103,7 +106,10 @@ export async function POST(request: Request) {
     });
 
     if (!userMessage) {
-      return new ChatSDKError('limit_exceeded:chat', 'Message limit reached for the day.').toResponse();
+      return new ChatSDKError(
+        'limit_exceeded:chat',
+        'Message limit reached for the day.',
+      ).toResponse();
     }
 
     const { longitude, latitude, city, country } = geolocation(request);
@@ -176,7 +182,10 @@ export async function POST(request: Request) {
         result.consumeStream();
         result.mergeIntoDataStream(dataStream, { sendReasoning: true });
       },
-      onError: () => 'Oops, an error occurred!',
+      onError: (error) => {
+        console.error('createDataStream error:', error);
+        return 'Oops, an error occurred!';
+      },
     });
 
     const streamContext = getStreamContext();
@@ -206,7 +215,10 @@ export async function DELETE(request: NextRequest) {
     const id = searchParams.get('id');
 
     if (!id) {
-      return new ChatSDKError('bad_request:api', 'Chat ID is required.').toResponse();
+      return new ChatSDKError(
+        'bad_request:api',
+        'Chat ID is required.',
+      ).toResponse();
     }
 
     const chat = await getChatById({ id });
@@ -216,12 +228,14 @@ export async function DELETE(request: NextRequest) {
     }
 
     if (chat.userId !== session.user.id) {
-      return new ChatSDKError('forbidden:chat', 'You do not own this chat.').toResponse();
+      return new ChatSDKError(
+        'forbidden:chat',
+        'You do not own this chat.',
+      ).toResponse();
     }
 
     const deletedChat = await deleteChatById({ id });
     return NextResponse.json(deletedChat, { status: 200 });
-
   } catch (err) {
     console.error('DELETE /api/chat failed:', err);
     if (err instanceof ChatSDKError) {
@@ -238,7 +252,10 @@ export async function GET(request: NextRequest) {
     const streamId = searchParams.get('streamId');
 
     if (!chatId) {
-      return new ChatSDKError('bad_request:api', 'chatId is required.').toResponse();
+      return new ChatSDKError(
+        'bad_request:api',
+        'chatId is required.',
+      ).toResponse();
     }
 
     const session = await auth();
@@ -256,15 +273,21 @@ export async function GET(request: NextRequest) {
 
     const streamContext = getStreamContext();
     if (!streamContext) {
-      return new ChatSDKError('bad_request:api', 'Resumable streams not configured.').toResponse();
+      return new ChatSDKError(
+        'bad_request:api',
+        'Resumable streams not configured.',
+      ).toResponse();
     }
 
     // The fallback function MUST return a Promise<ReadableStream | Response> or ReadableStream | Response
-    const resumedStream = await streamContext.resumableStream(streamId || chatId, async () => {
-      const data = new StreamData();
-      data.close(); // Close the StreamData instance, making its stream end.
-      return data.stream; // This is a ReadableStream
-    });
+    const resumedStream = await streamContext.resumableStream(
+      streamId || chatId,
+      async () => {
+        const data = new StreamData();
+        data.close(); // Close the StreamData instance, making its stream end.
+        return data.stream; // This is a ReadableStream
+      },
+    );
 
     return new Response(resumedStream);
   } catch (err) {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -69,7 +69,7 @@ export default async function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  const cookieStore = cookies();
+  const cookieStore = await cookies();
   const langCookie = cookieStore.get('language');
   const lang = (langCookie?.value === 'nl' ? 'nl' : 'en') as Language;
   return (

--- a/geminiClient.ts
+++ b/geminiClient.ts
@@ -1,4 +1,9 @@
-import { GoogleGenAI, type GenerationConfig, type SafetySetting } from '@google/genai';
+import {
+  GoogleGenAI,
+  type GenerationConfig,
+  type SafetySetting,
+  type GenerateContentParameters,
+} from '@google/genai';
 
 /* ------------------------------------------------------------------ */
 /* 0. Bootstrapping                                                   */
@@ -18,7 +23,11 @@ const MODEL_THINKING_ID = `${MODEL_BASE}:thinking`;
  */
 export function getModel(useThinking = false) {
   const modelId = useThinking ? MODEL_THINKING_ID : MODEL_BASE;
-  return genAI.getGenerativeModel({ model: modelId });
+  return {
+    generateContent(params: Omit<GenerateContentParameters, 'model'>) {
+      return genAI.models.generateContent({ ...params, model: modelId });
+    },
+  };
 }
 
 /** Default generation options mirroring Google defaults.
@@ -49,7 +58,7 @@ export async function explainTopic(topic: string, deep = false) {
   const config = { ...defaultGenerationConfig };
   if (!deep) config.thinkingBudget = 0;
   const res = await model.generateContent({
-    contents: [{ role: 'user', parts: [{ text: `Explain ${topic}` }]}],
+    contents: [{ role: 'user', parts: [{ text: `Explain ${topic}` }] }],
     generationConfig: config,
     safetySettings: defaultSafety,
   });

--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -3,13 +3,17 @@ import {
   extractReasoningMiddleware,
   wrapLanguageModel,
 } from 'ai';
-import { openai } from '@ai-sdk/openai';         // 👈 switched from xai
+import { openai } from '@ai-sdk/openai'; // 👈 switched from xai
 import type {
   LanguageModelV1,
   LanguageModelV1CallOptions,
   LanguageModelV1StreamPart,
 } from 'ai';
-import { getModel, defaultGenerationConfig, defaultSafety } from '@/geminiClient';
+import {
+  getModel,
+  defaultGenerationConfig,
+  defaultSafety,
+} from '@/geminiClient';
 import { isTestEnvironment } from '../constants';
 import {
   artifactModel,
@@ -30,21 +34,32 @@ function geminiLanguageModel(useThinking: boolean): LanguageModelV1 {
       const genModel = getModel(useThinking);
       const config = { ...defaultGenerationConfig };
       if (!useThinking) config.thinkingBudget = 0;
-      const contents = prompt.map(({ role, content }) => ({
-        role,
-        parts: [{ text: content }],
-      }));
-      const res = await genModel.generateContent({
-        contents,
-        generationConfig: config,
-        safetySettings: defaultSafety,
+      const contents = prompt.map(({ role, content, parts }) => {
+        let text = content as string | undefined;
+        if (!text && Array.isArray(parts)) {
+          const partWithText = (parts as Array<{ text?: string }>).find(
+            (p) => typeof p.text === 'string',
+          );
+          text = partWithText?.text;
+        }
+        return { role, parts: [{ text: text ?? '' }] };
       });
-      return {
-        text: res.text(),
-        finishReason: 'stop',
-        usage: { promptTokens: 0, completionTokens: 0 },
-        rawCall: { rawPrompt: contents, rawSettings: config },
-      };
+      try {
+        const res = await genModel.generateContent({
+          contents,
+          generationConfig: config,
+          safetySettings: defaultSafety,
+        });
+        return {
+          text: res.text(),
+          finishReason: 'stop',
+          usage: { promptTokens: 0, completionTokens: 0 },
+          rawCall: { rawPrompt: contents, rawSettings: config },
+        };
+      } catch (err) {
+        console.error('Gemini request failed:', err);
+        throw err;
+      }
     },
     async doStream(options: LanguageModelV1CallOptions) {
       const { text } = await this.doGenerate(options);
@@ -60,8 +75,8 @@ function geminiLanguageModel(useThinking: boolean): LanguageModelV1 {
 }
 
 export const myProvider = isTestEnvironment
-  /* ——————————————————————  MOCKS FOR AUTOMATED TESTS  ——————————————————— */
-  ? customProvider({
+  ? /* ——————————————————————  MOCKS FOR AUTOMATED TESTS  ——————————————————— */
+    customProvider({
       languageModels: {
         'chat-model': chatModel,
         'chat-model-reasoning': reasoningModel,
@@ -72,11 +87,11 @@ export const myProvider = isTestEnvironment
         'artifact-model': artifactModel,
       },
     })
-  /* ——————————————————————  PRODUCTION (OpenAI)  ———————————————————————— */
-  : customProvider({
+  : /* ——————————————————————  PRODUCTION (OpenAI)  ———————————————————————— */
+    customProvider({
       languageModels: {
         /* flagship model for normal chat                                */
-        'chat-model': openai('gpt-4.1'),             // GPT‑4.1 :contentReference[oaicite:4]{index=4}
+        'chat-model': openai('gpt-4.1'), // GPT‑4.1 :contentReference[oaicite:4]{index=4}
 
         'basis-model': openai('gpt-4.1'),
         'plus-model': geminiLanguageModel(false),
@@ -84,17 +99,17 @@ export const myProvider = isTestEnvironment
 
         /* reasoning stream with <think> traces, using 4o‑mini           */
         'chat-model-reasoning': wrapLanguageModel({
-          model: openai('gpt-4o-mini'),              // GPT‑4o mini :contentReference[oaicite:5]{index=5}
+          model: openai('gpt-4o-mini'), // GPT‑4o mini :contentReference[oaicite:5]{index=5}
           middleware: extractReasoningMiddleware({ tagName: 'think' }),
         }),
 
         /* tiny, cheap models for titles & document help                 */
-        'title-model': openai('gpt-4o-mini'),        // single‑shot tasks :contentReference[oaicite:6]{index=6}
-        'artifact-model': openai('gpt-4o-mini'),     // doc summaries etc. :contentReference[oaicite:7]{index=7}
+        'title-model': openai('gpt-4o-mini'), // single‑shot tasks :contentReference[oaicite:6]{index=6}
+        'artifact-model': openai('gpt-4o-mini'), // doc summaries etc. :contentReference[oaicite:7]{index=7}
       },
 
       imageModels: {
         /* DALL·E 3 remains OpenAI’s production image model              */
-        'small-model': openai.image('dall-e-3'),     // image gen :contentReference[oaicite:8]{index=8}
+        'small-model': openai.image('dall-e-3'), // image gen :contentReference[oaicite:8]{index=8}
       },
     });

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,7 +1,12 @@
-import type { CoreAssistantMessage, CoreToolMessage, UIMessage } from 'ai';
+import type {
+  CoreAssistantMessage,
+  CoreToolMessage,
+  UIMessage,
+  Attachment,
+} from 'ai';
 import { type ClassValue, clsx } from 'clsx';
 import { twMerge } from 'tailwind-merge';
-import type { Document } from '@/lib/db/schema';
+import type { Document, DBMessage } from '@/lib/db/schema';
 import { ChatSDKError, type ErrorCode } from './errors';
 
 export function cn(...inputs: ClassValue[]) {
@@ -95,4 +100,20 @@ export function getTrailingMessageId({
 
 export function sanitizeText(text: string) {
   return text.replace('<has_function_call>', '');
+}
+
+export function convertDBMessagesToUIMessages(
+  messages: Array<DBMessage>,
+): Array<UIMessage> {
+  return messages.map((message) => ({
+    id: message.id,
+    parts: message.parts as UIMessage['parts'],
+    role: message.role as UIMessage['role'],
+    content:
+      (message.parts as Array<{ type: string; text?: string }>).find(
+        (p) => p.type === 'text',
+      )?.text || '',
+    createdAt: message.createdAt,
+    experimental_attachments: (message.attachments as Array<Attachment>) ?? [],
+  }));
 }


### PR DESCRIPTION
## Summary
- convert database messages to UI shape before using them
- tolerate missing `content` field in Gemini message creation

## Testing
- `npx biome check lib/utils.ts lib/ai/providers.ts 'app/(chat)/api/chat/route.ts'`
- `pnpm exec playwright test` *(fails: missing browsers)*

------
https://chatgpt.com/codex/tasks/task_e_684aabbaca40832aa99fbe1ee11381cd