### PR TITLE
feat: redesign sidebar visuals

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -59,7 +59,7 @@
         --sidebar-border: 220 13% 91%;
         --sidebar-ring: 217.2 91.2% 59.8%;
         --brand-accent: #FFB98B;
-        --brand-beige: #F5EFEA;
+        --brand-beige: #fcf9f7;
         --ink: #1D1D1F;
         --gap-user-to-assistant: 40px;
         --gap-assistant-to-user: 0px;
@@ -285,6 +285,42 @@
     /* send message input background */
     .orange [data-testid="multimodal-input"] {
         background-color: #fcedde; /* lighter orange */
+    }
+
+    /* Sidebar redesign */
+    [data-sidebar="sidebar"] {
+        position: relative;
+        background: rgba(255,255,255,.18);
+        backdrop-filter: blur(18px) saturate(160%);
+        -webkit-backdrop-filter: blur(18px) saturate(160%);
+        box-shadow: inset 0 0 0 1px rgba(255,255,255,.12), 0 0 0 1px rgba(18,18,18,.06);
+    }
+
+    [data-sidebar="sidebar"]::before {
+        content: "";
+        position: absolute;
+        inset: 0;
+        pointer-events: none;
+        background: radial-gradient(circle at center, rgba(255,255,255,.05), transparent 70%);
+    }
+
+    [data-sidebar="sidebar"]::after {
+        content: "";
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        left: 0;
+        width: 6px;
+        pointer-events: none;
+        background: linear-gradient(90deg, #FFDEB7, #FFD4DB, #FFF6B7);
+        background-size: 200% 200%;
+        animation: sidebar-spine 30s linear infinite;
+    }
+
+    @keyframes sidebar-spine {
+        0% { background-position: 0% 50%; }
+        50% { background-position: 100% 50%; }
+        100% { background-position: 0% 50%; }
     }
 
     /* Ripple effect for buttons */

--- a/components/sidebar-history-item.tsx
+++ b/components/sidebar-history-item.tsx
@@ -2,7 +2,6 @@ import type { Chat } from '@/lib/db/schema';
 import {
   SidebarMenuAction,
   SidebarMenuButton,
-  SidebarMenuItem,
 } from './ui/sidebar';
 import Link from 'next/link';
 import {
@@ -24,6 +23,7 @@ import {
   TrashIcon,
 } from './icons';
 import { memo } from 'react';
+import { motion } from 'framer-motion';
 import { useChatVisibility } from '@/hooks/use-chat-visibility';
 import { useTranslation } from '@/lib/i18n';
 
@@ -32,11 +32,13 @@ const PureChatItem = ({
   isActive,
   onDelete,
   setOpenMobile,
+  index,
 }: {
   chat: Chat;
   isActive: boolean;
   onDelete: (chatId: string) => void;
   setOpenMobile: (open: boolean) => void;
+  index?: number;
 }) => {
   const { visibilityType, setVisibilityType } = useChatVisibility({
     chatId: chat.id,
@@ -45,7 +47,13 @@ const PureChatItem = ({
   const t = useTranslation();
 
   return (
-    <SidebarMenuItem>
+    <motion.li
+      data-sidebar="menu-item"
+      className="group/menu-item relative"
+      initial={{ opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ delay: index ? index * 0.08 : 0, duration: 0.3 }}
+    >
       <SidebarMenuButton asChild isActive={isActive}>
         <Link href={`/chat/${chat.id}`} onClick={() => setOpenMobile(false)}>
           <span>{chat.title}</span>
@@ -110,7 +118,7 @@ const PureChatItem = ({
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>
-    </SidebarMenuItem>
+    </motion.li>
   );
 };
 

--- a/components/sidebar-history.tsx
+++ b/components/sidebar-history.tsx
@@ -223,7 +223,7 @@ export function SidebarHistory({ user }: { user: User | undefined }) {
                         <div className="px-2 py-1 text-xs text-sidebar-foreground/50">
                           {t('today')}
                         </div>
-                        {groupedChats.today.map((chat) => (
+                        {groupedChats.today.map((chat, index) => (
                           <ChatItem
                             key={chat.id}
                             chat={chat}
@@ -233,6 +233,7 @@ export function SidebarHistory({ user }: { user: User | undefined }) {
                               setShowDeleteDialog(true);
                             }}
                             setOpenMobile={setOpenMobile}
+                            index={index}
                           />
                         ))}
                       </div>
@@ -243,7 +244,7 @@ export function SidebarHistory({ user }: { user: User | undefined }) {
                         <div className="px-2 py-1 text-xs text-sidebar-foreground/50">
                           {t('yesterday')}
                         </div>
-                        {groupedChats.yesterday.map((chat) => (
+                        {groupedChats.yesterday.map((chat, index) => (
                           <ChatItem
                             key={chat.id}
                             chat={chat}
@@ -253,6 +254,7 @@ export function SidebarHistory({ user }: { user: User | undefined }) {
                               setShowDeleteDialog(true);
                             }}
                             setOpenMobile={setOpenMobile}
+                            index={index}
                           />
                         ))}
                       </div>
@@ -263,7 +265,7 @@ export function SidebarHistory({ user }: { user: User | undefined }) {
                         <div className="px-2 py-1 text-xs text-sidebar-foreground/50">
                           {t('last7days')}
                         </div>
-                        {groupedChats.lastWeek.map((chat) => (
+                        {groupedChats.lastWeek.map((chat, index) => (
                           <ChatItem
                             key={chat.id}
                             chat={chat}
@@ -273,6 +275,7 @@ export function SidebarHistory({ user }: { user: User | undefined }) {
                               setShowDeleteDialog(true);
                             }}
                             setOpenMobile={setOpenMobile}
+                            index={index}
                           />
                         ))}
                       </div>
@@ -283,7 +286,7 @@ export function SidebarHistory({ user }: { user: User | undefined }) {
                         <div className="px-2 py-1 text-xs text-sidebar-foreground/50">
                           {t('last30days')}
                         </div>
-                        {groupedChats.lastMonth.map((chat) => (
+                        {groupedChats.lastMonth.map((chat, index) => (
                           <ChatItem
                             key={chat.id}
                             chat={chat}
@@ -293,6 +296,7 @@ export function SidebarHistory({ user }: { user: User | undefined }) {
                               setShowDeleteDialog(true);
                             }}
                             setOpenMobile={setOpenMobile}
+                            index={index}
                           />
                         ))}
                       </div>
@@ -303,7 +307,7 @@ export function SidebarHistory({ user }: { user: User | undefined }) {
                         <div className="px-2 py-1 text-xs text-sidebar-foreground/50">
                           {t('olderThanLastMonth')}
                         </div>
-                        {groupedChats.older.map((chat) => (
+                        {groupedChats.older.map((chat, index) => (
                           <ChatItem
                             key={chat.id}
                             chat={chat}
@@ -313,6 +317,7 @@ export function SidebarHistory({ user }: { user: User | undefined }) {
                               setShowDeleteDialog(true);
                             }}
                             setOpenMobile={setOpenMobile}
+                            index={index}
                           />
                         ))}
                       </div>

--- a/components/ui/sidebar.tsx
+++ b/components/ui/sidebar.tsx
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 import { Slot } from '@radix-ui/react-slot';
-import { VariantProps, cva } from 'class-variance-authority';
+import { type VariantProps, cva } from 'class-variance-authority';
 import { PanelLeft } from 'lucide-react';
 
 import { useIsMobile } from '@/hooks/use-mobile';
@@ -520,13 +520,13 @@ const SidebarMenuItem = React.forwardRef<
 SidebarMenuItem.displayName = 'SidebarMenuItem';
 
 const sidebarMenuButtonVariants = cva(
-  'peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm outline-none ring-sidebar-ring transition-[width,height,padding] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-[[data-sidebar=menu-action]]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:!size-8 group-data-[collapsible=icon]:!p-2 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0',
+  'ripple peer/menu-button relative flex w-full items-center gap-2 overflow-hidden rounded-full px-3 py-2 text-left text-sm font-medium tracking-[-0.015em] text-sidebar-foreground/70 outline-none ring-sidebar-ring transition-all hover:bg-white/10 hover:backdrop-blur-[8px] hover:[&>svg]:opacity-100 hover:text-sidebar-foreground/90 active:bg-gradient-to-r active:from-[#FFDEB7] active:to-[#FFD4DB] active:shadow-inner active:translate-y-[2px] disabled:pointer-events-none disabled:opacity-50 group-has-[[data-sidebar=menu-action]]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-gradient-to-r data-[active=true]:from-[#FFDEB7] data-[active=true]:to-[#FFD4DB] data-[active=true]:shadow-inner data-[active=true]:translate-y-[2px] data-[active=true]:text-sidebar-foreground data-[active=true][&>svg]:opacity-100 group-data-[collapsible=icon]:!size-8 group-data-[collapsible=icon]:!p-2 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0 [&>svg]:opacity-60',
   {
     variants: {
       variant: {
-        default: 'hover:bg-sidebar-accent hover:text-sidebar-accent-foreground',
+        default: '',
         outline:
-          'bg-background shadow-[0_0_0_1px_hsl(var(--sidebar-border))] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground hover:shadow-[0_0_0_1px_hsl(var(--sidebar-accent))]',
+          'bg-background shadow-[0_0_0_1px_hsl(var(--sidebar-border))]',
       },
       size: {
         default: 'h-8 text-sm',


### PR DESCRIPTION
## Summary
- tweak brand beige light value
- style sidebar with frosted glass and animated spine
- update sidebar menu button styling
- animate history items on reveal

## Testing
- `pnpm lint`
- `pnpm exec tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_6877cc34a83c832a8affc0cc5738b2d6