### PR TITLE
feat: refine agents header

### DIFF
--- a/app/(assistenten)/assistenten/page.tsx
+++ b/app/(assistenten)/assistenten/page.tsx
@@ -27,8 +27,9 @@ export default function AssistentenPage() {
   };
 
   return (
-    <div className="mx-auto max-w-[1280px] p-[clamp(1rem,4vw,3rem)]">
+    <>
       <AssistentenHeader />
+      <div className="mx-auto max-w-[1280px] px-[clamp(1rem,4vw,3rem)] pb-[clamp(1rem,4vw,3rem)]">
       <header className="hero">
         <h1>{t('aiAgentsTitle')}</h1>
         <p className="tagline">{t('aiAgentsSubtitle')}</p>
@@ -105,6 +106,7 @@ export default function AssistentenPage() {
           }
         }
       `}</style>
-    </div>
+      </div>
+    </>
   );
 }

--- a/components/assistenten-header.tsx
+++ b/components/assistenten-header.tsx
@@ -5,9 +5,10 @@ import { MenuIcon, InfoIcon } from '@/components/icons';
 import { useSidebar } from '@/components/ui/sidebar';
 import { useEffect, useState } from 'react';
 import { useTranslation } from '@/lib/i18n';
+import clsx from 'clsx';
 
 export default function AssistentenHeader() {
-  const { toggleSidebar } = useSidebar();
+  const { toggleSidebar, open: isSidebarOpen } = useSidebar();
   const t = useTranslation();
   const [hidden, setHidden] = useState(false);
   const [lastY, setLastY] = useState(0);
@@ -32,19 +33,22 @@ export default function AssistentenHeader() {
       initial={{ opacity: 0, y: -8 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.18, ease: 'easeOut' }}
-      className={`sticky top-0 z-[999] flex items-center px-4 md:px-6 h-14 md:h-16 border-b border-white/25 backdrop-blur-[14px] backdrop-saturate-[160%] bg-white/15 transition-transform duration-200 ease-out ${hidden ? '-translate-y-full' : ''}`}
+      className={clsx(
+        'stickyHeader px-4 md:px-6 h-14 md:h-16 transition-transform duration-200 ease-out',
+        { withSidebar: isSidebarOpen },
+        hidden && '-translate-y-full',
+      )}
       style={{ background: 'rgba(255,255,255,.15)' }}
     >
       <button
         type="button"
         onClick={toggleSidebar}
         aria-label={t('toggleSidebar')}
-        className="sidebar-toggle md:hidden mr-3 size-10 rounded-full backdrop-blur-sm bg-white/20 flex items-center justify-center hover:shadow-[0_0_8px_rgba(255,255,255,0.5)]"
+        className="sidebar-toggle mr-3 size-10 rounded-full backdrop-blur-sm bg-white/20 flex items-center justify-center hover:shadow-[0_0_8px_rgba(255,255,255,0.5)]"
       >
         <MenuIcon size={28} />
       </button>
-      <div className="flex-1" />
-      <div className="actions flex items-center gap-2">
+      <div className="actions ml-auto flex items-center gap-2">
         <Link
           href="/agentupdate"
           className="btn info flex items-center gap-2 rounded-full border border-white/40 backdrop-blur-sm px-3 h-9 text-sm transition-colors hover:bg-gradient-to-r hover:from-[var(--brand-accent)] hover:to-[#FFE3D2] hover:text-white"

--- a/themes/assistenten.css
+++ b/themes/assistenten.css
@@ -1,3 +1,23 @@
 /* Assistenten theme tweaks */
 .hero .tagline{margin-bottom:3rem;}
 @media(max-width:768px){.hero .tagline{margin-bottom:2.25rem;}}
+
+.stickyHeader{
+  position:sticky;
+  top:0;
+  left:0;
+  display:flex;
+  align-items:center;
+  padding:0 1rem;
+  z-index:999;
+  margin:-0.5rem -0.5rem 0;
+  width:calc(100% + 1rem);
+  backdrop-filter:blur(14px) saturate(160%);
+  background:rgba(255,255,255,.12);
+  border-bottom:1px solid rgba(255,255,255,.25);
+}
+.stickyHeader.withSidebar{
+  margin-left:calc(var(--sidebar-width) - 0.5rem);
+  width:calc(100% - var(--sidebar-width) + 1rem);
+  transition:margin-left .2s ease,width .2s ease;
+}


### PR DESCRIPTION
## Summary
- ensure sticky header spans the viewport and shifts with sidebar
- show sidebar toggle in Assistenten header with frosted style

## Testing
- `pnpm lint`
- `pnpm tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6877b1820c70832a84312c951eb2329a