### PR TITLE
fix: allow guest intro chat redirect

### DIFF
--- a/app/(chat)/introduction/page.tsx
+++ b/app/(chat)/introduction/page.tsx
@@ -1,0 +1,72 @@
+import { Chat } from '@/components/chat';
+import { DEFAULT_CHAT_MODEL } from '@/lib/ai/models';
+import { generateUUID } from '@/lib/utils';
+import { auth } from '@/app/(auth)/auth';
+import { redirect } from 'next/navigation';
+
+export default async function Page() {
+  const session = await auth();
+  if (!session) {
+    redirect('/api/auth/guest?redirectUrl=/introduction');
+  }
+  if (session.user.type !== 'guest') {
+    redirect('/');
+  }
+
+  const initialMessages = [
+    {
+      id: generateUUID(),
+      role: 'user' as const,
+      content: 'What are your capabilities?',
+      parts: [{ type: 'text', text: 'What are your capabilities?' }],
+      createdAt: new Date(),
+    },
+    {
+      id: generateUUID(),
+      role: 'assistant' as const,
+      content:
+        'I am a demo assistant that can answer questions, summarize information and help with simple tasks.',
+      parts: [
+        {
+          type: 'text',
+          text: 'I am a demo assistant that can answer questions, summarize information and help with simple tasks.',
+        },
+      ],
+      createdAt: new Date(),
+    },
+    {
+      id: generateUUID(),
+      role: 'user' as const,
+      content: 'Could you tell me something about NLmodel?',
+      parts: [
+        { type: 'text', text: 'Could you tell me something about NLmodel?' },
+      ],
+      createdAt: new Date(),
+    },
+    {
+      id: generateUUID(),
+      role: 'assistant' as const,
+      content:
+        'NL model is a dutch company specialised in AI, offering both consumer and enterprise integrations for the dutch AI market.',
+      parts: [
+        {
+          type: 'text',
+          text: 'NL model is a dutch company specialised in AI, offering both consumer and enterprise integrations for the dutch AI market.',
+        },
+      ],
+      createdAt: new Date(),
+    },
+  ];
+
+  return (
+    <Chat
+      id="introduction"
+      initialMessages={initialMessages}
+      initialChatModel={DEFAULT_CHAT_MODEL}
+      initialVisibilityType="public"
+      isReadonly={true}
+      session={session}
+      autoResume={false}
+    />
+  );
+}

--- a/components/sidebar-history.tsx
+++ b/components/sidebar-history.tsx
@@ -20,6 +20,8 @@ import {
   SidebarGroup,
   SidebarGroupContent,
   SidebarMenu,
+  SidebarMenuItem,
+  SidebarMenuButton,
   useSidebar,
 } from '@/components/ui/sidebar';
 import type { Chat } from '@/lib/db/schema';
@@ -28,6 +30,7 @@ import { ChatItem } from './sidebar-history-item';
 import useSWRInfinite from 'swr/infinite';
 import { LoaderIcon } from './icons';
 import { useTranslation } from '@/lib/i18n';
+import Link from 'next/link';
 
 type GroupedChats = {
   today: Chat[];
@@ -154,7 +157,16 @@ export function SidebarHistory({ user }: { user: User | undefined }) {
     return (
       <SidebarGroup>
         <SidebarGroupContent>
-          <div className="px-2 text-zinc-500 w-full flex flex-row justify-center items-center text-sm gap-2">
+          <SidebarMenu>
+            <SidebarMenuItem>
+              <SidebarMenuButton asChild isActive={false}>
+                <Link href="/introduction" onClick={() => setOpenMobile(false)}>
+                  <span>{t('introductionChatTitle')}</span>
+                </Link>
+              </SidebarMenuButton>
+            </SidebarMenuItem>
+          </SidebarMenu>
+          <div className="px-2 text-zinc-500 w-full flex flex-row justify-center items-center text-sm gap-2 mt-2">
             {t('loginHistoryNotice')}
           </div>
         </SidebarGroupContent>

--- a/lib/i18n.tsx
+++ b/lib/i18n.tsx
@@ -103,9 +103,12 @@ export const translations = {
     basisModelName: 'Basic model',
     basisModelDescription: 'The fast and reliable model. Unlimited access.',
     plusModelName: 'Plus model',
-    plusModelDescription: 'Very good model capable of most tasks. Unlimited access.',
+    plusModelDescription:
+      'Very good model capable of most tasks. Unlimited access.',
     topModelName: 'Top model',
-    topModelDescription: 'State of the art model capable of everything. Unlimited access.',
+    topModelDescription:
+      'State of the art model capable of everything. Unlimited access.',
+    introductionChatTitle: 'Introduction chat',
   },
   nl: {
     newChat: 'Nieuw gesprek',
@@ -207,11 +210,15 @@ export const translations = {
     reasoningModelName: 'Redeneermodel',
     reasoningModelDescription: 'Gebruikt geavanceerde redenering',
     basisModelName: 'Basis model',
-    basisModelDescription: 'Het snelle en betrouwbare model. Onbeperkte toegang.',
+    basisModelDescription:
+      'Het snelle en betrouwbare model. Onbeperkte toegang.',
     plusModelName: 'Plus model',
-    plusModelDescription: 'Zeer goed model dat de meeste taken aankan. Onbeperkte toegang.',
+    plusModelDescription:
+      'Zeer goed model dat de meeste taken aankan. Onbeperkte toegang.',
     topModelName: 'Top model',
-    topModelDescription: 'State-of-the-art model dat alles aankan. Onbeperkte toegang.',
+    topModelDescription:
+      'State-of-the-art model dat alles aankan. Onbeperkte toegang.',
+    introductionChatTitle: 'Introductiechat',
   },
 } as const;
 


### PR DESCRIPTION
## Summary
- fix guest introduction page redirect to return to introduction chat after guest login

## Testing
- `pnpm lint`
- `pnpm test` *(fails: CallbackRouteError when creating guest user)*

------
https://chatgpt.com/codex/tasks/task_e_68753a4c4934832aa57d7deaa9902b48