### PR TITLE
Fix guest limit and subscription model access

### DIFF
--- a/app/(chat)/chat/[id]/page.tsx
+++ b/app/(chat)/chat/[id]/page.tsx
@@ -80,7 +80,7 @@ export default async function Page({
   const userModels = session.user.models ?? [];
   const baseModels =
     entitlementsByUserType[session.user.type].availableChatModelIds;
-  const availableModels = userModels.length > 0 ? userModels : baseModels;
+  const availableModels = Array.from(new Set([...baseModels, ...userModels]));
   const isModelAvailable = availableModels.includes(chat.modelId);
 
   const chatComponentProps = {

--- a/components/model-selector.tsx
+++ b/components/model-selector.tsx
@@ -32,7 +32,9 @@ export function ModelSelector({
   const userType = session.user.type;
   const userModels = session.user.models ?? [];
   const baseModels = entitlementsByUserType[userType].availableChatModelIds;
-  const availableChatModelIds = userModels.length > 0 ? userModels : baseModels;
+  const availableChatModelIds = Array.from(
+    new Set([...baseModels, ...userModels]),
+  );
 
   const availableChatModels = chatModels.filter((chatModel) =>
     availableChatModelIds.includes(chatModel.id),

--- a/lib/ai/entitlements.ts
+++ b/lib/ai/entitlements.ts
@@ -25,17 +25,17 @@ export const entitlementsByUserType: Record<UserType, Entitlements> = {
 
   basis: {
     maxMessagesPerDay: Number.MAX_SAFE_INTEGER,
-    availableChatModelIds: ['basis-model'],
+    availableChatModelIds: ['basis-model', 'chat-model'],
   },
 
   plus: {
     maxMessagesPerDay: Number.MAX_SAFE_INTEGER,
-    availableChatModelIds: ['plus-model'],
+    availableChatModelIds: ['plus-model', 'chat-model'],
   },
 
   top: {
     maxMessagesPerDay: Number.MAX_SAFE_INTEGER,
-    availableChatModelIds: ['top-model'],
+    availableChatModelIds: ['top-model', 'chat-model'],
   },
 
   /*

--- a/lib/db/queries.ts
+++ b/lib/db/queries.ts
@@ -772,7 +772,11 @@ export async function getUserTypeById({ userId }: { userId: string }) {
       .where(eq(user.id, userId));
     let currentType: UserType = (row?.type as UserType) ?? 'regular';
 
-    if (currentType !== 'regular') {
+    if (
+      currentType === 'basis' ||
+      currentType === 'plus' ||
+      currentType === 'top'
+    ) {
       const active = await db
         .select({ modelId: userModel.modelId })
         .from(userModel)


### PR DESCRIPTION
## Summary
- let paid users also select the free `chat-model`
- preserve guest account type when checking subscriptions
- ensure free model always visible for paid accounts

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Playwright browsers missing)*

------
https://chatgpt.com/codex/tasks/task_e_684c0c902078832ab7c695404dcc9f9c