### PR TITLE
feat: add glass gradient sidebar

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -58,6 +58,7 @@
         --sidebar-accent-foreground: 240 5.9% 10%;
         --sidebar-border: 220 13% 91%;
         --sidebar-ring: 217.2 91.2% 59.8%;
+        --sidebar-background-light: 0 0% 98%;
         --brand-accent: #FFB98B;
         --brand-beige: #F5EFEA;
         --ink: #1D1D1F;
@@ -98,6 +99,7 @@
         --sidebar-accent-foreground: 240 4.8% 95.9%;
         --sidebar-border: 240 3.7% 15.9%;
         --sidebar-ring: 217.2 91.2% 59.8%;
+        --sidebar-background-light: 240 5.9% 20%;
         --brand-accent: #FFB98B;
         --brand-beige: #F5EFEA;
         --ink: #1D1D1F;
@@ -140,6 +142,7 @@
         --sidebar-accent-foreground: 24 37% 8%;
         --sidebar-border: 30 10% 90%;
         --sidebar-ring: 25 90% 55%;
+        --sidebar-background-light: 32 71% 98%;
         --brand-accent: #FFB98B;
         --brand-beige: #F5EFEA;
         --ink: #1D1D1F;

--- a/components/app-sidebar.tsx
+++ b/components/app-sidebar.tsx
@@ -51,7 +51,7 @@ export function AppSidebar({ user }: { user: User | undefined }) {
                 <Button
                   variant="ghost"
                   type="button"
-                  className="new-chat-button p-2 h-fit"
+                  className="new-chat-button p-2.5 h-fit"
                   style={{ marginTop: '-60px' }}
                   onClick={() => {
                     setOpenMobile(false);
@@ -59,7 +59,7 @@ export function AppSidebar({ user }: { user: User | undefined }) {
                     router.refresh();
                   }}
                 >
-                  <PlusIcon />
+                  <PlusIcon size={20} />
                 </Button>
               </TooltipTrigger>
               <TooltipContent align="end">{t('newChat')}</TooltipContent>

--- a/components/ui/sidebar.tsx
+++ b/components/ui/sidebar.tsx
@@ -256,7 +256,11 @@ const Sidebar = React.forwardRef<
         >
           <div
             data-sidebar="sidebar"
-            className="flex h-full w-full flex-col bg-sidebar group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:border group-data-[variant=floating]:border-sidebar-border group-data-[variant=floating]:shadow"
+            className="flex h-full w-full flex-col backdrop-blur-md backdrop-saturate-150 group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:border group-data-[variant=floating]:border-sidebar-border group-data-[variant=floating]:shadow"
+            style={{
+              background:
+                'linear-gradient(to bottom, hsl(var(--sidebar-background)), hsl(var(--sidebar-background-light)))',
+            }}
           >
             {children}
           </div>


### PR DESCRIPTION
## Summary
- give sidebar a gradient glass effect across all themes
- lighten dark and orange sidebars towards the bottom
- slightly enlarge the new-chat button

## Testing
- `pnpm lint`
- `pnpm tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6877c89bf9ec832abd7d222c399bed80