### PR TITLE
feat: polish agents layout

### DIFF
--- a/app/(agents)/agents/page.tsx
+++ b/app/(agents)/agents/page.tsx
@@ -1,41 +1,73 @@
 'use client';
 
-import { AgentCard } from '@/components/agents/agent-card';
+import { AgentCard, type AgentCardProps } from '@/components/agents/agent-card';
 import { useTranslation } from '@/lib/i18n';
-import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import { Search } from 'lucide-react';
+import { motion } from 'framer-motion';
 
 export default function AgentsPage() {
   const t = useTranslation();
+
+  const recentlyUsed: AgentCardProps[] = [
+    { name: 'Luna', description: 'Creative writing assistant', avatar: 'https://avatar.vercel.sh/luna' },
+    { name: 'Moga', description: 'Math tutor bot', avatar: 'https://avatar.vercel.sh/moga' },
+  ];
+
+  const recommended: AgentCardProps[] = [
+    { name: 'Rela', description: 'Relationship advice', avatar: 'https://avatar.vercel.sh/rela' },
+    { name: 'Echo', description: 'Quick Q&A', avatar: 'https://avatar.vercel.sh/echo' },
+    { name: 'Beta', description: 'Beta features explorer', avatar: 'https://avatar.vercel.sh/beta' },
+  ];
+
+  const container = {
+    hidden: {},
+    show: { transition: { staggerChildren: 0.12 } },
+  };
+
   return (
-    <div className="p-6 space-y-8">
+    <div className="mx-auto max-w-[1280px] space-y-12 p-[clamp(1rem,4vw,3rem)]">
       <header className="space-y-2">
         <h1 className="text-4xl font-bold">{t('aiAgentsTitle')}</h1>
         <p className="text-muted-foreground">{t('aiAgentsSubtitle')}</p>
       </header>
 
-      <section className="space-y-2">
+      <section className="space-y-4">
         <h2 className="text-2xl font-semibold">{t('recentlyUsed')}</h2>
-        <div className="text-sm text-muted-foreground">
-          {t('startUsingAgents')}
-        </div>
+        <motion.div
+          variants={container}
+          initial="hidden"
+          whileInView="show"
+          viewport={{ once: true }}
+          className="grid gap-4 recent md:grid-cols-2"
+        >
+          {recentlyUsed.map((agent) => (
+            <AgentCard key={agent.name} {...agent} />
+          ))}
+        </motion.div>
       </section>
 
-      <section className="space-y-2">
+      <section className="space-y-4">
         <h2 className="text-2xl font-semibold">{t('searchAgents')}</h2>
-        <div className="flex items-center gap-2">
-          <Input disabled placeholder={t('askAboutAgentsPlaceholder')} />
-          <Button disabled>{t('send')}</Button>
+        <div className="relative">
+          <Search className="absolute left-4 top-1/2 -translate-y-1/2 size-5 opacity-70" />
+          <Input className="h-14 rounded-[24px] pl-10 shadow-inner" placeholder={t('askAboutAgentsPlaceholder')} disabled />
         </div>
       </section>
 
-      <section className="space-y-2">
+      <section className="space-y-4">
         <h2 className="text-2xl font-semibold">{t('recommended')}</h2>
-        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
-          <AgentCard name="LUNA" />
-          <AgentCard name="MOGA" />
-          <AgentCard name="RELA" />
-        </div>
+        <motion.div
+          variants={container}
+          initial="hidden"
+          whileInView="show"
+          viewport={{ once: true }}
+          className="grid gap-4 recommended"
+        >
+          {recommended.map((agent) => (
+            <AgentCard key={agent.name} {...agent} />
+          ))}
+        </motion.div>
       </section>
     </div>
   );

--- a/app/globals.css
+++ b/app/globals.css
@@ -58,6 +58,9 @@
         --sidebar-accent-foreground: 240 5.9% 10%;
         --sidebar-border: 220 13% 91%;
         --sidebar-ring: 217.2 91.2% 59.8%;
+        --brand-accent: #FFB98B;
+        --brand-beige: #F5EFEA;
+        --ink: #1D1D1F;
         --gap-user-to-assistant: 40px;
         --gap-assistant-to-user: 0px;
     }
@@ -95,6 +98,9 @@
         --sidebar-accent-foreground: 240 4.8% 95.9%;
         --sidebar-border: 240 3.7% 15.9%;
         --sidebar-ring: 217.2 91.2% 59.8%;
+        --brand-accent: #FFB98B;
+        --brand-beige: #F5EFEA;
+        --ink: #1D1D1F;
         --gap-user-to-assistant: 40px;
         --gap-assistant-to-user: 0px;
     }
@@ -134,6 +140,9 @@
         --sidebar-accent-foreground: 24 37% 8%;
         --sidebar-border: 30 10% 90%;
         --sidebar-ring: 25 90% 55%;
+        --brand-accent: #FFB98B;
+        --brand-beige: #F5EFEA;
+        --ink: #1D1D1F;
         --gap-user-to-assistant: 40px;
         --gap-assistant-to-user: 0px;
     }
@@ -276,5 +285,55 @@
     /* send message input background */
     .orange [data-testid="multimodal-input"] {
         background-color: #fcedde; /* lighter orange */
+    }
+
+    /* Ripple effect for buttons */
+    @keyframes ripple {
+        from {
+            transform: scale(0);
+            opacity: 0.3;
+        }
+        to {
+            transform: scale(4);
+            opacity: 0;
+        }
+    }
+
+    .ripple:after {
+        content: "";
+        position: absolute;
+        inset: 0;
+        border-radius: inherit;
+        background: white;
+        opacity: 0;
+    }
+
+    .ripple:active:after {
+        animation: ripple 400ms ease-out;
+    }
+
+    .recommended {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
+    }
+
+    @media (width <= 1024px) {
+        .recommended {
+            grid-template-columns: repeat(2, 1fr);
+        }
+    }
+
+    @media (width <= 768px) {
+        .recent,
+        .recommended {
+            grid-template-columns: 1fr;
+        }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+        * {
+            transition: none !important;
+            animation: none !important;
+        }
     }
 }

--- a/components/agents/agent-card.tsx
+++ b/components/agents/agent-card.tsx
@@ -1,12 +1,35 @@
 import { motion } from 'framer-motion';
-import { Card } from '@/components/ui/card';
+import Image from 'next/image';
 
-export function AgentCard({ name }: { name: string }) {
+export interface AgentCardProps {
+  name: string;
+  description: string;
+  avatar: string;
+}
+
+const cardVariants = {
+  initial: { opacity: 0, y: 20 },
+  animate: { opacity: 1, y: 0 },
+};
+
+export function AgentCard({ name, description, avatar }: AgentCardProps) {
   return (
-    <motion.div whileHover={{ scale: 1.05 }}>
-      <Card className="p-4 text-center cursor-pointer select-none">
-        {name}
-      </Card>
-    </motion.div>
+    <motion.button
+      variants={cardVariants}
+      whileHover={{ translateY: -4, scale: 1.015 }}
+      whileTap={{ scale: 0.98 }}
+      className="ripple relative flex items-start gap-5 rounded-[24px] border border-white/30 bg-white/10 px-[2rem] py-[1.75rem] backdrop-blur-[18px] backdrop-saturate-[180%] transition-transform shadow-sm hover:shadow-md focus:outline-none overflow-hidden"
+    >
+      <span
+        className="flex h-[72px] w-[72px] flex-shrink-0 items-center justify-center rounded-full"
+        style={{ background: 'radial-gradient(circle at 30% 30%, var(--brand-accent), #FFE3D2)' }}
+      >
+        <Image src={avatar} alt="" width={64} height={64} className="h-12 w-12 rounded-full object-cover" loading="lazy" />
+      </span>
+      <span className="text-left">
+        <h3 className="font-bold [font-size:clamp(1.1rem,0.9rem+0.6vw,1.35rem)]">{name}</h3>
+        <p className="[font-size:clamp(.85rem,.75rem+.4vw,1rem)] opacity-80">{description}</p>
+      </span>
+    </motion.button>
   );
 }

--- a/lib/db/queries.ts
+++ b/lib/db/queries.ts
@@ -38,6 +38,7 @@ import { generateUUID } from '../utils';
 import { generateHashedPassword } from './utils';
 import type { VisibilityType } from '@/components/visibility-selector';
 import { ChatSDKError } from '../errors';
+import type { UserType } from '../user-types';
 
 if (!process.env.POSTGRES_URL) {
   throw new Error('POSTGRES_URL is not defined');

--- a/tests/e2e/session.test.ts
+++ b/tests/e2e/session.test.ts
@@ -15,7 +15,7 @@ test.describe
         throw new Error('Failed to load page');
       }
 
-      let request = response.request();
+      let request: Request | null = response.request();
 
       const chain = [];
 
@@ -57,7 +57,7 @@ test.describe
         throw new Error('Failed to load page');
       }
 
-      let request = response.request();
+      let request: Request | null = response.request();
 
       const chain = [];
 


### PR DESCRIPTION
## Summary
- improve layout for Agents page using dynamic `AgentCard`
- add ripple and responsive grid utilities
- expose brand CSS tokens
- import missing type
- tweak test typings

## Testing
- `pnpm lint`
- `pnpm tsc --noEmit` *(fails: Property 'redirectedFrom' does not exist on type 'Request')*

------
https://chatgpt.com/codex/tasks/task_e_68777c75c050832a88e3fada9e0cac67