### PR TITLE
Update default chat suggestions

### DIFF
--- a/components/suggested-actions.tsx
+++ b/components/suggested-actions.tsx
@@ -3,6 +3,7 @@
 import { motion } from 'framer-motion';
 import { Button } from './ui/button';
 import { memo } from 'react';
+import { useLanguage } from './language-provider';
 import type { UseChatHelpers } from '@ai-sdk/react';
 import type { VisibilityType } from './visibility-selector';
 
@@ -17,28 +18,54 @@ function PureSuggestedActions({
   append,
   selectedVisibilityType,
 }: SuggestedActionsProps) {
-  const suggestedActions = [
-    {
-      title: 'What are the advantages',
-      label: 'of using Next.js?',
-      action: 'What are the advantages of using Next.js?',
-    },
-    {
-      title: 'Write code to',
-      label: `demonstrate djikstra's algorithm`,
-      action: `Write code to demonstrate djikstra's algorithm`,
-    },
-    {
-      title: 'Help me write an essay',
-      label: `about silicon valley`,
-      action: `Help me write an essay about silicon valley`,
-    },
-    {
-      title: 'What is the weather',
-      label: 'in San Francisco?',
-      action: 'What is the weather in San Francisco?',
-    },
-  ];
+  const { lang } = useLanguage();
+
+  const suggestedActions =
+    lang === 'nl'
+      ? [
+          {
+            title: 'Vertel mij een feitje',
+            label: 'over Nederland',
+            action: 'Vertel mij een feitje over Nederland',
+          },
+          {
+            title: 'Waarom is de Nederlandse',
+            label: 'vlag rood, wit en blauw?',
+            action: 'Waarom is de Nederlandse vlag rood, wit en blauw?',
+          },
+          {
+            title: 'Wat is het weer',
+            label: 'in Amsterdam vandaag?',
+            action: 'Wat is het weer in Amsterdam vandaag?',
+          },
+          {
+            title: 'Schrijf een gedicht',
+            label: 'over een koe',
+            action: 'Schrijf een gedicht over een koe',
+          },
+        ]
+      : [
+          {
+            title: 'Tell me a fact',
+            label: 'about the Netherlands',
+            action: 'Tell me a fact about the Netherlands',
+          },
+          {
+            title: 'Why is the Dutch flag',
+            label: 'red, white, and blue?',
+            action: 'Why is the Dutch flag red, white, and blue?',
+          },
+          {
+            title: "What's the weather",
+            label: 'in Amsterdam today?',
+            action: "What's the weather in Amsterdam today?",
+          },
+          {
+            title: 'Write a poem',
+            label: 'about a cow',
+            action: 'Write a poem about a cow',
+          },
+        ];
 
   return (
     <div

--- a/tests/e2e/chat.test.ts
+++ b/tests/e2e/chat.test.ts
@@ -32,7 +32,7 @@ test.describe('Chat activity', () => {
 
     const assistantMessage = await chatPage.getRecentAssistantMessage();
     expect(assistantMessage.content).toContain(
-      'With Next.js, you can ship fast!',
+      'The Netherlands is famous for its windmills!',
     );
   });
 

--- a/tests/pages/chat.ts
+++ b/tests/pages/chat.ts
@@ -64,7 +64,7 @@ export class ChatPage {
 
   async sendUserMessageFromSuggestion() {
     await this.page
-      .getByRole('button', { name: 'What are the advantages of' })
+      .getByRole('button', { name: 'Tell me a fact about' })
       .click();
   }
 

--- a/tests/prompts/basic.ts
+++ b/tests/prompts/basic.ts
@@ -16,7 +16,7 @@ export const TEST_PROMPTS: Record<string, CoreMessage> = {
   USER_NEXTJS: {
     role: 'user',
     content: [
-      { type: 'text', text: 'What are the advantages of using Next.js?' },
+      { type: 'text', text: 'Tell me a fact about the Netherlands' },
     ],
   },
   USER_IMAGE_ATTACHMENT: {

--- a/tests/prompts/utils.ts
+++ b/tests/prompts/utils.ts
@@ -125,7 +125,7 @@ export const getResponseChunksByPrompt = (
     ];
   } else if (compareMessages(recentMessage, TEST_PROMPTS.USER_NEXTJS)) {
     return [
-      ...textToDeltas('With Next.js, you can ship fast!'),
+      ...textToDeltas('The Netherlands is famous for its windmills!'),
 
       {
         type: 'finish',


### PR DESCRIPTION
## Summary
- show language-specific default questions in SuggestedActions
- update tests for new prompts and expected text

## Testing
- `pnpm test` *(fails: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1161/chrome-linux/headless_shell)*
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_684c1a0bfb74832a98803454c442f57e