### PR TITLE
feat: slide agents header with sidebar

### DIFF
--- a/app/(assistenten)/assistenten/page.tsx
+++ b/app/(assistenten)/assistenten/page.tsx
@@ -27,9 +27,10 @@ export default function AssistentenPage() {
   };
 
   return (
-    <div className="mx-auto max-w-[1280px] p-[clamp(1rem,4vw,3rem)]">
+    <>
       <AssistentenHeader />
-      <header className="hero">
+      <div className="mx-auto max-w-[1280px] p-[clamp(1rem,4vw,3rem)]">
+        <header className="hero">
         <h1>{t('aiAgentsTitle')}</h1>
         <p className="tagline">{t('aiAgentsSubtitle')}</p>
         <SearchInput placeholder={t('askAboutAgentsPlaceholder')} />
@@ -105,6 +106,7 @@ export default function AssistentenPage() {
           }
         }
       `}</style>
-    </div>
+        </div>
+      </>
   );
 }

--- a/components/assistenten-header.tsx
+++ b/components/assistenten-header.tsx
@@ -3,11 +3,12 @@ import { motion } from 'framer-motion';
 import Link from 'next/link';
 import { MenuIcon, InfoIcon } from '@/components/icons';
 import { useSidebar } from '@/components/ui/sidebar';
+import { cn } from '@/lib/utils';
 import { useEffect, useState } from 'react';
 import { useTranslation } from '@/lib/i18n';
 
 export default function AssistentenHeader() {
-  const { toggleSidebar } = useSidebar();
+  const { open: isSidebarOpen, toggleSidebar } = useSidebar();
   const t = useTranslation();
   const [hidden, setHidden] = useState(false);
   const [lastY, setLastY] = useState(0);
@@ -32,7 +33,11 @@ export default function AssistentenHeader() {
       initial={{ opacity: 0, y: -8 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.18, ease: 'easeOut' }}
-      className={`sticky top-0 z-[999] flex items-center px-4 md:px-6 h-14 md:h-16 border-b border-white/25 backdrop-blur-[14px] backdrop-saturate-[160%] bg-white/15 transition-transform duration-200 ease-out ${hidden ? '-translate-y-full' : ''}`}
+      className={cn(
+        'stickyHeader h-14 md:h-16 transition-transform duration-200 ease-out',
+        hidden && '-translate-y-full',
+        isSidebarOpen && 'withSidebar',
+      )}
       style={{ background: 'rgba(255,255,255,.15)' }}
     >
       <button

--- a/themes/assistenten.css
+++ b/themes/assistenten.css
@@ -1,3 +1,23 @@
 /* Assistenten theme tweaks */
 .hero .tagline{margin-bottom:3rem;}
 @media(max-width:768px){.hero .tagline{margin-bottom:2.25rem;}}
+
+.stickyHeader{
+  position:sticky;
+  top:0;
+  left:0;
+  width:100%;
+  display:flex;
+  align-items:center;
+  padding:0 1rem;
+  z-index:999;
+  backdrop-filter:blur(14px) saturate(160%);
+  background:rgba(255,255,255,.12);
+  border-bottom:1px solid rgba(255,255,255,.25);
+}
+
+.stickyHeader.withSidebar{
+  margin-left:var(--sidebar-width);
+  width:calc(100% - var(--sidebar-width));
+  transition:margin-left .2s ease,width .2s ease;
+}


### PR DESCRIPTION
## Summary
- make Agents page header full-width
- slide header with sidebar open state

## Testing
- `pnpm lint`
- `pnpm tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6877b1820c70832a84312c951eb2329a