### PR TITLE
[feat]: enhance agents page layout

### DIFF
--- a/app/(agents)/agents/page.tsx
+++ b/app/(agents)/agents/page.tsx
@@ -2,39 +2,42 @@
 
 import { AgentCard } from '@/components/agents/agent-card';
 import { useTranslation } from '@/lib/i18n';
-import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import { useSidebar } from '@/components/ui/sidebar';
+
+const RECENT = ['LUNA', 'MOGA'];
+const RECOMMENDED = ['LUNA', 'MOGA', 'RELA'];
 
 export default function AgentsPage() {
   const t = useTranslation();
+  useSidebar();
   return (
-    <div className="p-6 space-y-8">
-      <header className="space-y-2">
+    <div className="max-w-[1280px] mx-auto p-[clamp(1rem,4vw,3rem)] space-y-8">
+      <Input
+        disabled
+        placeholder={t('askAboutAgentsPlaceholder')}
+        className="rounded-[24px] h-14 shadow-inner"
+      />
+      <header className="space-y-2 text-center">
         <h1 className="text-4xl font-bold">{t('aiAgentsTitle')}</h1>
         <p className="text-muted-foreground">{t('aiAgentsSubtitle')}</p>
       </header>
 
       <section className="space-y-2">
         <h2 className="text-2xl font-semibold">{t('recentlyUsed')}</h2>
-        <div className="text-sm text-muted-foreground">
-          {t('startUsingAgents')}
-        </div>
-      </section>
-
-      <section className="space-y-2">
-        <h2 className="text-2xl font-semibold">{t('searchAgents')}</h2>
-        <div className="flex items-center gap-2">
-          <Input disabled placeholder={t('askAboutAgentsPlaceholder')} />
-          <Button disabled>{t('send')}</Button>
+        <div className="grid gap-4 md:grid-cols-2">
+          {RECENT.map((name) => (
+            <AgentCard key={name} name={name} />
+          ))}
         </div>
       </section>
 
       <section className="space-y-2">
         <h2 className="text-2xl font-semibold">{t('recommended')}</h2>
-        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
-          <AgentCard name="LUNA" />
-          <AgentCard name="MOGA" />
-          <AgentCard name="RELA" />
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+          {RECOMMENDED.map((name) => (
+            <AgentCard key={name} name={name} />
+          ))}
         </div>
       </section>
     </div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -58,6 +58,9 @@
         --sidebar-accent-foreground: 240 5.9% 10%;
         --sidebar-border: 220 13% 91%;
         --sidebar-ring: 217.2 91.2% 59.8%;
+        --brand-accent: #FFB98B;
+        --brand-beige: #F5EFEA;
+        --ink: #1D1D1F;
         --gap-user-to-assistant: 40px;
         --gap-assistant-to-user: 0px;
     }
@@ -95,6 +98,9 @@
         --sidebar-accent-foreground: 240 4.8% 95.9%;
         --sidebar-border: 240 3.7% 15.9%;
         --sidebar-ring: 217.2 91.2% 59.8%;
+        --brand-accent: #FFB98B;
+        --brand-beige: #F5EFEA;
+        --ink: #1D1D1F;
         --gap-user-to-assistant: 40px;
         --gap-assistant-to-user: 0px;
     }
@@ -134,6 +140,9 @@
         --sidebar-accent-foreground: 24 37% 8%;
         --sidebar-border: 30 10% 90%;
         --sidebar-ring: 25 90% 55%;
+        --brand-accent: #FFB98B;
+        --brand-beige: #F5EFEA;
+        --ink: #1D1D1F;
         --gap-user-to-assistant: 40px;
         --gap-assistant-to-user: 0px;
     }

--- a/components/agents/agent-card.tsx
+++ b/components/agents/agent-card.tsx
@@ -1,12 +1,20 @@
 import { motion } from 'framer-motion';
-import { Card } from '@/components/ui/card';
 
 export function AgentCard({ name }: { name: string }) {
   return (
-    <motion.div whileHover={{ scale: 1.05 }}>
-      <Card className="p-4 text-center cursor-pointer select-none">
-        {name}
-      </Card>
-    </motion.div>
+    <motion.button
+      whileHover={{ y: -4, scale: 1.015 }}
+      whileTap={{ scale: 0.98 }}
+      className="flex flex-row gap-5 p-[1.75rem_2rem] rounded-[24px] bg-white/12 backdrop-blur-[18px] backdrop-saturate-[180%] border border-white/28 transition-transform duration-150 ease-linear hover:shadow-lg"
+      style={{ WebkitTapHighlightColor: 'transparent' }}
+    >
+      <span className="flex items-center justify-center w-[72px] h-[72px] rounded-full bg-gradient-radial from-[#FFB98B] to-[#FFE3D2] text-2xl font-bold">
+        {name.charAt(0)}
+      </span>
+      <span className="text-left flex flex-col justify-center">
+        <h3 className="font-bold text-[clamp(1.1rem,0.9rem+0.6vw,1.35rem)]">{name}</h3>
+      </span>
+    </motion.button>
   );
 }
+

--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -5,6 +5,7 @@ import {
 } from 'ai';
 import { openai } from '@ai-sdk/openai'; // 👈 switched from xai
 import { createPartFromText } from '@google/genai';
+import type { GenerateContentParameters } from '@google/genai/dist/genai';
 import type {
   LanguageModelV1,
   LanguageModelV1CallOptions,
@@ -66,7 +67,7 @@ function geminiLanguageModel(useThinking: boolean): LanguageModelV1 {
           contents.push(message);
         }
       }
-      const params: Record<string, any> = {
+      const params: Omit<GenerateContentParameters, 'model'> = {
         contents,
         generationConfig: config,
         safetySettings: defaultSafety,
@@ -81,21 +82,22 @@ function geminiLanguageModel(useThinking: boolean): LanguageModelV1 {
           finishReason: 'stop',
           usage: { promptTokens: 0, completionTokens: 0 },
           rawCall: { rawPrompt: contents, rawSettings: config },
-        };
+        } as const;
       } catch (err) {
         console.error('Gemini request failed:', err);
         throw err;
       }
     },
     async doStream(options: LanguageModelV1CallOptions) {
-      const { text } = await this.doGenerate(options);
+      const result = await this.doGenerate(options);
+      const { text } = result;
       const stream = new ReadableStream<LanguageModelV1StreamPart>({
         start(controller) {
           if (text) controller.enqueue({ type: 'text-delta', textDelta: text });
           controller.close();
         },
       });
-      return { stream };
+      return { stream, ...result } as any;
     },
   };
 }

--- a/lib/db/queries.ts
+++ b/lib/db/queries.ts
@@ -38,6 +38,7 @@ import { generateUUID } from '../utils';
 import { generateHashedPassword } from './utils';
 import type { VisibilityType } from '@/components/visibility-selector';
 import { ChatSDKError } from '../errors';
+import type { UserType } from '../user-types';
 
 if (!process.env.POSTGRES_URL) {
   throw new Error('POSTGRES_URL is not defined');

--- a/tests/e2e/session.test.ts
+++ b/tests/e2e/session.test.ts
@@ -15,7 +15,7 @@ test.describe
         throw new Error('Failed to load page');
       }
 
-      let request = response.request();
+      let request: Request | null = response.request();
 
       const chain = [];
 
@@ -57,7 +57,7 @@ test.describe
         throw new Error('Failed to load page');
       }
 
-      let request = response.request();
+      let request: Request | null = response.request();
 
       const chain = [];
 


### PR DESCRIPTION
## Summary
- tweak theme variables with brand colors
- update AgentCard component style
- rework Agents page layout with dynamic cards
- adjust provider and queries types
- tweak e2e session tests

## Testing
- `pnpm lint`
- `pnpm tsc --noEmit` *(fails: Argument of type 'unknown' is not assignable ...)*

------
https://chatgpt.com/codex/tasks/task_e_68777c75c050832a88e3fada9e0cac67