### PR TITLE
feat: refresh sidebar style

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -285,6 +285,19 @@
         border-color: hsl(var(--primary));
     }
 
+    [data-sidebar="sidebar"] {
+        border-color: hsl(var(--sidebar-border) / 0.5);
+        background: radial-gradient(120% 100% at 20% -40%, var(--brand-accent), transparent 70%), linear-gradient(to bottom, hsl(var(--sidebar-background) / 0.85), hsl(var(--sidebar-background-light) / 0.85));
+        backdrop-filter: blur(20px) saturate(160%);
+    }
+
+    [data-sidebar="sidebar"] .new-chat-button {
+        background-image: linear-gradient(90deg, var(--brand-accent), #FFE3D2);
+        color: hsl(var(--sidebar-primary-foreground));
+        box-shadow: 0 0 8px rgba(255, 255, 255, 0.25);
+        border-color: transparent;
+    }
+
     /* send message input background */
     .orange [data-testid="multimodal-input"] {
         background-color: #fcedde; /* lighter orange */

--- a/components/app-sidebar.tsx
+++ b/components/app-sidebar.tsx
@@ -51,7 +51,7 @@ export function AppSidebar({ user }: { user: User | undefined }) {
                 <Button
                   variant="ghost"
                   type="button"
-                  className="new-chat-button p-2.5 h-fit"
+                  className="ripple new-chat-button p-2.5 h-fit"
                   style={{ marginTop: '-60px' }}
                   onClick={() => {
                     setOpenMobile(false);

--- a/components/ui/sidebar.tsx
+++ b/components/ui/sidebar.tsx
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 import { Slot } from '@radix-ui/react-slot';
-import { VariantProps, cva } from 'class-variance-authority';
+import { type VariantProps, cva } from 'class-variance-authority';
 import { PanelLeft } from 'lucide-react';
 
 import { useIsMobile } from '@/hooks/use-mobile';
@@ -256,10 +256,10 @@ const Sidebar = React.forwardRef<
         >
           <div
             data-sidebar="sidebar"
-            className="flex h-full w-full flex-col backdrop-blur-md backdrop-saturate-150 group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:border group-data-[variant=floating]:border-sidebar-border group-data-[variant=floating]:shadow"
+            className="flex h-full w-full flex-col border border-sidebar-border/50 backdrop-blur-lg backdrop-saturate-[180%] group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:shadow-lg"
             style={{
               background:
-                'linear-gradient(to bottom, hsl(var(--sidebar-background)), hsl(var(--sidebar-background-light)))',
+                'radial-gradient(120% 100% at 20% -40%, var(--brand-accent), transparent 70%), linear-gradient(to bottom, hsl(var(--sidebar-background)/0.85), hsl(var(--sidebar-background-light)/0.85))',
             }}
           >
             {children}


### PR DESCRIPTION
## Summary
- style the sidebar with a glassy gradient look
- add ripple effect to the new chat button
- tweak CSS for sidebar elements

## Testing
- `pnpm lint`
- `pnpm tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6877cfc811e8832abfdff786e988fd6b