### PR TITLE
Add subscription cancellation and management

### DIFF
--- a/app/(chat)/actions.ts
+++ b/app/(chat)/actions.ts
@@ -76,7 +76,9 @@ export async function updateUserTypeAfterCheckout({
   if (!type) return;
 
   await db.update(userTable).set({ type }).where(eq(userTable.id, userId));
-  await addUserModel({ userId, modelId: planId });
+  const expiresAt = new Date();
+  expiresAt.setMonth(expiresAt.getMonth() + 1);
+  await addUserModel({ userId, modelId: planId, expiresAt });
   const models = await getUserModelIds({ userId });
   await unstable_update({ user: { type, models } });
   await saveChatModelAsCookie(planId);

--- a/app/(chat)/api/subscriptions/cancel/route.ts
+++ b/app/(chat)/api/subscriptions/cancel/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from 'next/server';
+import { auth } from '@/app/(auth)/auth';
+import stripe from '@/lib/stripe';
+import { cancelUserModel } from '@/lib/db/queries';
+
+const PRICE_MAP: Record<string, string | undefined> = {
+  'basis-model': process.env.STRIPE_PRICE_BASIS_ID,
+  'plus-model': process.env.STRIPE_PRICE_PLUS_ID,
+  'top-model': process.env.STRIPE_PRICE_TOP_ID,
+};
+
+export async function POST(req: Request) {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { planId, reason } = await req.json();
+  const priceId = PRICE_MAP[planId];
+  if (!priceId) {
+    return NextResponse.json({ error: 'Invalid plan' }, { status: 400 });
+  }
+
+  // Attempt to find subscription by customer email and price
+  const customers = await stripe.customers.list({ email: session.user.email || undefined });
+  if (customers.data.length > 0) {
+    const customerId = customers.data[0].id;
+    const subs = await stripe.subscriptions.list({ customer: customerId });
+    const sub = subs.data.find((s) =>
+      s.items.data.some((item) => item.price.id === priceId),
+    );
+    if (sub) {
+      await stripe.subscriptions.update(sub.id, {
+        cancel_at_period_end: true,
+      });
+    }
+  }
+
+  await cancelUserModel({ userId: session.user.id, modelId: planId });
+  return NextResponse.json({ success: true });
+}

--- a/app/(chat)/api/subscriptions/route.ts
+++ b/app/(chat)/api/subscriptions/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from 'next/server';
+import { auth } from '@/app/(auth)/auth';
+import { getUserSubscriptions } from '@/lib/db/queries';
+
+export async function GET() {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const subs = await getUserSubscriptions({ userId: session.user.id });
+  return NextResponse.json({ subscriptions: subs });
+}

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -1,0 +1,18 @@
+import { auth } from '../(auth)/auth';
+import { redirect } from 'next/navigation';
+import { ManageSubscriptions } from '@/components/manage-subscriptions';
+
+export default async function Page() {
+  const session = await auth();
+  if (!session?.user) {
+    redirect('/login');
+  }
+
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-semibold mb-4">Settings</h1>
+      <h2 className="text-xl font-semibold mb-2">Manage Subscriptions</h2>
+      <ManageSubscriptions />
+    </div>
+  );
+}

--- a/components/chat-header.tsx
+++ b/components/chat-header.tsx
@@ -13,7 +13,8 @@ import { memo } from 'react';
 import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip';
 import { type VisibilityType, VisibilitySelector } from './visibility-selector';
 import type { Session } from 'next-auth';
-import { MessageLimitIndicator } from './message-limit-indicator'; // Added
+import { MessageLimitIndicator } from './message-limit-indicator';
+import { SubscriptionIndicator } from './subscription-indicator';
 import { useUpgradePopup } from '@/hooks/use-upgrade-popup';
 import { useTranslation } from '@/lib/i18n';
 
@@ -80,8 +81,10 @@ function PureChatHeader({
             chatId={chatId}
             selectedVisibilityType={selectedVisibilityType}
           />
-          {session?.user && (
-            <MessageLimitIndicator userId={session.user.id} />
+          {session?.user?.models?.length ? (
+            <SubscriptionIndicator />
+          ) : (
+            session?.user && <MessageLimitIndicator userId={session.user.id} />
           )}
         </div>
       )}

--- a/components/manage-subscriptions.tsx
+++ b/components/manage-subscriptions.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import Image from 'next/image';
+import useSWR from 'swr';
+import Link from 'next/link';
+import { Button } from '@/components/ui/button';
+import { fetcher } from '@/lib/utils';
+import { plans } from '@/lib/plans';
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useTranslation } from '@/lib/i18n';
+import { format } from 'date-fns';
+
+interface Subscription {
+  modelId: string;
+  expiresAt: string | null;
+  canceled: boolean;
+}
+
+export function ManageSubscriptions() {
+  const { data, mutate } = useSWR<{ subscriptions: Subscription[] }>('/api/subscriptions', fetcher);
+  const [loadingId, setLoadingId] = useState<string | null>(null);
+  const [reason, setReason] = useState('');
+  const router = useRouter();
+  const t = useTranslation();
+
+  async function checkout(planId: string) {
+    setLoadingId(planId);
+    const res = await fetch('/api/checkout', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ planId }),
+    });
+    const json = await res.json();
+    setLoadingId(null);
+    if (json.url) {
+      window.location.href = json.url;
+    }
+  }
+
+  async function cancel(planId: string) {
+    if (!confirm(t('confirmCancelQuestion'))) return;
+    setLoadingId(planId);
+    await fetch('/api/subscriptions/cancel', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ planId, reason }),
+    });
+    setLoadingId(null);
+    setReason('');
+    mutate();
+  }
+
+  const subs = data?.subscriptions ?? [];
+
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-12 px-10 py-10">
+      {plans.map((plan) => {
+        const subscription = subs.find((s) => s.modelId === plan.id && !s.canceled);
+        const comingSoon = plan.id === 'coming-soon';
+        return (
+          <div key={plan.id} className="model-card bg-white dark:bg-gray-800 rounded-[28px] shadow-lg flex flex-col justify-between p-4 m-2">
+            <div className="flex flex-col flex-1">
+              <Image src={plan.image} alt={plan.name} width={300} height={176} className="object-cover rounded-t-lg" />
+              <h3 className="font-semibold text-lg leading-tight mt-4">{plan.name}</h3>
+              <p className="mt-1 text-sm text-muted-foreground">{plan.description}</p>
+              {!comingSoon && plan.price && <p className="mt-4 font-bold text-base">{plan.price}</p>}
+              {subscription?.expiresAt && (
+                <p className="mt-2 text-sm">{t('validUntil', { date: format(new Date(subscription.expiresAt), 'PPP'), time: format(new Date(subscription.expiresAt), 'p') })}</p>
+              )}
+            </div>
+            {!comingSoon ? (
+              subscription ? (
+                <>
+                  <textarea className="mt-2 w-full border rounded p-1" placeholder={t('reasonPlaceholder')} value={reason} onChange={(e) => setReason(e.target.value)} />
+                  <Button className="mt-2 w-full" onClick={() => cancel(plan.id)} disabled={loadingId === plan.id}>
+                    {loadingId === plan.id ? t('loading') : t('cancelSubscription')}
+                  </Button>
+                </>
+              ) : (
+                <>
+                  <Button className="mt-4 w-full" onClick={() => checkout(plan.id)} disabled={loadingId === plan.id}>
+                    {loadingId === plan.id ? t('loading') : t('purchase')}
+                  </Button>
+                  <Link href="/compare" className="mt-2 text-center text-sm font-semibold text-gray-800 hover:underline dark:text-zinc-200">
+                    {t('compareModels')}
+                  </Link>
+                </>
+              )
+            ) : (
+              <p className="mt-4 text-center text-sm text-muted-foreground font-semibold">{t('comingSoon')}</p>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/components/sidebar-user-nav.tsx
+++ b/components/sidebar-user-nav.tsx
@@ -7,6 +7,7 @@ import { signOut, useSession } from 'next-auth/react';
 import { useTheme } from 'next-themes';
 import { useLanguage } from '@/components/language-provider';
 import { useTranslation } from '@/lib/i18n';
+import Link from 'next/link';
 
 import {
   DropdownMenu,
@@ -91,6 +92,11 @@ export function SidebarUserNav({ user }: { user: User }) {
               onSelect={() => setLang(lang === 'en' ? 'nl' : 'en')}
             >
               {lang === 'en' ? t('switchToDutch') : t('switchToEnglish')}
+            </DropdownMenuItem>
+            <DropdownMenuItem asChild>
+              <Link href="/settings" className="w-full cursor-pointer">
+                {t('settings')}
+              </Link>
             </DropdownMenuItem>
             <DropdownMenuSeparator />
             <DropdownMenuItem asChild data-testid="user-nav-item-auth">

--- a/components/subscription-indicator.tsx
+++ b/components/subscription-indicator.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import useSWR from 'swr';
+import { fetcher, cn } from '@/lib/utils';
+import { format } from 'date-fns';
+import { useTranslation } from '@/lib/i18n';
+
+interface Subscription {
+  modelId: string;
+  expiresAt: string | null;
+  canceled: boolean;
+}
+
+export function SubscriptionIndicator({ className }: { className?: string }) {
+  const { data } = useSWR<{ subscriptions: Subscription[] }>('/api/subscriptions', fetcher, { refreshInterval: 30000 });
+  const t = useTranslation();
+
+  if (!data) return null;
+  const subs = data.subscriptions.filter((s) => !s.canceled && s.expiresAt);
+  if (subs.length === 0) return null;
+  const earliest = subs.sort((a, b) => (new Date(a.expiresAt as string).getTime() > new Date(b.expiresAt as string).getTime() ? 1 : -1))[0];
+  const date = format(new Date(earliest.expiresAt as string), 'PPP');
+  const time = format(new Date(earliest.expiresAt as string), 'p');
+  return (
+    <div className={cn('text-xs text-muted-foreground px-2 py-1 border rounded-md', className)}>
+      {t('validUntil', { date, time })}
+    </div>
+  );
+}

--- a/components/ui/upgrade-dialog.tsx
+++ b/components/ui/upgrade-dialog.tsx
@@ -15,44 +15,7 @@ import { useState } from 'react'
 import { useSession } from 'next-auth/react'
 import { useRouter } from 'next/navigation'
 import { useTranslation } from '@/lib/i18n'
-
-interface Plan {
-  id: string
-  name: string
-  description: string
-  image: string
-  price?: string
-}
-
-const plans: Plan[] = [
-  {
-    id: 'basis-model',
-    name: 'BASIS MODEL',
-    description: 'The fast and reliable model.',
-    price: '€4.99',
-    image: '/images/ChatGPT Image Jun 8, 2025, 04_07_35 PM.png',
-  },
-  {
-    id: 'plus-model',
-    name: 'PLUS MODEL',
-    description: 'Very good model capable of most tasks.',
-    price: '€9.99',
-    image: '/images/ChatGPT Image Jun 8, 2025, 04_08_58 PM.png',
-  },
-  {
-    id: 'top-model',
-    name: 'TOP MODEL',
-    description: 'Best state of the art model capable of everything.',
-    price: '€19.99',
-    image: '/images/ChatGPT Image Jun 8, 2025, 04_00_45 PM.png',
-  },
-  {
-    id: 'coming-soon',
-    name: 'COMING SOON',
-    description: 'New model available soon.',
-    image: '/images/ChatGPT Image Jun 8, 2025, 05_03_41 PM.png',
-  },
-]
+import { plans } from '@/lib/plans'
 
 export function UpgradeDialog() {
   const { isOpen, closePopup } = useUpgradePopup()

--- a/lib/db/migrations/0009_add_user_model_subscription.sql
+++ b/lib/db/migrations/0009_add_user_model_subscription.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "UserModel" ADD COLUMN IF NOT EXISTS "expiresAt" timestamp;
+ALTER TABLE "UserModel" ADD COLUMN IF NOT EXISTS "canceled" boolean DEFAULT false;

--- a/lib/db/queries.ts
+++ b/lib/db/queries.ts
@@ -11,6 +11,7 @@ import {
   gte,
   inArray,
   lt,
+  or,
   sql,
   type SQL,
 } from 'drizzle-orm';
@@ -662,14 +663,16 @@ export async function getStreamIdsByChatId({ chatId }: { chatId: string }) {
 export async function addUserModel({
   userId,
   modelId,
+  expiresAt,
 }: {
   userId: string;
   modelId: string;
+  expiresAt: Date;
 }) {
   try {
     await db
       .insert(userModel)
-      .values({ userId, modelId })
+      .values({ userId, modelId, expiresAt })
       .onConflictDoNothing();
   } catch (error) {
     throw new ChatSDKError(
@@ -684,13 +687,51 @@ export async function getUserModelIds({ userId }: { userId: string }) {
     const rows = await db
       .select({ modelId: userModel.modelId })
       .from(userModel)
-      .where(eq(userModel.userId, userId));
+      .where(
+        and(
+          eq(userModel.userId, userId),
+          eq(userModel.canceled, false),
+          or(userModel.expiresAt.isNull(), gt(userModel.expiresAt, new Date())),
+        ),
+      );
     return rows.map((r) => r.modelId);
   } catch (error) {
     throw new ChatSDKError(
       'bad_request:database',
       'Failed to get user models',
     );
+  }
+}
+
+export async function getUserSubscriptions({ userId }: { userId: string }) {
+  try {
+    return await db
+      .select({
+        modelId: userModel.modelId,
+        expiresAt: userModel.expiresAt,
+        canceled: userModel.canceled,
+      })
+      .from(userModel)
+      .where(eq(userModel.userId, userId));
+  } catch (error) {
+    throw new ChatSDKError('bad_request:database', 'Failed to get subscriptions');
+  }
+}
+
+export async function cancelUserModel({
+  userId,
+  modelId,
+}: {
+  userId: string;
+  modelId: string;
+}) {
+  try {
+    await db
+      .update(userModel)
+      .set({ canceled: true })
+      .where(and(eq(userModel.userId, userId), eq(userModel.modelId, modelId)));
+  } catch (error) {
+    throw new ChatSDKError('bad_request:database', 'Failed to cancel subscription');
   }
 }
 

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -181,6 +181,8 @@ export const userModel = pgTable(
       .notNull()
       .references(() => user.id),
     modelId: varchar('modelId', { length: 64 }).notNull(),
+    expiresAt: timestamp('expiresAt'),
+    canceled: boolean('canceled').default(false),
   },
   (table) => ({
     pk: primaryKey({ columns: [table.userId, table.modelId] }),

--- a/lib/i18n.tsx
+++ b/lib/i18n.tsx
@@ -71,6 +71,12 @@ export const translations = {
     private: 'Private',
     public: 'Public',
     delete: 'Delete',
+    settings: 'Settings',
+    manageSubscriptions: 'Manage Subscriptions',
+    cancelSubscription: 'Cancel subscription',
+    confirmCancelQuestion: 'Are you sure you want to cancel this subscription?',
+    validUntil: 'Valid until {date} at {time}',
+    reasonPlaceholder: 'Reason (optional)',
   },
   nl: {
     newChat: 'Nieuw gesprek',
@@ -142,6 +148,12 @@ export const translations = {
     private: 'Privé',
     public: 'Publiek',
     delete: 'Verwijderen',
+    settings: 'Instellingen',
+    manageSubscriptions: 'Beheer abonnementen',
+    cancelSubscription: 'Abonnement opzeggen',
+    confirmCancelQuestion: 'Weet je zeker dat je dit abonnement wilt opzeggen?',
+    validUntil: 'Geldig tot {date} om {time}',
+    reasonPlaceholder: 'Reden (optioneel)',
   },
 } as const;
 

--- a/lib/plans.ts
+++ b/lib/plans.ts
@@ -1,0 +1,37 @@
+export interface Plan {
+  id: string;
+  name: string;
+  description: string;
+  image: string;
+  price?: string;
+}
+
+export const plans: Plan[] = [
+  {
+    id: 'basis-model',
+    name: 'BASIS MODEL',
+    description: 'The fast and reliable model.',
+    price: '€4.99',
+    image: '/images/ChatGPT Image Jun 8, 2025, 04_07_35 PM.png',
+  },
+  {
+    id: 'plus-model',
+    name: 'PLUS MODEL',
+    description: 'Very good model capable of most tasks.',
+    price: '€9.99',
+    image: '/images/ChatGPT Image Jun 8, 2025, 04_08_58 PM.png',
+  },
+  {
+    id: 'top-model',
+    name: 'TOP MODEL',
+    description: 'Best state of the art model capable of everything.',
+    price: '€19.99',
+    image: '/images/ChatGPT Image Jun 8, 2025, 04_00_45 PM.png',
+  },
+  {
+    id: 'coming-soon',
+    name: 'COMING SOON',
+    description: 'New model available soon.',
+    image: '/images/ChatGPT Image Jun 8, 2025, 05_03_41 PM.png',
+  },
+];


### PR DESCRIPTION
## Summary
- share plan data between dialogs and management page
- track user subscription expiration in database schema
- add API endpoints to get and cancel subscriptions
- create manage subscriptions page and UI components
- display subscription expiration in chat header
- update translations for new UI text

## Testing
- `pnpm lint`
- `pnpm test` *(fails: playwright tests require environment)*

------
https://chatgpt.com/codex/tasks/task_e_684bd8a0b644832a9c9f83884a4fd152