### PR TITLE
fix: add solid background to agent dialog

### DIFF
--- a/components/agents/agent-dialog.tsx
+++ b/components/agents/agent-dialog.tsx
@@ -14,12 +14,15 @@ export function AgentDialog() {
   return (
     <Dialog open={isOpen} onOpenChange={closePopup}>
       <DialogContent className="bg-transparent shadow-none border-none p-0 max-w-none rounded-none">
-        <div className="mx-auto w-full max-w-[52rem] p-6 sm:p-8 rounded-[28px] bg-white/90 dark:bg-gray-900/80 backdrop-blur-md shadow transition-transform duration-200 hover:scale-[1.02]">
-          <div className="h-60" />
-          <div className="mt-6 flex justify-center">
-            <Button className="bg-gradient-to-r from-[var(--brand-accent)] to-[#FFE3D2] text-white px-4 h-9 flex items-center shadow transition-shadow hover:shadow-[0_0_8px_rgba(255,255,255,0.5)]">
-              {t('goToChat')}
-            </Button>
+        <div className="relative mx-auto w-full max-w-[52rem] rounded-[28px]">
+          <div className="absolute inset-0 rounded-[28px] bg-[#f0f0f0]" aria-hidden="true" />
+          <div className="relative p-6 sm:p-8 rounded-[28px] bg-white/90 dark:bg-gray-900/80 backdrop-blur-md shadow transition-transform duration-200 hover:scale-[1.02]">
+            <div className="h-60" />
+            <div className="mt-6 flex justify-center">
+              <Button className="bg-gradient-to-r from-[var(--brand-accent)] to-[#FFE3D2] text-white px-4 h-9 flex items-center shadow transition-shadow hover:shadow-[0_0_8px_rgba(255,255,255,0.5)]">
+                {t('goToChat')}
+              </Button>
+            </div>
           </div>
         </div>
       </DialogContent>


### PR DESCRIPTION
## Summary
- add a white background layer behind the Agents popup to keep the glass look while hiding the page content

## Testing
- `pnpm lint`
- `pnpm tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68781b822cbc832a8c1abc5f0269a091