### PR TITLE
[fix]: differentiate owned vs selected model icon

### DIFF
--- a/components/model-selector.tsx
+++ b/components/model-selector.tsx
@@ -13,6 +13,7 @@ import { useTranslation } from '@/lib/i18n';
 import { cn } from '@/lib/utils';
 
 import { CheckCircleFillIcon, ChevronDownIcon, LockIcon } from './icons';
+import { Check } from 'lucide-react';
 import { entitlementsByUserType } from '@/lib/ai/entitlements';
 import type { Session } from 'next-auth';
 import { useLoginSignupPopup } from '@/hooks/use-login-signup-popup';
@@ -117,7 +118,15 @@ export function ModelSelector({
                 </div>
 
                 <div className="text-foreground dark:text-foreground">
-                  {owned ? <CheckCircleFillIcon /> : <LockIcon />}
+                  {owned ? (
+                    id === optimisticModelId ? (
+                      <CheckCircleFillIcon />
+                    ) : (
+                      <Check className="size-4 opacity-50" />
+                    )
+                  ) : (
+                    <LockIcon />
+                  )}
                 </div>
               </button>
             </DropdownMenuItem>


### PR DESCRIPTION
## Summary
- ensure model selector only shows the filled checkmark for the active model
- show a faded check for owned models

## Testing
- `pnpm lint`
- `pnpm test` *(fails: CallbackRouteError)*

------
https://chatgpt.com/codex/tasks/task_e_6876a0af0fac832abf232c9f97863e9a