### PR TITLE
feat: apply glassy design to chat UI

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -60,6 +60,10 @@
         --sidebar-ring: 217.2 91.2% 59.8%;
         --sidebar-background-light: 0 0% 98%;
         --brand-accent: #FFB98B;
+        --accent-peach: #FFB98B;
+        --accent-peach-soft: #FFE3D2;
+        --surface-base: #FFFDFB;
+        --surface-glass: rgba(255,255,255,.20);
         --brand-beige: #F5EFEA;
         --ink: #1D1D1F;
         --gap-user-to-assistant: 40px;
@@ -101,6 +105,10 @@
         --sidebar-ring: 217.2 91.2% 59.8%;
         --sidebar-background-light: 240 5.9% 20%;
         --brand-accent: #FFB98B;
+        --accent-peach: #FFB98B;
+        --accent-peach-soft: #FFE3D2;
+        --surface-base: #0F0F10;
+        --surface-glass: rgba(255,255,255,.08);
         --brand-beige: #F5EFEA;
         --ink: #1D1D1F;
         --gap-user-to-assistant: 40px;
@@ -144,6 +152,10 @@
         --sidebar-ring: 25 90% 55%;
         --sidebar-background-light: 32 71% 98%;
         --brand-accent: #FFB98B;
+        --accent-peach: #FFB98B;
+        --accent-peach-soft: #FFE3D2;
+        --surface-base: #FFFDFB;
+        --surface-glass: rgba(255,255,255,.20);
         --brand-beige: #F5EFEA;
         --ink: #1D1D1F;
         --gap-user-to-assistant: 40px;

--- a/components/chat-header.tsx
+++ b/components/chat-header.tsx
@@ -43,7 +43,7 @@ function PureChatHeader({
   const { width: windowWidth } = useWindowSize();
 
   return (
-    <header className="flex sticky top-0 bg-background py-1.5 items-center px-2 md:px-2 gap-2 border-b"> {/* Added border-b for separation */}
+    <header className="flex sticky top-0 h-16 bg-[var(--surface-glass)] backdrop-blur-md items-center px-4 gap-2 border-b border-white/20">
       <SidebarToggle />
 
       {(!open || windowWidth < 768) && (
@@ -94,8 +94,8 @@ function PureChatHeader({
       {session?.user && session.user.models?.length !== plansLength && (
         <Button
           data-testid="upgrade-button"
-          variant="outline"
-          className="hidden md:flex py-1.5 px-2 h-fit md:h-[34px] order-last md:order-4 ml-2"
+          variant="ghost"
+          className="hidden md:flex py-1.5 px-3 h-fit rounded-full bg-gradient-to-r from-[var(--accent-peach)] to-[var(--accent-peach-soft)] text-white order-last md:order-4 ml-2"
           onClick={() => openUpgradePopup()}
         >
           {t('upgrade')}

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -302,7 +302,8 @@ export function Chat({
 
   return (
     <>
-      <div className="flex flex-col min-w-0 h-dvh bg-background">
+      <div className="flex flex-col min-w-0 h-dvh bg-[var(--surface-base)] relative">
+        <div className="pointer-events-none absolute inset-0 bg-gradient-to-b from-transparent via-black/5 dark:via-white/10 to-transparent" />
         <ChatHeader
           chatId={id}
           selectedModelId={chatModelId}
@@ -311,42 +312,40 @@ export function Chat({
           isReadonly={isReadonly}
           session={session}
         />
+        <div className="mx-auto w-full max-w-[55rem] flex flex-col flex-1 overflow-hidden px-4 py-2 gap-4 bg-[var(--surface-glass)] backdrop-blur-md border border-white/20 rounded-3xl mt-4">
+          <Messages
+            chatId={id}
+            status={status}
+            votes={votes}
+            messages={messages}
+            setMessages={setMessages}
+            reload={reload}
+            isReadonly={isReadonly}
+            isArtifactVisible={isArtifactVisible}
+          />
 
-        <Messages
-          chatId={id}
-          status={status}
-          votes={votes}
-          messages={messages}
-          setMessages={setMessages}
-          reload={reload}
-          isReadonly={isReadonly}
-          isArtifactVisible={isArtifactVisible}
-        />
-
-        <form
-          // The `handleSubmit` from `useChat` (now `internalUseChatHandleSubmit`)
-          // is designed to be used directly as a form's onSubmit handler.
-          // Our wrapped `handleSubmit` also supports this.
-          onSubmit={handleSubmit}
-          className="flex mx-auto px-4 bg-background pb-4 md:pb-6 gap-2 w-full md:max-w-[52rem]"
-        >
-          {!isReadonly && (
-            <MultimodalInput
-              chatId={id}
-              input={input}
-              setInput={setInput}
-              handleSubmit={handleSubmit} // Pass the component's memoized handleSubmit
-              status={status}
-              stop={stop}
-              attachments={attachments}
-              setAttachments={setAttachments}
-              messages={messages}
-              setMessages={setMessages}
-              append={append}
-              selectedVisibilityType={visibilityType}
-            />
-          )}
-        </form>
+          <form
+            onSubmit={handleSubmit}
+            className="w-full"
+          >
+            {!isReadonly && (
+              <MultimodalInput
+                chatId={id}
+                input={input}
+                setInput={setInput}
+                handleSubmit={handleSubmit}
+                status={status}
+                stop={stop}
+                attachments={attachments}
+                setAttachments={setAttachments}
+                messages={messages}
+                setMessages={setMessages}
+                append={append}
+                selectedVisibilityType={visibilityType}
+              />
+            )}
+          </form>
+        </div>
       </div>
 
       <Artifact

--- a/components/message-actions.tsx
+++ b/components/message-actions.tsx
@@ -41,8 +41,8 @@ export function PureMessageActions({
         <Tooltip>
           <TooltipTrigger asChild>
             <Button
-              className="py-1 px-2 h-fit text-muted-foreground"
-              variant="outline"
+              className="p-2 rounded-full bg-[var(--surface-glass)] backdrop-blur-sm hover:bg-white/30"
+              variant="ghost"
               onClick={async () => {
                 const textFromParts = message.parts
                   ?.filter((part) => part.type === 'text')
@@ -69,9 +69,9 @@ export function PureMessageActions({
           <TooltipTrigger asChild>
             <Button
               data-testid="message-upvote"
-              className="py-1 px-2 h-fit text-muted-foreground !pointer-events-auto"
+              className="p-2 rounded-full bg-[var(--surface-glass)] backdrop-blur-sm !pointer-events-auto hover:bg-white/30"
               disabled={vote?.isUpvoted}
-              variant="outline"
+              variant="ghost"
               onClick={async () => {
                 const upvote = fetch('/api/vote', {
                   method: 'PATCH',
@@ -122,8 +122,8 @@ export function PureMessageActions({
           <TooltipTrigger asChild>
             <Button
               data-testid="message-downvote"
-              className="py-1 px-2 h-fit text-muted-foreground !pointer-events-auto"
-              variant="outline"
+              className="p-2 rounded-full bg-[var(--surface-glass)] backdrop-blur-sm !pointer-events-auto hover:bg-white/30"
+              variant="ghost"
               disabled={vote && !vote.isUpvoted}
               onClick={async () => {
                 const downvote = fetch('/api/vote', {

--- a/components/message.tsx
+++ b/components/message.tsx
@@ -127,11 +127,15 @@ const PurePreviewMessage = ({
 
                       <div
                         data-testid="message-content"
-                        className={cn('flex flex-col gap-4', {
-                          'bg-primary text-primary-foreground px-3 py-2 rounded-xl':
-                            message.role === 'user',
-                          'chat-response': message.role === 'assistant',
-                        })}
+                        className={cn(
+                          'flex flex-col gap-4 px-4 py-3 rounded-3xl border backdrop-blur-md',
+                          {
+                            'border-[var(--accent-peach)] bg-transparent text-foreground':
+                              message.role === 'user',
+                            'border-white/30 bg-[var(--surface-glass)]':
+                              message.role === 'assistant',
+                          },
+                        )}
                       >
                         <Markdown>{sanitizeText(part.text)}</Markdown>
                       </div>
@@ -266,12 +270,7 @@ export const ThinkingMessage = () => {
       data-role={role}
     >
       <div
-        className={cx(
-          'flex gap-4 group-data-[role=user]/message:px-3 w-full group-data-[role=user]/message:w-fit group-data-[role=user]/message:ml-auto group-data-[role=user]/message:max-w-[45rem] group-data-[role=user]/message:py-2 rounded-xl',
-          {
-            'group-data-[role=user]/message:bg-muted': true,
-          },
-        )}
+        className="flex gap-4 w-full group-data-[role=user]/message:ml-auto group-data-[role=user]/message:max-w-[45rem] rounded-3xl border border-white/30 bg-[var(--surface-glass)] backdrop-blur-md px-4 py-3"
       >
         <div className="size-8 -ml-12 flex items-center rounded-full justify-center ring-1 shrink-0 ring-border">
           <SparklesIcon size={14} />

--- a/components/messages.tsx
+++ b/components/messages.tsx
@@ -42,7 +42,7 @@ function PureMessages({
   return (
     <div
       ref={messagesContainerRef}
-      className="flex flex-col min-w-0 gap-6 flex-1 overflow-y-scroll pt-4 pb-6 relative"
+      className="flex flex-col min-w-0 gap-6 flex-1 overflow-y-auto py-4 relative"
     >
       {messages.length === 0 && <Greeting />}
 

--- a/components/multimodal-input.tsx
+++ b/components/multimodal-input.tsx
@@ -201,7 +201,7 @@ function PureMultimodalInput({
   }, [status, scrollToBottom]);
 
   return (
-    <div className="relative w-full flex flex-col gap-4">
+    <div className="relative w-full flex flex-col gap-4 bg-[var(--surface-glass)] backdrop-blur-md rounded-[28px] p-4">
       <AnimatePresence>
         {!isAtBottom && (
           <motion.div
@@ -276,7 +276,7 @@ function PureMultimodalInput({
         value={input}
         onChange={handleInput}
         className={cx(
-          'min-h-[24px] max-h-[calc(75dvh)] overflow-hidden resize-none rounded-2xl !text-base bg-muted pb-10 dark:border-zinc-700',
+          'min-h-[24px] max-h-[calc(75dvh)] overflow-hidden resize-none rounded-[28px] !text-base border border-white/30 bg-transparent pb-10 backdrop-blur-sm',
           className,
         )}
         rows={2}
@@ -340,7 +340,7 @@ function PureAttachmentsButton({
   return (
     <Button
       data-testid="attachments-button"
-      className="rounded-md rounded-bl-lg p-[7px] h-fit dark:border-zinc-700 hover:dark:bg-zinc-900 hover:bg-zinc-200"
+      className="rounded-full p-2 h-fit bg-[var(--surface-glass)] backdrop-blur-sm hover:bg-white/30"
       onClick={(event) => {
         event.preventDefault();
         fileInputRef.current?.click();
@@ -365,7 +365,7 @@ function PureStopButton({
   return (
     <Button
       data-testid="stop-button"
-      className="rounded-full p-1.5 h-fit border dark:border-zinc-600"
+      className="rounded-full p-2 h-fit bg-[var(--surface-glass)] backdrop-blur-sm"
       onClick={(event) => {
         event.preventDefault();
         stop();
@@ -391,7 +391,7 @@ function PureSendButton({
   return (
     <Button
       data-testid="send-button"
-      className="rounded-full p-1.5 h-fit border dark:border-zinc-600"
+      className="rounded-full p-2 h-fit bg-gradient-to-r from-[var(--accent-peach)] to-[var(--accent-peach-soft)] text-white"
       onClick={(event) => {
         event.preventDefault();
         submitForm();


### PR DESCRIPTION
## Summary
- introduce `--surface-base` and other color tokens
- add glass styles for chat header, messages, and composer
- use gradient buttons for message actions and sending
- update chat layout with blurred conversation rail

## Testing
- `pnpm lint`
- `pnpm tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6878acfde6bc832a99576ea93b246433