### PR TITLE
feat: apply glassy chat styles

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -62,6 +62,10 @@
         --brand-accent: #FFB98B;
         --brand-beige: #F5EFEA;
         --ink: #1D1D1F;
+        --surface-base: #FFFDFB;
+        --surface-glass: rgba(255,255,255,.20);
+        --accent-peach: #FFB98B;
+        --accent-peach-soft: #FFE3D2;
         --gap-user-to-assistant: 40px;
         --gap-assistant-to-user: 0px;
     }
@@ -103,6 +107,10 @@
         --brand-accent: #FFB98B;
         --brand-beige: #F5EFEA;
         --ink: #1D1D1F;
+        --surface-base: #0F0F10;
+        --surface-glass: rgba(255,255,255,.08);
+        --accent-peach: #FFB98B;
+        --accent-peach-soft: #FFE3D2;
         --gap-user-to-assistant: 40px;
         --gap-assistant-to-user: 0px;
     }
@@ -146,6 +154,10 @@
         --brand-accent: #FFB98B;
         --brand-beige: #F5EFEA;
         --ink: #1D1D1F;
+        --surface-base: #FFFDFB;
+        --surface-glass: rgba(255,255,255,.20);
+        --accent-peach: #FFB98B;
+        --accent-peach-soft: #FFE3D2;
         --gap-user-to-assistant: 40px;
         --gap-assistant-to-user: 0px;
     }
@@ -313,6 +325,31 @@
 
     .ripple:active:after {
         animation: ripple 400ms ease-out;
+    }
+
+    /* Chat redesign styles */
+    .conversation-rail {
+        margin-inline: auto;
+        max-width: 55rem;
+        padding-inline: 2rem;
+        backdrop-filter: blur(10px);
+        background: var(--surface-glass);
+        border-radius: 1.25rem;
+        border: 1px solid rgba(255,255,255,0.35);
+    }
+
+    [data-role="assistant"] [data-testid="message-content"] {
+        background: var(--surface-glass);
+        border-radius: 1.25rem;
+        border: 1px solid rgba(255,255,255,0.35);
+        padding: 0.5rem 0.75rem;
+    }
+
+    [data-role="user"] [data-testid="message-content"] {
+        background: transparent;
+        border-radius: 1.25rem;
+        padding: 0.5rem 0.75rem;
+        border: 1px solid var(--accent-peach);
     }
 
     .recommended {

--- a/components/chat-header.tsx
+++ b/components/chat-header.tsx
@@ -43,7 +43,7 @@ function PureChatHeader({
   const { width: windowWidth } = useWindowSize();
 
   return (
-    <header className="flex sticky top-0 bg-background py-1.5 items-center px-2 md:px-2 gap-2 border-b"> {/* Added border-b for separation */}
+    <header className="flex sticky top-0 z-10 h-16 backdrop-blur-md bg-[var(--surface-glass)] py-1.5 items-center px-2 md:px-4 gap-2 border-b border-white/30">
       <SidebarToggle />
 
       {(!open || windowWidth < 768) && (

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -302,7 +302,7 @@ export function Chat({
 
   return (
     <>
-      <div className="flex flex-col min-w-0 h-dvh bg-background">
+      <div className="flex flex-col min-w-0 h-dvh bg-[var(--surface-base)]">
         <ChatHeader
           chatId={id}
           selectedModelId={chatModelId}
@@ -311,42 +311,40 @@ export function Chat({
           isReadonly={isReadonly}
           session={session}
         />
+        <div className="conversation-rail flex flex-col flex-1">
+          <Messages
+            chatId={id}
+            status={status}
+            votes={votes}
+            messages={messages}
+            setMessages={setMessages}
+            reload={reload}
+            isReadonly={isReadonly}
+            isArtifactVisible={isArtifactVisible}
+          />
 
-        <Messages
-          chatId={id}
-          status={status}
-          votes={votes}
-          messages={messages}
-          setMessages={setMessages}
-          reload={reload}
-          isReadonly={isReadonly}
-          isArtifactVisible={isArtifactVisible}
-        />
-
-        <form
-          // The `handleSubmit` from `useChat` (now `internalUseChatHandleSubmit`)
-          // is designed to be used directly as a form's onSubmit handler.
-          // Our wrapped `handleSubmit` also supports this.
-          onSubmit={handleSubmit}
-          className="flex mx-auto px-4 bg-background pb-4 md:pb-6 gap-2 w-full md:max-w-[52rem]"
-        >
-          {!isReadonly && (
-            <MultimodalInput
-              chatId={id}
-              input={input}
-              setInput={setInput}
-              handleSubmit={handleSubmit} // Pass the component's memoized handleSubmit
-              status={status}
-              stop={stop}
-              attachments={attachments}
-              setAttachments={setAttachments}
-              messages={messages}
-              setMessages={setMessages}
-              append={append}
-              selectedVisibilityType={visibilityType}
-            />
-          )}
-        </form>
+          <form
+            onSubmit={handleSubmit}
+            className="flex mx-auto pb-4 md:pb-6 gap-2 w-full"
+          >
+            {!isReadonly && (
+              <MultimodalInput
+                chatId={id}
+                input={input}
+                setInput={setInput}
+                handleSubmit={handleSubmit}
+                status={status}
+                stop={stop}
+                attachments={attachments}
+                setAttachments={setAttachments}
+                messages={messages}
+                setMessages={setMessages}
+                append={append}
+                selectedVisibilityType={visibilityType}
+              />
+            )}
+          </form>
+        </div>
       </div>
 
       <Artifact

--- a/components/message-actions.tsx
+++ b/components/message-actions.tsx
@@ -41,8 +41,8 @@ export function PureMessageActions({
         <Tooltip>
           <TooltipTrigger asChild>
             <Button
-              className="py-1 px-2 h-fit text-muted-foreground"
-              variant="outline"
+              className="p-2 h-fit rounded-full bg-[var(--surface-glass)] backdrop-blur-sm border border-white/30 text-muted-foreground hover:scale-105 transition-transform"
+              variant="ghost"
               onClick={async () => {
                 const textFromParts = message.parts
                   ?.filter((part) => part.type === 'text')
@@ -69,9 +69,9 @@ export function PureMessageActions({
           <TooltipTrigger asChild>
             <Button
               data-testid="message-upvote"
-              className="py-1 px-2 h-fit text-muted-foreground !pointer-events-auto"
+              className="p-2 h-fit rounded-full bg-[var(--surface-glass)] backdrop-blur-sm border border-white/30 text-muted-foreground !pointer-events-auto hover:scale-105 transition-transform"
               disabled={vote?.isUpvoted}
-              variant="outline"
+              variant="ghost"
               onClick={async () => {
                 const upvote = fetch('/api/vote', {
                   method: 'PATCH',
@@ -122,8 +122,8 @@ export function PureMessageActions({
           <TooltipTrigger asChild>
             <Button
               data-testid="message-downvote"
-              className="py-1 px-2 h-fit text-muted-foreground !pointer-events-auto"
-              variant="outline"
+              className="p-2 h-fit rounded-full bg-[var(--surface-glass)] backdrop-blur-sm border border-white/30 text-muted-foreground !pointer-events-auto hover:scale-105 transition-transform"
+              variant="ghost"
               disabled={vote && !vote.isUpvoted}
               onClick={async () => {
                 const downvote = fetch('/api/vote', {


### PR DESCRIPTION
## Summary
- introduce `--surface-base` and related theme tokens
- style chat header and messages with new glass aesthetic
- add conversation rail container
- restyle inline message actions

## Testing
- `pnpm lint`
- `pnpm tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_6878acfde6bc832a99576ea93b246433