### PR TITLE
feat: add agent detail dialog

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -10,6 +10,7 @@ import './globals.css';
 import { SessionProvider } from 'next-auth/react';
 import { LoginSignupDialog } from '@/components/ui/login-signup-dialog';
 import { UpgradeDialog } from '@/components/ui/upgrade-dialog';
+import { AgentDialog } from '@/components/agents/agent-dialog';
 
 export const metadata: Metadata = {
   title: 'Next.js Chatbot Template',
@@ -99,6 +100,7 @@ export default async function RootLayout({
             {children}
             <LoginSignupDialog />
             <UpgradeDialog />
+            <AgentDialog />
           </SessionProvider>
         </ThemeProvider>
         </LanguageProvider>

--- a/components/agents/agent-card.tsx
+++ b/components/agents/agent-card.tsx
@@ -1,5 +1,6 @@
 import { motion } from 'framer-motion';
 import Image from 'next/image';
+import { useAgentPopup } from '@/hooks/use-agent-popup';
 
 export interface AgentCardProps {
   name: string;
@@ -13,12 +14,14 @@ const cardVariants = {
 };
 
 export function AgentCard({ name, description, avatar }: AgentCardProps) {
+  const { openPopup } = useAgentPopup();
   return (
     <motion.button
       variants={cardVariants}
       whileHover={{ translateY: -4, scale: 1.015 }}
       whileTap={{ scale: 0.98 }}
       className="ripple relative flex items-start gap-5 rounded-[24px] border border-white/30 bg-white/10 px-[2rem] py-[1.75rem] backdrop-blur-[18px] backdrop-saturate-[180%] transition-transform shadow-sm hover:shadow-md focus:outline-none overflow-hidden"
+      onClick={openPopup}
     >
       <span
         className="flex h-[72px] w-[72px] flex-shrink-0 items-center justify-center rounded-full"

--- a/components/agents/agent-dialog.tsx
+++ b/components/agents/agent-dialog.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { Dialog, DialogContent } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { useAgentPopup } from '@/hooks/use-agent-popup';
+import { useTranslation } from '@/lib/i18n';
+
+export function AgentDialog() {
+  const { isOpen, closePopup } = useAgentPopup();
+  const t = useTranslation();
+
+  if (!isOpen) return null;
+
+  return (
+    <Dialog open={isOpen} onOpenChange={closePopup}>
+      <DialogContent className="bg-transparent shadow-none border-none p-0 max-w-none rounded-none">
+        <div className="mx-auto w-full max-w-[52rem] p-6 sm:p-8 rounded-[28px] bg-white/40 dark:bg-gray-900/40 backdrop-blur-md shadow transition-transform duration-200 hover:scale-[1.02]">
+          <div className="h-60" />
+          <div className="mt-6 flex justify-center">
+            <Button className="bg-gradient-to-r from-[var(--brand-accent)] to-[#FFE3D2] text-white px-4 h-9 flex items-center shadow transition-shadow hover:shadow-[0_0_8px_rgba(255,255,255,0.5)]">
+              {t('goToChat')}
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/hooks/use-agent-popup.ts
+++ b/hooks/use-agent-popup.ts
@@ -1,0 +1,13 @@
+import { create } from 'zustand';
+
+interface AgentPopupState {
+  isOpen: boolean;
+  openPopup: () => void;
+  closePopup: () => void;
+}
+
+export const useAgentPopup = create<AgentPopupState>((set) => ({
+  isOpen: false,
+  openPopup: () => set({ isOpen: true }),
+  closePopup: () => set({ isOpen: false }),
+}));

--- a/lib/i18n.tsx
+++ b/lib/i18n.tsx
@@ -117,6 +117,7 @@ export const translations = {
     recommended: 'Recommended',
     agentUpdateInfo: 'Info about Assistants',
     upgradeModel: 'Upgrade model',
+    goToChat: 'Go to chat',
   },
   nl: {
     newChat: 'Nieuw gesprek',
@@ -234,6 +235,7 @@ export const translations = {
     recommended: 'Aanbevolen',
     agentUpdateInfo: 'Info over Assistenten',
     upgradeModel: 'Upgrade model',
+    goToChat: 'Ga naar chat',
   },
 } as const;
 


### PR DESCRIPTION
## Summary
- add popup state for custom agents
- create glassy `AgentDialog`
- open the dialog when clicking an agent card
- expose dialog from layout
- localize new `goToChat` string

## Testing
- `pnpm lint`
- `pnpm tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_687811d09f6c832aa4bba0a19f40b09d