### PR TITLE
feat: implement global site header

### DIFF
--- a/app/(assistenten)/assistenten/page.tsx
+++ b/app/(assistenten)/assistenten/page.tsx
@@ -3,7 +3,6 @@
 import { AgentCard, type AgentCardProps } from '@/components/agents/agent-card';
 import { useTranslation } from '@/lib/i18n';
 import { SearchInput } from '@/components/search-input';
-import AssistentenHeader from '@/components/assistenten-header';
 import '../../../themes/assistenten.css';
 import { motion } from 'framer-motion';
 
@@ -28,7 +27,6 @@ export default function AssistentenPage() {
 
   return (
     <div className="mx-auto max-w-[1280px] p-[clamp(1rem,4vw,3rem)]">
-      <AssistentenHeader />
       <header className="hero">
         <h1>{t('aiAgentsTitle')}</h1>
         <p className="tagline">{t('aiAgentsSubtitle')}</p>

--- a/app/(assistenten)/layout.tsx
+++ b/app/(assistenten)/layout.tsx
@@ -2,6 +2,7 @@ import { cookies } from 'next/headers';
 
 import { AppSidebar } from '@/components/app-sidebar';
 import { SidebarInset, SidebarProvider } from '@/components/ui/sidebar';
+import { SiteHeader } from '@/components/site-header';
 import { auth } from '../(auth)/auth';
 import Script from 'next/script';
 
@@ -23,6 +24,7 @@ export default async function Layout({
       />
       <SidebarProvider defaultOpen={!isCollapsed}>
         <AppSidebar user={session?.user} />
+        <SiteHeader />
         <SidebarInset>{children}</SidebarInset>
       </SidebarProvider>
     </>

--- a/app/(chat)/layout.tsx
+++ b/app/(chat)/layout.tsx
@@ -2,6 +2,7 @@ import { cookies } from 'next/headers';
 
 import { AppSidebar } from '@/components/app-sidebar';
 import { SidebarInset, SidebarProvider } from '@/components/ui/sidebar';
+import { SiteHeader } from '@/components/site-header';
 import { auth } from '../(auth)/auth';
 import Script from 'next/script';
 
@@ -24,6 +25,7 @@ export default async function Layout({
       />
       <SidebarProvider defaultOpen={!isCollapsed}>
         <AppSidebar user={session?.user} />
+        <SiteHeader />
         <SidebarInset>{children}</SidebarInset>
       </SidebarProvider>
     </>

--- a/app/globals.css
+++ b/app/globals.css
@@ -58,6 +58,7 @@
         --sidebar-accent-foreground: 240 5.9% 10%;
         --sidebar-border: 220 13% 91%;
         --sidebar-ring: 217.2 91.2% 59.8%;
+        --header-height: 56px;
         --brand-accent: #FFB98B;
         --brand-beige: #F5EFEA;
         --ink: #1D1D1F;
@@ -98,6 +99,7 @@
         --sidebar-accent-foreground: 240 4.8% 95.9%;
         --sidebar-border: 240 3.7% 15.9%;
         --sidebar-ring: 217.2 91.2% 59.8%;
+        --header-height: 56px;
         --brand-accent: #FFB98B;
         --brand-beige: #F5EFEA;
         --ink: #1D1D1F;
@@ -140,6 +142,7 @@
         --sidebar-accent-foreground: 24 37% 8%;
         --sidebar-border: 30 10% 90%;
         --sidebar-ring: 25 90% 55%;
+        --header-height: 56px;
         --brand-accent: #FFB98B;
         --brand-beige: #F5EFEA;
         --ink: #1D1D1F;

--- a/components/chat-header.tsx
+++ b/components/chat-header.tsx
@@ -6,6 +6,7 @@ import { useWindowSize } from 'usehooks-ts';
 
 import { ModelSelector } from '@/components/model-selector';
 import { SidebarToggle } from '@/components/sidebar-toggle';
+import { SiteHeader } from '@/components/site-header';
 import { Button } from '@/components/ui/button';
 import { PlusIcon, VercelIcon } from './icons';
 import { useSidebar } from './ui/sidebar';
@@ -43,7 +44,7 @@ function PureChatHeader({
   const { width: windowWidth } = useWindowSize();
 
   return (
-    <header className="flex sticky top-0 bg-background py-1.5 items-center px-2 md:px-2 gap-2 border-b"> {/* Added border-b for separation */}
+    <SiteHeader showInfo={false} showUpgrade={false}>
       <SidebarToggle />
 
       {(!open || windowWidth < 768) && (
@@ -114,7 +115,7 @@ function PureChatHeader({
           {t('deploy')}
         </Link>
       </Button>
-    </header>
+    </SiteHeader>
   );
 }
 

--- a/components/site-header.tsx
+++ b/components/site-header.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import Link from 'next/link';
+import { MenuIcon, InfoIcon } from '@/components/icons';
+import { useSidebar } from '@/components/ui/sidebar';
+import { cn } from '@/lib/utils';
+import { useTranslation } from '@/lib/i18n';
+
+export interface SiteHeaderProps {
+  showSidebarToggle?: boolean;
+  showInfo?: boolean;
+  showUpgrade?: boolean;
+  children?: React.ReactNode;
+}
+
+export function SiteHeader({
+  showSidebarToggle = true,
+  showInfo = true,
+  showUpgrade = true,
+  children,
+}: SiteHeaderProps) {
+  const { open: isSidebarOpen, toggleSidebar } = useSidebar();
+  const t = useTranslation();
+
+  return (
+    <header
+      className={cn(
+        'sticky top-0 left-0 z-[999] flex items-center border-b border-white/25 backdrop-blur-[14px] backdrop-saturate-[160%] px-4',
+        isSidebarOpen &&
+          'ml-[var(--sidebar-width)] w-[calc(100vw-var(--sidebar-width))] transition-[margin-left,width] duration-200 ease-out',
+      )}
+      style={{ background: 'rgba(255,255,255,.12)' }}
+    >
+      {showSidebarToggle && (
+        <button
+          type="button"
+          onClick={toggleSidebar}
+          aria-label={t('toggleSidebar')}
+          className="size-10 rounded-full border border-white/30 bg-white/20 backdrop-blur-sm backdrop-saturate-150 flex items-center justify-center hover:shadow-[0_0_8px_rgba(255,255,255,0.5)]"
+        >
+          <MenuIcon size={24} />
+        </button>
+      )}
+      {children}
+      <div className="flex-grow" />
+      {showInfo && (
+        <Link
+          href="/agentupdate"
+          rel="noopener noreferrer"
+          className="btn info flex items-center gap-2 rounded-full border border-white/40 backdrop-blur-sm px-3 h-9 text-sm transition-colors hover:bg-gradient-to-r hover:from-[var(--brand-accent)] hover:to-[#FFE3D2] hover:text-white"
+        >
+          <InfoIcon size={24} />
+          <span className="max-[420px]:sr-only">{t('agentUpdateInfo')}</span>
+        </Link>
+      )}
+      {showUpgrade && (
+        <Link
+          href="#"
+          className="btn upgrade ml-1 rounded-full bg-gradient-to-r from-[var(--brand-accent)] to-[#FFE3D2] text-white px-4 h-9 flex items-center shadow transition-shadow hover:shadow-[0_0_8px_rgba(255,255,255,0.5)]"
+        >
+          {t('upgradeModel')}
+        </Link>
+      )}
+    </header>
+  );
+}
+


### PR DESCRIPTION
## Summary
- create `SiteHeader` component
- add header to chat and assistenten layouts
- remove old per-page header usage
- integrate `SiteHeader` with `ChatHeader`
- define `--header-height` CSS variable for themes

## Testing
- `pnpm lint`
- `pnpm tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6877ac5bf2f8832a9268e4ccb158b0cf