### PR TITLE
[ui]: improve model lock indication

### DIFF
--- a/components/model-selector.tsx
+++ b/components/model-selector.tsx
@@ -106,7 +106,7 @@ export function ModelSelector({
                 type="button"
                 className={cn(
                   'gap-4 group/item flex flex-row justify-between items-center w-full',
-                  !owned && 'opacity-70',
+                  owned ? 'font-medium' : 'opacity-50 text-muted-foreground',
                 )}
               >
                 <div className="flex flex-col gap-1 items-start">
@@ -116,7 +116,7 @@ export function ModelSelector({
                   </div>
                 </div>
 
-                <div className="text-foreground dark:text-foreground opacity-0 group-data-[active=true]/item:opacity-100">
+                <div className="text-foreground dark:text-foreground">
                   {owned ? <CheckCircleFillIcon /> : <LockIcon />}
                 </div>
               </button>


### PR DESCRIPTION
## Summary
- highlight owned models in the selector
- dim locked models and always show lock icon

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Error occurred while executing a database query)*

------
https://chatgpt.com/codex/tasks/task_e_68752e57baa0832a91a8688940090e51