### PR TITLE
fix: polish agents header slide

### DIFF
--- a/app/(assistenten)/assistenten/page.tsx
+++ b/app/(assistenten)/assistenten/page.tsx
@@ -27,8 +27,9 @@ export default function AssistentenPage() {
   };
 
   return (
-    <div className="mx-auto max-w-[1280px] p-[clamp(1rem,4vw,3rem)]">
+    <>
       <AssistentenHeader />
+      <div className="mx-auto max-w-[1280px] px-[clamp(1rem,4vw,3rem)] pb-[clamp(1rem,4vw,3rem)]">
       <header className="hero">
         <h1>{t('aiAgentsTitle')}</h1>
         <p className="tagline">{t('aiAgentsSubtitle')}</p>
@@ -105,6 +106,7 @@ export default function AssistentenPage() {
           }
         }
       `}</style>
-    </div>
+      </div>
+    </>
   );
 }

--- a/components/assistenten-header.tsx
+++ b/components/assistenten-header.tsx
@@ -1,13 +1,14 @@
 'use client';
 import { motion } from 'framer-motion';
 import Link from 'next/link';
-import { MenuIcon, InfoIcon } from '@/components/icons';
+import { SidebarLeftIcon, InfoIcon } from '@/components/icons';
 import { useSidebar } from '@/components/ui/sidebar';
 import { useEffect, useState } from 'react';
 import { useTranslation } from '@/lib/i18n';
+import clsx from 'clsx';
 
 export default function AssistentenHeader() {
-  const { toggleSidebar } = useSidebar();
+  const { toggleSidebar, open: isSidebarOpen } = useSidebar();
   const t = useTranslation();
   const [hidden, setHidden] = useState(false);
   const [lastY, setLastY] = useState(0);
@@ -32,16 +33,20 @@ export default function AssistentenHeader() {
       initial={{ opacity: 0, y: -8 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.18, ease: 'easeOut' }}
-      className={`sticky top-0 z-[999] flex items-center px-4 md:px-6 h-14 md:h-16 border-b border-white/25 backdrop-blur-[14px] backdrop-saturate-[160%] bg-white/15 transition-transform duration-200 ease-out ${hidden ? '-translate-y-full' : ''}`}
+      className={clsx(
+        'stickyHeader px-4 md:px-6 h-14 md:h-16 transition-transform duration-200 ease-out',
+        { withSidebar: isSidebarOpen },
+        hidden && '-translate-y-full',
+      )}
       style={{ background: 'rgba(255,255,255,.15)' }}
     >
       <button
         type="button"
         onClick={toggleSidebar}
         aria-label={t('toggleSidebar')}
-        className="sidebar-toggle md:hidden mr-3 size-10 rounded-full backdrop-blur-sm bg-white/20 flex items-center justify-center hover:shadow-[0_0_8px_rgba(255,255,255,0.5)]"
+        className="assistenten-toggle md:hidden mr-3 size-10 rounded-full backdrop-blur-sm bg-white/20 flex items-center justify-center hover:shadow-[0_0_8px_rgba(255,255,255,0.5)]"
       >
-        <MenuIcon size={28} />
+        <SidebarLeftIcon size={24} />
       </button>
       <div className="flex-1" />
       <div className="actions flex items-center gap-2">

--- a/themes/assistenten.css
+++ b/themes/assistenten.css
@@ -1,3 +1,36 @@
 /* Assistenten theme tweaks */
 .hero .tagline{margin-bottom:3rem;}
 @media(max-width:768px){.hero .tagline{margin-bottom:2.25rem;}}
+
+.stickyHeader{
+  position:sticky;
+  top:0;
+  left:0;
+  right:0;
+  display:flex;
+  align-items:center;
+  padding:0 1rem;
+  z-index:999;
+  backdrop-filter:blur(14px) saturate(160%);
+  background:rgba(255,255,255,.12);
+  border-bottom:1px solid rgba(255,255,255,.25);
+  transition:left .2s ease;
+}
+.stickyHeader.withSidebar{
+  left:var(--sidebar-width);
+}
+
+.assistenten-toggle{
+  width:40px;
+  height:40px;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  border-radius:9999px;
+  backdrop-filter:blur(8px);
+  background:rgba(255,255,255,.2);
+  transition:box-shadow .2s ease;
+}
+.assistenten-toggle:hover{
+  box-shadow:0 0 8px rgba(255,255,255,.5);
+}


### PR DESCRIPTION
## Summary
- tweak Agents header CSS so it hugs the viewport and slides using `left`
- restyle sidebar toggle button and insert hamburger icon

## Testing
- `pnpm lint`
- `pnpm tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6877b1820c70832a84312c951eb2329a