### PR TITLE
feat: apply glass sidebar styling

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -287,6 +287,26 @@
         background-color: #fcedde; /* lighter orange */
     }
 
+    /* glass effect for the sidebar */
+    [data-sidebar="sidebar"] {
+        @apply backdrop-blur-lg;
+    }
+
+    html.light [data-sidebar="sidebar"] {
+        background-color: hsl(var(--sidebar-background)/0.8);
+    }
+
+    html.dark [data-sidebar="sidebar"],
+    html.orange [data-sidebar="sidebar"] {
+        background-image: linear-gradient(
+            to bottom,
+            color-mix(in srgb, hsl(var(--sidebar-background)), white 0%),
+            color-mix(in srgb, hsl(var(--sidebar-background)), white 25%)
+        );
+        background-color: hsl(var(--sidebar-background)/0.85);
+    }
+
+
     /* Ripple effect for buttons */
     @keyframes ripple {
         from {

--- a/components/app-sidebar.tsx
+++ b/components/app-sidebar.tsx
@@ -51,7 +51,7 @@ export function AppSidebar({ user }: { user: User | undefined }) {
                 <Button
                   variant="ghost"
                   type="button"
-                  className="new-chat-button p-2 h-fit"
+                  className="new-chat-button p-2 h-10 w-10"
                   style={{ marginTop: '-60px' }}
                   onClick={() => {
                     setOpenMobile(false);
@@ -59,7 +59,7 @@ export function AppSidebar({ user }: { user: User | undefined }) {
                     router.refresh();
                   }}
                 >
-                  <PlusIcon />
+                  <PlusIcon size={20} />
                 </Button>
               </TooltipTrigger>
               <TooltipContent align="end">{t('newChat')}</TooltipContent>


### PR DESCRIPTION
## Summary
- add glass and gradient effect to sidebar across themes
- enlarge new chat button in sidebar

## Testing
- `pnpm lint`
- `pnpm tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6877c89bf9ec832abd7d222c399bed80