### PR TITLE
feat: add agent popup overlay

### DIFF
--- a/app/(assistenten)/assistenten/page.tsx
+++ b/app/(assistenten)/assistenten/page.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import { AgentCard, type AgentCardProps } from '@/components/agents/agent-card';
+import { AgentPopup } from '@/components/agents/agent-popup';
+import { useAgentPopup } from '@/hooks/use-agent-popup';
 import { useTranslation } from '@/lib/i18n';
 import { SearchInput } from '@/components/search-input';
 import AssistentenHeader from '@/components/assistenten-header';
@@ -9,6 +11,7 @@ import { motion } from 'framer-motion';
 
 export default function AssistentenPage() {
   const t = useTranslation();
+  const { openPopup } = useAgentPopup();
 
   const recentlyUsed: AgentCardProps[] = [
     { name: 'Luna', description: 'Creative writing assistant', avatar: 'https://avatar.vercel.sh/luna' },
@@ -46,7 +49,7 @@ export default function AssistentenPage() {
           className="grid gap-4 recent md:grid-cols-2"
         >
           {recentlyUsed.map((agent) => (
-            <AgentCard key={agent.name} {...agent} />
+            <AgentCard key={agent.name} {...agent} onClick={openPopup} />
           ))}
         </motion.div>
       </section>
@@ -62,7 +65,7 @@ export default function AssistentenPage() {
           className="grid gap-4 recommended"
         >
           {recommended.map((agent) => (
-            <AgentCard key={agent.name} {...agent} />
+            <AgentCard key={agent.name} {...agent} onClick={openPopup} />
           ))}
         </motion.div>
       </section>
@@ -107,6 +110,7 @@ export default function AssistentenPage() {
         }
       `}</style>
       </div>
+      <AgentPopup />
     </>
   );
 }

--- a/components/agents/agent-card.tsx
+++ b/components/agents/agent-card.tsx
@@ -5,6 +5,7 @@ export interface AgentCardProps {
   name: string;
   description: string;
   avatar: string;
+  onClick?: () => void;
 }
 
 const cardVariants = {
@@ -12,12 +13,13 @@ const cardVariants = {
   animate: { opacity: 1, y: 0 },
 };
 
-export function AgentCard({ name, description, avatar }: AgentCardProps) {
+export function AgentCard({ name, description, avatar, onClick }: AgentCardProps) {
   return (
     <motion.button
       variants={cardVariants}
       whileHover={{ translateY: -4, scale: 1.015 }}
       whileTap={{ scale: 0.98 }}
+      onClick={onClick}
       className="ripple relative flex items-start gap-5 rounded-[24px] border border-white/30 bg-white/10 px-[2rem] py-[1.75rem] backdrop-blur-[18px] backdrop-saturate-[180%] transition-transform shadow-sm hover:shadow-md focus:outline-none overflow-hidden"
     >
       <span

--- a/components/agents/agent-popup.tsx
+++ b/components/agents/agent-popup.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { Dialog, DialogContent, DialogOverlay } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { useAgentPopup } from '@/hooks/use-agent-popup';
+
+export function AgentPopup() {
+  const { isOpen, closePopup } = useAgentPopup();
+
+  if (!isOpen) return null;
+
+  return (
+    <Dialog open={isOpen} onOpenChange={closePopup}>
+      <DialogOverlay className="backdrop-blur-sm" />
+      <DialogContent className="bg-white/20 dark:bg-gray-800/20 border border-white/30 backdrop-blur-lg backdrop-saturate-150 max-w-[52rem] w-full p-6 rounded-2xl shadow-xl transition-transform hover:scale-[1.02]">
+        <div className="flex flex-col gap-6 min-h-[24rem]">
+          {/* Content goes here */}
+          <Button className="self-end mt-auto">Go to chat</Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/hooks/use-agent-popup.ts
+++ b/hooks/use-agent-popup.ts
@@ -1,0 +1,13 @@
+import { create } from 'zustand';
+
+interface AgentPopupState {
+  isOpen: boolean;
+  openPopup: () => void;
+  closePopup: () => void;
+}
+
+export const useAgentPopup = create<AgentPopupState>((set) => ({
+  isOpen: false,
+  openPopup: () => set({ isOpen: true }),
+  closePopup: () => set({ isOpen: false }),
+}));


### PR DESCRIPTION
## Summary
- trigger a glassy pop‑up when clicking an agent card
- create zustand store for opening and closing the pop‑up
- show overlay in the agents page

## Testing
- `pnpm lint`
- `pnpm tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_687811d09f6c832aa4bba0a19f40b09d