### PR TITLE
Add per-chat model tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ You can deploy your own version of the Next.js AI Chatbot to Vercel with one cli
 
 [![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fvercel%2Fai-chatbot&env=AUTH_SECRET&envDescription=Learn+more+about+how+to+get+the+API+Keys+for+the+application&envLink=https%3A%2F%2Fgithub.com%2Fvercel%2Fai-chatbot%2Fblob%2Fmain%2F.env.example&demo-title=AI+Chatbot&demo-description=An+Open-Source+AI+Chatbot+Template+Built+With+Next.js+and+the+AI+SDK+by+Vercel.&demo-url=https%3A%2F%2Fchat.vercel.ai&products=%5B%7B%22type%22%3A%22integration%22%2C%22protocol%22%3A%22ai%22%2C%22productSlug%22%3A%22grok%22%2C%22integrationSlug%22%3A%22xai%22%7D%2C%7B%22type%22%3A%22integration%22%2C%22protocol%22%3A%22storage%22%2C%22productSlug%22%3A%22neon%22%2C%22integrationSlug%22%3A%22neon%22%7D%2C%7B%22type%22%3A%22integration%22%2C%22protocol%22%3A%22storage%22%2C%22productSlug%22%3A%22upstash-kv%22%2C%22integrationSlug%22%3A%22upstash%22%7D%2C%7B%22type%22%3A%22blob%22%7D%5D)
 
+## Chat model management
+
+Each chat stores the model that created it. When you pick a different model while chatting you are asked to start a new chat; previous context is not sent to the new model. Chats using models that you no longer have access to become read‑only.
+
+Paid plans still include unlimited access to the free model so that chats created before upgrading remain editable.
+
 ## Running locally
 
 You will need to use the environment variables [defined in `.env.example`](.env.example) to run Next.js AI Chatbot. It's recommended you use [Vercel Environment Variables](https://vercel.com/docs/projects/environment-variables) for this, but a `.env` file is all that is necessary.

--- a/app/(chat)/api/chat/route.ts
+++ b/app/(chat)/api/chat/route.ts
@@ -85,6 +85,7 @@ export async function POST(request: Request) {
         userId: session.user.id,
         title,
         visibility: selectedVisibilityType,
+        modelId: selectedChatModel,
       });
     } else if (chat.userId !== session.user.id) {
       return new ChatSDKError('forbidden:chat').toResponse();

--- a/app/(chat)/chat/[id]/page.tsx
+++ b/app/(chat)/chat/[id]/page.tsx
@@ -1,12 +1,11 @@
 // app/(chat)/chat/[id]/page.tsx
-import { cookies } from 'next/headers';
 import { notFound, redirect } from 'next/navigation';
 
 import { auth } from '@/app/(auth)/auth';
 import { Chat } from '@/components/chat';
 import { getChatById, getMessagesByChatId } from '@/lib/db/queries';
 import { DataStreamHandler } from '@/components/data-stream-handler';
-import { DEFAULT_CHAT_MODEL } from '@/lib/ai/models';
+import { entitlementsByUserType } from '@/lib/ai/entitlements';
 import type { DBMessage } from '@/lib/db/schema';
 import type { Attachment, UIMessage } from 'ai';
 
@@ -23,7 +22,7 @@ export default async function Page({
     typeof resolvedSearchParams?.prompt === 'string'
       ? resolvedSearchParams.prompt
       : undefined;
-  
+
   const chat = await getChatById({ id: chatId });
 
   if (!chat) {
@@ -39,12 +38,12 @@ export default async function Page({
     if (initialPromptFromQuery) {
       redirectUrlQuery = `?prompt=${encodeURIComponent(initialPromptFromQuery)}`;
     }
-    
+
     const fullRedirectUrl = `${redirectBase}${currentPath}${redirectUrlQuery}`;
-    
+
     const guestAuthUrl = new URL('/api/auth/guest', redirectBase);
     guestAuthUrl.searchParams.set('redirectUrl', fullRedirectUrl);
-    
+
     redirect(guestAuthUrl.toString());
   }
 
@@ -68,22 +67,28 @@ export default async function Page({
       id: message.id,
       parts: message.parts as UIMessage['parts'],
       role: message.role as UIMessage['role'],
-      content: (message.parts as Array<{type: string, text?: string}>)?.find(p => p.type === 'text')?.text || '',
+      content:
+        (message.parts as Array<{ type: string; text?: string }>)?.find(
+          (p) => p.type === 'text',
+        )?.text || '',
       createdAt: message.createdAt,
       experimental_attachments:
         (message.attachments as Array<Attachment>) ?? [],
     }));
   }
 
-  const cookieStore = await cookies();
-  const chatModelFromCookie = cookieStore.get('chat-model');
+  const userModels = session.user.models ?? [];
+  const baseModels =
+    entitlementsByUserType[session.user.type].availableChatModelIds;
+  const availableModels = userModels.length > 0 ? userModels : baseModels;
+  const isModelAvailable = availableModels.includes(chat.modelId);
 
   const chatComponentProps = {
     id: chat.id,
     initialMessages: convertToUIMessages(messagesFromDb),
-    initialChatModel: chatModelFromCookie?.value || DEFAULT_CHAT_MODEL,
+    initialChatModel: chat.modelId,
     initialVisibilityType: chat.visibility,
-    isReadonly: session?.user?.id !== chat.userId,
+    isReadonly: session?.user?.id !== chat.userId || !isModelAvailable,
     session: session, // session is guaranteed here
     autoResume: true,
     initialInput: initialPromptFromQuery,

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -1,7 +1,11 @@
 // components/chat.tsx
 'use client';
 
-import type { Attachment, UIMessage, ChatRequestOptions as CoreChatRequestOptions } from 'ai';
+import type {
+  Attachment,
+  UIMessage,
+  ChatRequestOptions as CoreChatRequestOptions,
+} from 'ai';
 import { useChat, type UseChatHelpers } from '@ai-sdk/react';
 import { useEffect, useState, useCallback, useRef } from 'react';
 import useSWR, { useSWRConfig } from 'swr';
@@ -17,7 +21,7 @@ import { unstable_serialize } from 'swr/infinite';
 import { getChatHistoryPaginationKey } from './sidebar-history';
 import { toast } from './toast';
 import type { Session } from 'next-auth';
-import { useSearchParams } from 'next/navigation';
+import { useSearchParams, useRouter } from 'next/navigation';
 import { useChatVisibility } from '@/hooks/use-chat-visibility';
 import { useAutoResume } from '@/hooks/use-auto-resume';
 import { ChatSDKError } from '@/lib/errors';
@@ -58,7 +62,22 @@ export function Chat({
   const { openPopup: openUpgradePopup } = useUpgradePopup();
   const hasSetInitialInputRef = useRef(false);
 
+  const router = useRouter();
+
   const [chatModelId, setChatModelId] = useState(initialChatModel);
+
+  const handleModelChange = useCallback(
+    (modelId: string) => {
+      if (modelId === chatModelId) return;
+      const confirmSwitch = window.confirm(
+        'The context will not be taken into account. Start a new chat?',
+      );
+      if (confirmSwitch) {
+        router.push(`/?modelId=${modelId}`);
+      }
+    },
+    [chatModelId, router],
+  );
 
   useEffect(() => {
     const url = new URL(window.location.href);
@@ -75,16 +94,15 @@ export function Chat({
 
   // SWR key for messageStatus uses the session.user.id from the props.
   // This is critical: if `session` prop updates correctly after login, this key will change.
-  const messageStatusSWRKey = session?.user?.id ? `/api/message-status?userId=${session.user.id}` : null;
-  const { data: messageStatus, mutate: mutateMessageStatus } = useSWR<MessageStatus>(
-    messageStatusSWRKey,
-    fetcher,
-    {
+  const messageStatusSWRKey = session?.user?.id
+    ? `/api/message-status?userId=${session.user.id}`
+    : null;
+  const { data: messageStatus, mutate: mutateMessageStatus } =
+    useSWR<MessageStatus>(messageStatusSWRKey, fetcher, {
       revalidateOnFocus: true,
       refreshInterval: 30000,
-    },
-  );
-  
+    });
+
   const [attachments, setAttachments] = useState<Array<Attachment>>([]);
 
   const {
@@ -120,13 +138,13 @@ export function Chat({
     onError: (error) => {
       if (error instanceof ChatSDKError) {
         if (error.type === 'limit_exceeded' && error.surface === 'chat') {
-           if (session.user?.id) {
-             openLoginSignupPopup({
-               chatId: id,
-               guestUserId: session.user.id,
-               unsentPrompt: input,
-             });
-           }
+          if (session.user?.id) {
+            openLoginSignupPopup({
+              chatId: id,
+              guestUserId: session.user.id,
+              unsentPrompt: input,
+            });
+          }
           return;
         }
         toast({
@@ -147,82 +165,125 @@ export function Chat({
   const promptFromAuthRedirect = searchParams.get('prompt');
 
   useEffect(() => {
-    const promptToUse = propInitialInput || promptFromAuthRedirect || queryFromUrl;
+    const promptToUse =
+      propInitialInput || promptFromAuthRedirect || queryFromUrl;
     if (promptToUse && !hasSetInitialInputRef.current && status === 'ready') {
       const lastMessage = messages.at(-1);
-      if (!(lastMessage?.role === 'user' && lastMessage.content === promptToUse)) {
+      if (
+        !(lastMessage?.role === 'user' && lastMessage.content === promptToUse)
+      ) {
         setInput(promptToUse);
       }
       hasSetInitialInputRef.current = true;
       const newUrl = new URL(window.location.href);
       if (promptFromAuthRedirect) newUrl.searchParams.delete('prompt');
       if (queryFromUrl) newUrl.searchParams.delete('query');
-      if (newUrl.searchParams.toString() !== new URL(window.location.href).searchParams.toString()) {
+      if (
+        newUrl.searchParams.toString() !==
+        new URL(window.location.href).searchParams.toString()
+      ) {
         window.history.replaceState({}, '', newUrl.toString());
       }
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [propInitialInput, promptFromAuthRedirect, queryFromUrl, setInput, status, messages.length]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    propInitialInput,
+    promptFromAuthRedirect,
+    queryFromUrl,
+    setInput,
+    status,
+    messages.length,
+  ]);
 
-
-   const handleSubmit: UseChatHelpers['handleSubmit'] = useCallback(
+  const handleSubmit: UseChatHelpers['handleSubmit'] = useCallback(
     (eOrForm, chatRequestOptions) => {
-    // Allow calling without an event when submitting programmatically
-    eOrForm?.preventDefault?.();
-    
-    if (messageStatus && messageStatus.messagesLeft <= 0 && input.trim() !== '') {
-      if (messageStatus.userType === 'guest') {
-        if (session.user?.id) {
-          openLoginSignupPopup({
-            chatId: id,
-            guestUserId: session.user.id,
-            unsentPrompt: input,
-          });
+      // Allow calling without an event when submitting programmatically
+      eOrForm?.preventDefault?.();
+
+      if (
+        messageStatus &&
+        messageStatus.messagesLeft <= 0 &&
+        input.trim() !== ''
+      ) {
+        if (messageStatus.userType === 'guest') {
+          if (session.user?.id) {
+            openLoginSignupPopup({
+              chatId: id,
+              guestUserId: session.user.id,
+              unsentPrompt: input,
+            });
+          }
+        } else {
+          openUpgradePopup();
         }
-      } else {
-        openUpgradePopup();
+        return;
       }
-      return;
-    }
-    
-    const currentPath = `/chat/${id}`;
-    if (window.location.pathname !== currentPath || window.location.search !== '') {
-      window.history.replaceState({}, '', currentPath);
-    }
 
-    const optionsWithAttachments: ChatRequestOptions = {
-      ...chatRequestOptions,
-      experimental_attachments: attachments,
-    };
-    // The first argument to useChat's handleSubmit can be an event or options.
-    // If eOrForm is an event, it's passed. If it's undefined (programmatic call), pass undefined.
-    internalUseChatHandleSubmit(eOrForm, optionsWithAttachments);
-  }, [messageStatus, openLoginSignupPopup, openUpgradePopup, internalUseChatHandleSubmit, id, attachments, input, session.user?.id]);
+      const currentPath = `/chat/${id}`;
+      if (
+        window.location.pathname !== currentPath ||
+        window.location.search !== ''
+      ) {
+        window.history.replaceState({}, '', currentPath);
+      }
 
+      const optionsWithAttachments: ChatRequestOptions = {
+        ...chatRequestOptions,
+        experimental_attachments: attachments,
+      };
+      // The first argument to useChat's handleSubmit can be an event or options.
+      // If eOrForm is an event, it's passed. If it's undefined (programmatic call), pass undefined.
+      internalUseChatHandleSubmit(eOrForm, optionsWithAttachments);
+    },
+    [
+      messageStatus,
+      openLoginSignupPopup,
+      openUpgradePopup,
+      internalUseChatHandleSubmit,
+      id,
+      attachments,
+      input,
+      session.user?.id,
+    ],
+  );
 
   const append: UseChatHelpers['append'] = useCallback(
     async (message, chatRequestOptions) => {
-    if (messageStatus && messageStatus.messagesLeft <= 0) {
-       if (messageStatus.userType === 'guest') {
-         if (session.user?.id) {
-           openLoginSignupPopup({
-             chatId: id,
-             guestUserId: session.user.id,
-             unsentPrompt: typeof message.content === 'string' ? message.content : input,
-           });
-         }
-       } else {
-         openUpgradePopup();
-       }
-      return null;
-    }
-    const currentPath = `/chat/${id}`;
-    if (window.location.pathname !== currentPath || window.location.search !== '') {
+      if (messageStatus && messageStatus.messagesLeft <= 0) {
+        if (messageStatus.userType === 'guest') {
+          if (session.user?.id) {
+            openLoginSignupPopup({
+              chatId: id,
+              guestUserId: session.user.id,
+              unsentPrompt:
+                typeof message.content === 'string' ? message.content : input,
+            });
+          }
+        } else {
+          openUpgradePopup();
+        }
+        return null;
+      }
+      const currentPath = `/chat/${id}`;
+      if (
+        window.location.pathname !== currentPath ||
+        window.location.search !== ''
+      ) {
         window.history.replaceState({}, '', currentPath);
-    }
-    return internalUseChatAppend(message, chatRequestOptions);
-  // Dependencies for the outer useCallback wrapper for `append`
-  }, [messageStatus, session?.user?.id, openLoginSignupPopup, openUpgradePopup, id, input, internalUseChatAppend]);
+      }
+      return internalUseChatAppend(message, chatRequestOptions);
+      // Dependencies for the outer useCallback wrapper for `append`
+    },
+    [
+      messageStatus,
+      session?.user?.id,
+      openLoginSignupPopup,
+      openUpgradePopup,
+      id,
+      input,
+      internalUseChatAppend,
+    ],
+  );
 
   const { data: votes } = useSWR<Array<Vote>>(
     messages.length >= 2 ? `/api/vote?chatId=${id}` : null,
@@ -245,7 +306,7 @@ export function Chat({
         <ChatHeader
           chatId={id}
           selectedModelId={chatModelId}
-          onModelChange={setChatModelId}
+          onModelChange={handleModelChange}
           selectedVisibilityType={visibilityType}
           isReadonly={isReadonly}
           session={session}

--- a/components/model-selector.tsx
+++ b/components/model-selector.tsx
@@ -32,19 +32,15 @@ export function ModelSelector({
   const userType = session.user.type;
   const userModels = session.user.models ?? [];
   const baseModels = entitlementsByUserType[userType].availableChatModelIds;
-  const availableChatModelIds =
-    userModels.length > 0 ? userModels : baseModels;
+  const availableChatModelIds = userModels.length > 0 ? userModels : baseModels;
 
   const availableChatModels = chatModels.filter((chatModel) =>
     availableChatModelIds.includes(chatModel.id),
   );
 
   const selectedChatModel = useMemo(
-    () =>
-      availableChatModels.find(
-        (chatModel) => chatModel.id === optimisticModelId,
-      ),
-    [optimisticModelId, availableChatModels],
+    () => chatModels.find((chatModel) => chatModel.id === optimisticModelId),
+    [optimisticModelId],
   );
 
   return (
@@ -61,7 +57,9 @@ export function ModelSelector({
           variant="outline"
           className="md:px-2 md:h-[34px]"
         >
-          <span className="mr-1 truncate max-w-[8rem]">{selectedChatModel?.name}</span>
+          <span className="mr-1 truncate max-w-[8rem]">
+            {selectedChatModel?.name}
+          </span>
           <ChevronDownIcon />
         </Button>
       </DropdownMenuTrigger>

--- a/lib/ai/entitlements.ts
+++ b/lib/ai/entitlements.ts
@@ -25,17 +25,17 @@ export const entitlementsByUserType: Record<UserType, Entitlements> = {
 
   basis: {
     maxMessagesPerDay: Number.MAX_SAFE_INTEGER,
-    availableChatModelIds: ['basis-model'],
+    availableChatModelIds: ['basis-model', 'chat-model'],
   },
 
   plus: {
     maxMessagesPerDay: Number.MAX_SAFE_INTEGER,
-    availableChatModelIds: ['plus-model'],
+    availableChatModelIds: ['plus-model', 'chat-model'],
   },
 
   top: {
     maxMessagesPerDay: Number.MAX_SAFE_INTEGER,
-    availableChatModelIds: ['top-model'],
+    availableChatModelIds: ['top-model', 'chat-model'],
   },
 
   /*

--- a/lib/db/migrations/0010_add_chat_model.sql
+++ b/lib/db/migrations/0010_add_chat_model.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "Chat" ADD COLUMN IF NOT EXISTS "modelId" varchar(64) NOT NULL DEFAULT 'chat-model';

--- a/lib/db/queries.ts
+++ b/lib/db/queries.ts
@@ -45,7 +45,6 @@ if (!process.env.POSTGRES_URL) {
 const client = postgres(process.env.POSTGRES_URL);
 const db = drizzle(client);
 
-
 export async function transferChatOwnership(
   chatId: string,
   oldUserId: string, // This is the guestUserId
@@ -53,7 +52,9 @@ export async function transferChatOwnership(
 ) {
   try {
     if (!chatId || !oldUserId || !newUserId || oldUserId === newUserId) {
-      console.warn(`Invalid parameters for chat transfer: chatId=${chatId}, oldUserId=${oldUserId}, newUserId=${newUserId}`);
+      console.warn(
+        `Invalid parameters for chat transfer: chatId=${chatId}, oldUserId=${oldUserId}, newUserId=${newUserId}`,
+      );
       return null;
     }
 
@@ -70,7 +71,9 @@ export async function transferChatOwnership(
     }
 
     if (chatToTransfer.currentUserId !== oldUserId) {
-      console.warn(`Chat transfer: Chat ${chatId} belongs to user ${chatToTransfer.currentUserId}, not guest ${oldUserId}. Cannot transfer.`);
+      console.warn(
+        `Chat transfer: Chat ${chatId} belongs to user ${chatToTransfer.currentUserId}, not guest ${oldUserId}. Cannot transfer.`,
+      );
       return null;
     }
 
@@ -79,16 +82,26 @@ export async function transferChatOwnership(
       .set({ userId: newUserId })
       .where(and(eq(chat.id, chatId), eq(chat.userId, oldUserId))) // Double-check ownership during update
       .returning();
-    
+
     if (updatedChat) {
-        console.log(`Successfully transferred ownership of chat ${chatId} from guest ${oldUserId} to user ${newUserId}`);
+      console.log(
+        `Successfully transferred ownership of chat ${chatId} from guest ${oldUserId} to user ${newUserId}`,
+      );
     } else {
-        console.warn(`Failed to transfer ownership of chat ${chatId} from guest ${oldUserId} to user ${newUserId}. Update returned no rows.`);
+      console.warn(
+        `Failed to transfer ownership of chat ${chatId} from guest ${oldUserId} to user ${newUserId}. Update returned no rows.`,
+      );
     }
     return updatedChat || null;
   } catch (error) {
-    console.error(`Error during transferChatOwnership for chat ${chatId}:`, error);
-    throw new ChatSDKError('bad_request:database', 'Failed to transfer chat ownership due to a database error.');
+    console.error(
+      `Error during transferChatOwnership for chat ${chatId}:`,
+      error,
+    );
+    throw new ChatSDKError(
+      'bad_request:database',
+      'Failed to transfer chat ownership due to a database error.',
+    );
   }
 }
 
@@ -104,7 +117,10 @@ export async function getUser(email: string): Promise<Array<User>> {
   }
 }
 
-export async function createUser(email: string, password: string): Promise<User> {
+export async function createUser(
+  email: string,
+  password: string,
+): Promise<User> {
   const hashedPassword = generateHashedPassword(password);
 
   try {
@@ -113,7 +129,7 @@ export async function createUser(email: string, password: string): Promise<User>
       .values({ email, password: hashedPassword, type: 'regular' })
       .returning();
     if (!createdUser) {
-        throw new Error('User creation failed to return the created user.');
+      throw new Error('User creation failed to return the created user.');
     }
     return createdUser;
   } catch (error) {
@@ -122,7 +138,9 @@ export async function createUser(email: string, password: string): Promise<User>
   }
 }
 
-export async function createGuestUser(): Promise<Array<Pick<User, 'id' | 'email'>>> {
+export async function createGuestUser(): Promise<
+  Array<Pick<User, 'id' | 'email'>>
+> {
   const email = `guest-${Date.now()}`;
   const password = generateHashedPassword(generateUUID());
 
@@ -144,7 +162,11 @@ export async function createGuestUser(): Promise<Array<Pick<User, 'id' | 'email'
 
 export async function getUserById(id: string): Promise<User | null> {
   try {
-    const [foundUser] = await db.select().from(user).where(eq(user.id, id)).limit(1);
+    const [foundUser] = await db
+      .select()
+      .from(user)
+      .where(eq(user.id, id))
+      .limit(1);
     return foundUser ?? null;
   } catch (error) {
     throw new ChatSDKError('bad_request:database', 'Failed to get user by id');
@@ -156,11 +178,13 @@ export async function saveChat({
   userId,
   title,
   visibility,
+  modelId,
 }: {
   id: string;
   userId: string;
   title: string;
   visibility: VisibilityType;
+  modelId: string;
 }) {
   try {
     return await db.insert(chat).values({
@@ -169,9 +193,10 @@ export async function saveChat({
       userId,
       title,
       visibility,
+      modelId,
     });
   } catch (error) {
-    console.error("Error saving chat:", error);
+    console.error('Error saving chat:', error);
     throw new ChatSDKError('bad_request:database', 'Failed to save chat');
   }
 }
@@ -608,7 +633,8 @@ export async function getStreamIdsByChatId({ chatId }: { chatId: string }) {
       'Failed to get stream ids by chat id',
     );
   }
-}export async function saveUserMessageWithLimit({
+}
+export async function saveUserMessageWithLimit({
   userId,
   chatId,
   messageId,
@@ -679,10 +705,7 @@ export async function addUserModel({
         set: { expiresAt, canceled: false },
       });
   } catch (error) {
-    throw new ChatSDKError(
-      'bad_request:database',
-      'Failed to add user model',
-    );
+    throw new ChatSDKError('bad_request:database', 'Failed to add user model');
   }
 }
 
@@ -694,7 +717,10 @@ export async function getUserModelIds({ userId }: { userId: string }) {
       .where(
         and(
           eq(userModel.userId, userId),
-          or(eq(userModel.canceled, false), gt(userModel.expiresAt, new Date())),
+          or(
+            eq(userModel.canceled, false),
+            gt(userModel.expiresAt, new Date()),
+          ),
           or(isNull(userModel.expiresAt), gt(userModel.expiresAt, new Date())),
         ),
       );
@@ -753,22 +779,28 @@ export async function getUserTypeById({ userId }: { userId: string }) {
         .where(
           and(
             eq(userModel.userId, userId),
-            or(eq(userModel.canceled, false), gt(userModel.expiresAt, new Date())),
-            or(isNull(userModel.expiresAt), gt(userModel.expiresAt, new Date())),
+            or(
+              eq(userModel.canceled, false),
+              gt(userModel.expiresAt, new Date()),
+            ),
+            or(
+              isNull(userModel.expiresAt),
+              gt(userModel.expiresAt, new Date()),
+            ),
           ),
         )
         .limit(1);
       if (active.length === 0) {
-        await db.update(user).set({ type: 'regular' }).where(eq(user.id, userId));
+        await db
+          .update(user)
+          .set({ type: 'regular' })
+          .where(eq(user.id, userId));
         currentType = 'regular';
       }
     }
 
     return currentType;
   } catch (error) {
-    throw new ChatSDKError(
-      'bad_request:database',
-      'Failed to get user type',
-    );
+    throw new ChatSDKError('bad_request:database', 'Failed to get user type');
   }
 }

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -34,6 +34,7 @@ export const chat = pgTable('Chat', {
   visibility: varchar('visibility', { enum: ['public', 'private'] })
     .notNull()
     .default('private'),
+  modelId: varchar('modelId', { length: 64 }).notNull().default('chat-model'),
 });
 
 export type Chat = InferSelectModel<typeof chat>;


### PR DESCRIPTION
## Summary
- store the selected model on each chat
- start a new chat when switching models in the UI
- disable chats that use a model no longer available to the user
- document chat model behaviour
- database migration for chat model column
- allow premium users to use the free model for old chats

## Testing
- `pnpm lint`
- `pnpm test` *(fails: tests require environment setup)*

------
https://chatgpt.com/codex/tasks/task_e_684bff6a8590832ab20e1eb6eb738462