### PR TITLE
feat: apply glass sidebar styling

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -58,7 +58,8 @@
         --sidebar-accent-foreground: 240 5.9% 10%;
         --sidebar-border: 220 13% 91%;
         --sidebar-ring: 217.2 91.2% 59.8%;
-        --brand-accent: #FFB98B;
+        --brand-accent: #FFE3D2;
+        --sidebar-glass-bg: rgba(255,255,255,.22);
         --brand-beige: #F5EFEA;
         --ink: #1D1D1F;
         --gap-user-to-assistant: 40px;
@@ -98,7 +99,8 @@
         --sidebar-accent-foreground: 240 4.8% 95.9%;
         --sidebar-border: 240 3.7% 15.9%;
         --sidebar-ring: 217.2 91.2% 59.8%;
-        --brand-accent: #FFB98B;
+        --brand-accent: #FFE3D2;
+        --sidebar-glass-bg: rgba(255,255,255,.22);
         --brand-beige: #F5EFEA;
         --ink: #1D1D1F;
         --gap-user-to-assistant: 40px;
@@ -140,7 +142,8 @@
         --sidebar-accent-foreground: 24 37% 8%;
         --sidebar-border: 30 10% 90%;
         --sidebar-ring: 25 90% 55%;
-        --brand-accent: #FFB98B;
+        --brand-accent: #FFE3D2;
+        --sidebar-glass-bg: rgba(255,255,255,.22);
         --brand-beige: #F5EFEA;
         --ink: #1D1D1F;
         --gap-user-to-assistant: 40px;

--- a/components/ui/sidebar.tsx
+++ b/components/ui/sidebar.tsx
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 import { Slot } from '@radix-ui/react-slot';
-import { VariantProps, cva } from 'class-variance-authority';
+import { type VariantProps, cva } from 'class-variance-authority';
 import { PanelLeft } from 'lucide-react';
 
 import { useIsMobile } from '@/hooks/use-mobile';
@@ -256,8 +256,15 @@ const Sidebar = React.forwardRef<
         >
           <div
             data-sidebar="sidebar"
-            className="flex h-full w-full flex-col bg-sidebar group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:border group-data-[variant=floating]:border-sidebar-border group-data-[variant=floating]:shadow"
+            className="relative flex h-full w-full flex-col bg-sidebar group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:border group-data-[variant=floating]:border-sidebar-border group-data-[variant=floating]:shadow"
+            style={{
+              background: 'var(--sidebar-glass-bg, hsl(var(--sidebar-background)))',
+              backdropFilter: 'blur(16px) saturate(160%)',
+              boxShadow: 'inset 0 0 0 1px rgba(255,255,255,0.2)',
+              border: '1px solid rgba(0,0,0,0.06)',
+            }}
           >
+            <span className="pointer-events-none absolute left-0 top-0 bottom-0 w-1 bg-[linear-gradient(180deg,#FFE8C2_0%,#FFE3D2_100%)]" />
             {children}
           </div>
         </div>
@@ -520,7 +527,7 @@ const SidebarMenuItem = React.forwardRef<
 SidebarMenuItem.displayName = 'SidebarMenuItem';
 
 const sidebarMenuButtonVariants = cva(
-  'peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm outline-none ring-sidebar-ring transition-[width,height,padding] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-[[data-sidebar=menu-action]]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:!size-8 group-data-[collapsible=icon]:!p-2 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0',
+  'peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm outline-none ring-sidebar-ring transition-[width,height,padding] hover:bg-[rgba(255,255,255,0.12)] hover:shadow-[0_2px_6px_rgba(0,0,0,0.05)] focus-visible:ring-2 active:shadow-[inset_0_1px_2px_rgba(0,0,0,0.1)] disabled:pointer-events-none disabled:opacity-50 group-has-[[data-sidebar=menu-action]]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-[linear-gradient(90deg,#FFDFB0_0%,#FFD4C1_100%)] data-[active=true]:font-medium group-data-[collapsible=icon]:!size-8 group-data-[collapsible=icon]:!p-2 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0 [&>svg]:text-ink/70 dark:[&>svg]:text-white/70 data-[active=true]:[&>svg]:text-ink dark:data-[active=true]:[&>svg]:text-white',
   {
     variants: {
       variant: {
@@ -730,8 +737,8 @@ const SidebarMenuSubButton = React.forwardRef<
       data-size={size}
       data-active={isActive}
       className={cn(
-        'flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 text-sidebar-foreground outline-none ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0 [&>svg]:text-sidebar-accent-foreground',
-        'data-[active=true]:bg-sidebar-accent data-[active=true]:text-sidebar-accent-foreground',
+        'flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 outline-none ring-sidebar-ring hover:bg-[rgba(255,255,255,0.12)] hover:shadow-[0_2px_6px_rgba(0,0,0,0.05)] focus-visible:ring-2 active:shadow-[inset_0_1px_2px_rgba(0,0,0,0.1)] disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0 [&>svg]:text-ink/70 dark:[&>svg]:text-white/70',
+        'data-[active=true]:bg-[linear-gradient(90deg,#FFDFB0_0%,#FFD4C1_100%)] data-[active=true]:text-ink dark:data-[active=true]:text-white',
         size === 'sm' && 'text-xs',
         size === 'md' && 'text-sm',
         'group-data-[collapsible=icon]:hidden',


### PR DESCRIPTION
## Summary
- update brand accent color and add sidebar glass bg variable
- apply frosted-glass design to sidebar container
- refresh menu hover/active styles with gradients

## Testing
- `pnpm lint`
- `pnpm tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6877c05efe94832abb5748673387d012