### PR TITLE
feat: initial glassy chat redesign

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -62,6 +62,10 @@
         --brand-accent: #FFB98B;
         --brand-beige: #F5EFEA;
         --ink: #1D1D1F;
+        --surface-base: #FFFDFB;
+        --surface-glass: rgba(255,255,255,.20);
+        --accent-peach: #FFB98B;
+        --accent-peach-soft: #FFE3D2;
         --gap-user-to-assistant: 40px;
         --gap-assistant-to-user: 0px;
     }
@@ -103,6 +107,10 @@
         --brand-accent: #FFB98B;
         --brand-beige: #F5EFEA;
         --ink: #1D1D1F;
+        --surface-base: #0F0F10;
+        --surface-glass: rgba(255,255,255,.08);
+        --accent-peach: #FFB98B;
+        --accent-peach-soft: #FFE3D2;
         --gap-user-to-assistant: 40px;
         --gap-assistant-to-user: 0px;
     }
@@ -146,6 +154,10 @@
         --brand-accent: #FFB98B;
         --brand-beige: #F5EFEA;
         --ink: #1D1D1F;
+        --surface-base: #FFFDFB;
+        --surface-glass: rgba(255,255,255,.20);
+        --accent-peach: #FFB98B;
+        --accent-peach-soft: #FFE3D2;
         --gap-user-to-assistant: 40px;
         --gap-assistant-to-user: 0px;
     }
@@ -288,6 +300,41 @@
     /* send message input background */
     .orange [data-testid="multimodal-input"] {
         background-color: #fcedde; /* lighter orange */
+    }
+
+    .conversation-rail {
+        background: var(--surface-glass);
+        backdrop-filter: blur(10px);
+        border: 1px solid rgba(255, 255, 255, 0.35);
+        border-radius: 1.5rem;
+    }
+
+    .assistant-bubble {
+        background: color-mix(in srgb, var(--accent-peach-soft) 30%, transparent);
+        border: 1px solid rgba(255, 255, 255, 0.35);
+        backdrop-filter: blur(10px);
+        border-radius: 1.5rem;
+        padding: 0.5rem 0.75rem;
+    }
+
+    .user-bubble {
+        background: transparent;
+        border-radius: 1.5rem;
+        padding: 0.5rem 0.75rem;
+        border: 1px solid var(--accent-peach);
+    }
+
+    .glass-composer {
+        background: var(--surface-glass);
+        backdrop-filter: blur(10px);
+        border: 1px solid rgba(255, 255, 255, 0.35);
+        border-radius: 1.75rem;
+    }
+
+    .chat-header-glass {
+        background: var(--surface-glass);
+        backdrop-filter: blur(10px);
+        border-bottom: 1px solid rgba(255, 255, 255, 0.25);
     }
 
     /* Ripple effect for buttons */

--- a/components/chat-header.tsx
+++ b/components/chat-header.tsx
@@ -43,7 +43,7 @@ function PureChatHeader({
   const { width: windowWidth } = useWindowSize();
 
   return (
-    <header className="flex sticky top-0 bg-background py-1.5 items-center px-2 md:px-2 gap-2 border-b"> {/* Added border-b for separation */}
+    <header className="chat-header-glass flex sticky top-0 py-1.5 items-center px-2 md:px-2 gap-2 h-16">
       <SidebarToggle />
 
       {(!open || windowWidth < 768) && (

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -302,7 +302,7 @@ export function Chat({
 
   return (
     <>
-      <div className="flex flex-col min-w-0 h-dvh bg-background">
+      <div className="flex flex-col min-w-0 h-dvh bg-[var(--surface-base)]">
         <ChatHeader
           chatId={id}
           selectedModelId={chatModelId}
@@ -312,41 +312,37 @@ export function Chat({
           session={session}
         />
 
-        <Messages
-          chatId={id}
-          status={status}
-          votes={votes}
-          messages={messages}
-          setMessages={setMessages}
-          reload={reload}
-          isReadonly={isReadonly}
-          isArtifactVisible={isArtifactVisible}
-        />
+        <div className="flex flex-col flex-1 w-full max-w-[55rem] mx-auto px-4 py-4 gap-4 conversation-rail">
+          <Messages
+            chatId={id}
+            status={status}
+            votes={votes}
+            messages={messages}
+            setMessages={setMessages}
+            reload={reload}
+            isReadonly={isReadonly}
+            isArtifactVisible={isArtifactVisible}
+          />
 
-        <form
-          // The `handleSubmit` from `useChat` (now `internalUseChatHandleSubmit`)
-          // is designed to be used directly as a form's onSubmit handler.
-          // Our wrapped `handleSubmit` also supports this.
-          onSubmit={handleSubmit}
-          className="flex mx-auto px-4 bg-background pb-4 md:pb-6 gap-2 w-full md:max-w-[52rem]"
-        >
-          {!isReadonly && (
-            <MultimodalInput
-              chatId={id}
-              input={input}
-              setInput={setInput}
-              handleSubmit={handleSubmit} // Pass the component's memoized handleSubmit
-              status={status}
-              stop={stop}
-              attachments={attachments}
-              setAttachments={setAttachments}
-              messages={messages}
-              setMessages={setMessages}
-              append={append}
-              selectedVisibilityType={visibilityType}
-            />
-          )}
-        </form>
+          <form onSubmit={handleSubmit} className="flex w-full">
+            {!isReadonly && (
+              <MultimodalInput
+                chatId={id}
+                input={input}
+                setInput={setInput}
+                handleSubmit={handleSubmit}
+                status={status}
+                stop={stop}
+                attachments={attachments}
+                setAttachments={setAttachments}
+                messages={messages}
+                setMessages={setMessages}
+                append={append}
+                selectedVisibilityType={visibilityType}
+              />
+            )}
+          </form>
+        </div>
       </div>
 
       <Artifact

--- a/components/message.tsx
+++ b/components/message.tsx
@@ -127,11 +127,10 @@ const PurePreviewMessage = ({
 
                       <div
                         data-testid="message-content"
-                        className={cn('flex flex-col gap-4', {
-                          'bg-primary text-primary-foreground px-3 py-2 rounded-xl':
-                            message.role === 'user',
-                          'chat-response': message.role === 'assistant',
-                        })}
+                        className={cn(
+                          'flex flex-col gap-4',
+                          message.role === 'user' ? 'user-bubble' : 'assistant-bubble',
+                        )}
                       >
                         <Markdown>{sanitizeText(part.text)}</Markdown>
                       </div>

--- a/components/multimodal-input.tsx
+++ b/components/multimodal-input.tsx
@@ -201,7 +201,7 @@ function PureMultimodalInput({
   }, [status, scrollToBottom]);
 
   return (
-    <div className="relative w-full flex flex-col gap-4">
+    <div className="relative w-full flex flex-col gap-4 glass-composer p-4">
       <AnimatePresence>
         {!isAtBottom && (
           <motion.div


### PR DESCRIPTION
## Summary
- begin applying "Assistenten" look to chat
- add surface and accent tokens
- style conversation rail, header and composer with new glass classes
- update message bubbles for soft peach glass look

## Testing
- `pnpm lint`
- `pnpm tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6878acfde6bc832a99576ea93b246433