### PR TITLE
feat: apply glassy aesthetic to chat

### DIFF
--- a/app/(chat)/layout.tsx
+++ b/app/(chat)/layout.tsx
@@ -1,4 +1,5 @@
 import { cookies } from 'next/headers';
+import '../../themes/assistenten.css';
 
 import { AppSidebar } from '@/components/app-sidebar';
 import { SidebarInset, SidebarProvider } from '@/components/ui/sidebar';
@@ -14,7 +15,6 @@ export default async function Layout({
 }) {
   const [session, cookieStore] = await Promise.all([auth(), cookies()]);
   const isCollapsed = cookieStore.get('sidebar:state')?.value === 'false';
-
 
   return (
     <>

--- a/app/globals.css
+++ b/app/globals.css
@@ -62,6 +62,10 @@
         --brand-accent: #FFB98B;
         --brand-beige: #F5EFEA;
         --ink: #1D1D1F;
+        --surface-base: #FFFDFB;
+        --surface-glass: rgba(255,255,255,.20);
+        --accent-peach: #FFB98B;
+        --accent-peach-soft: #FFE3D2;
         --gap-user-to-assistant: 40px;
         --gap-assistant-to-user: 0px;
     }
@@ -103,6 +107,10 @@
         --brand-accent: #FFB98B;
         --brand-beige: #F5EFEA;
         --ink: #1D1D1F;
+        --surface-base: #0F0F10;
+        --surface-glass: rgba(255,255,255,.08);
+        --accent-peach: #FFB98B;
+        --accent-peach-soft: #FFE3D2;
         --gap-user-to-assistant: 40px;
         --gap-assistant-to-user: 0px;
     }
@@ -146,6 +154,10 @@
         --brand-accent: #FFB98B;
         --brand-beige: #F5EFEA;
         --ink: #1D1D1F;
+        --surface-base: #FFFDFB;
+        --surface-glass: rgba(255,255,255,.20);
+        --accent-peach: #FFB98B;
+        --accent-peach-soft: #FFE3D2;
         --gap-user-to-assistant: 40px;
         --gap-assistant-to-user: 0px;
     }
@@ -240,6 +252,18 @@
 
     .model-card img {
         @apply block w-full object-cover rounded-t-lg;
+    }
+
+    .assistant-bubble {
+        @apply px-3 py-2 rounded-2xl border border-white/35 backdrop-blur-md bg-[var(--surface-glass)]/60;
+    }
+
+    .user-bubble {
+        @apply px-3 py-2 rounded-2xl border border-white/40 backdrop-blur-md bg-gradient-to-br from-[var(--accent-peach)]/30 to-[var(--accent-peach-soft)]/30;
+    }
+
+    .glass-pill {
+        @apply backdrop-blur-md bg-[var(--surface-glass)]/40 border border-white/30 rounded-full transition-transform hover:scale-105;
     }
 
     /* Orange theme component tweaks */

--- a/components/chat-header.tsx
+++ b/components/chat-header.tsx
@@ -43,9 +43,8 @@ function PureChatHeader({
   const { width: windowWidth } = useWindowSize();
 
   return (
-    <header className="flex sticky top-0 bg-background py-1.5 items-center px-2 md:px-2 gap-2 border-b"> {/* Added border-b for separation */}
+    <header className="stickyHeader h-16 px-2 md:px-4 gap-2">
       <SidebarToggle />
-
       {(!open || windowWidth < 768) && (
         <Tooltip>
           <TooltipTrigger asChild>
@@ -59,13 +58,13 @@ function PureChatHeader({
               }}
             >
               <PlusIcon />
-              <span className="hidden md:inline ml-1">{t('newChat')}</span> {/* Changed sr-only to hidden md:inline */}
+              <span className="hidden md:inline ml-1">{t('newChat')}</span>{' '}
+              {/* Changed sr-only to hidden md:inline */}
             </Button>
           </TooltipTrigger>
           <TooltipContent>{t('newChat')}</TooltipContent>
         </Tooltip>
       )}
-
       {!isReadonly && (
         <ModelSelector
           session={session}
@@ -74,7 +73,6 @@ function PureChatHeader({
           className="order-1 md:order-2"
         />
       )}
-
       {!isReadonly && (
         <div className="order-1 md:order-3 flex items-center gap-2">
           <VisibilitySelector
@@ -88,9 +86,8 @@ function PureChatHeader({
           )}
         </div>
       )}
-
-      <div className="flex-grow md:flex-grow-0" /> {/* Pushes elements to the right more effectively */}
-
+      <div className="flex-grow md:flex-grow-0" />{' '}
+      {/* Pushes elements to the right more effectively */}
       {session?.user && session.user.models?.length !== plansLength && (
         <Button
           data-testid="upgrade-button"
@@ -101,7 +98,6 @@ function PureChatHeader({
           {t('upgrade')}
         </Button>
       )}
-
       <Button
         className="bg-zinc-900 dark:bg-zinc-100 hover:bg-zinc-800 dark:hover:bg-zinc-200 text-zinc-50 dark:text-zinc-900 hidden md:flex py-1.5 px-2 h-fit md:h-[34px] order-last md:order-5 ml-2" // order-4 to order-last/5 and ml-auto to ml-2
         asChild
@@ -120,7 +116,8 @@ function PureChatHeader({
 
 export const ChatHeader = memo(PureChatHeader, (prevProps, nextProps) => {
   if (prevProps.selectedModelId !== nextProps.selectedModelId) return false;
-  if (prevProps.selectedVisibilityType !== nextProps.selectedVisibilityType) return false;
+  if (prevProps.selectedVisibilityType !== nextProps.selectedVisibilityType)
+    return false;
   if (prevProps.isReadonly !== nextProps.isReadonly) return false;
   // Add more checks if needed, e.g., for session changes that affect UI
   return true;

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -302,7 +302,7 @@ export function Chat({
 
   return (
     <>
-      <div className="flex flex-col min-w-0 h-dvh bg-background">
+      <div className="flex flex-col min-w-0 h-dvh bg-[var(--surface-base)]">
         <ChatHeader
           chatId={id}
           selectedModelId={chatModelId}
@@ -311,42 +311,40 @@ export function Chat({
           isReadonly={isReadonly}
           session={session}
         />
+        <div className="flex flex-col flex-1 mx-auto w-full max-w-[55rem] px-4 md:px-6 mt-2 rounded-3xl backdrop-blur-md bg-[var(--surface-glass)]/60 shadow-inner">
+          <Messages
+            chatId={id}
+            status={status}
+            votes={votes}
+            messages={messages}
+            setMessages={setMessages}
+            reload={reload}
+            isReadonly={isReadonly}
+            isArtifactVisible={isArtifactVisible}
+          />
 
-        <Messages
-          chatId={id}
-          status={status}
-          votes={votes}
-          messages={messages}
-          setMessages={setMessages}
-          reload={reload}
-          isReadonly={isReadonly}
-          isArtifactVisible={isArtifactVisible}
-        />
-
-        <form
-          // The `handleSubmit` from `useChat` (now `internalUseChatHandleSubmit`)
-          // is designed to be used directly as a form's onSubmit handler.
-          // Our wrapped `handleSubmit` also supports this.
-          onSubmit={handleSubmit}
-          className="flex mx-auto px-4 bg-background pb-4 md:pb-6 gap-2 w-full md:max-w-[52rem]"
-        >
-          {!isReadonly && (
-            <MultimodalInput
-              chatId={id}
-              input={input}
-              setInput={setInput}
-              handleSubmit={handleSubmit} // Pass the component's memoized handleSubmit
-              status={status}
-              stop={stop}
-              attachments={attachments}
-              setAttachments={setAttachments}
-              messages={messages}
-              setMessages={setMessages}
-              append={append}
-              selectedVisibilityType={visibilityType}
-            />
-          )}
-        </form>
+          <form
+            onSubmit={handleSubmit}
+            className="flex pb-4 md:pb-6 gap-2 w-full"
+          >
+            {!isReadonly && (
+              <MultimodalInput
+                chatId={id}
+                input={input}
+                setInput={setInput}
+                handleSubmit={handleSubmit}
+                status={status}
+                stop={stop}
+                attachments={attachments}
+                setAttachments={setAttachments}
+                messages={messages}
+                setMessages={setMessages}
+                append={append}
+                selectedVisibilityType={visibilityType}
+              />
+            )}
+          </form>
+        </div>
       </div>
 
       <Artifact

--- a/components/message-actions.tsx
+++ b/components/message-actions.tsx
@@ -41,8 +41,8 @@ export function PureMessageActions({
         <Tooltip>
           <TooltipTrigger asChild>
             <Button
-              className="py-1 px-2 h-fit text-muted-foreground"
-              variant="outline"
+              className="glass-pill p-2 h-fit text-muted-foreground"
+              variant="ghost"
               onClick={async () => {
                 const textFromParts = message.parts
                   ?.filter((part) => part.type === 'text')
@@ -69,9 +69,9 @@ export function PureMessageActions({
           <TooltipTrigger asChild>
             <Button
               data-testid="message-upvote"
-              className="py-1 px-2 h-fit text-muted-foreground !pointer-events-auto"
+              className="glass-pill p-2 h-fit text-muted-foreground !pointer-events-auto"
               disabled={vote?.isUpvoted}
-              variant="outline"
+              variant="ghost"
               onClick={async () => {
                 const upvote = fetch('/api/vote', {
                   method: 'PATCH',
@@ -122,8 +122,8 @@ export function PureMessageActions({
           <TooltipTrigger asChild>
             <Button
               data-testid="message-downvote"
-              className="py-1 px-2 h-fit text-muted-foreground !pointer-events-auto"
-              variant="outline"
+              className="glass-pill p-2 h-fit text-muted-foreground !pointer-events-auto"
+              variant="ghost"
               disabled={vote && !vote.isUpvoted}
               onClick={async () => {
                 const downvote = fetch('/api/vote', {

--- a/components/message.tsx
+++ b/components/message.tsx
@@ -128,9 +128,8 @@ const PurePreviewMessage = ({
                       <div
                         data-testid="message-content"
                         className={cn('flex flex-col gap-4', {
-                          'bg-primary text-primary-foreground px-3 py-2 rounded-xl':
-                            message.role === 'user',
-                          'chat-response': message.role === 'assistant',
+                          'user-bubble': message.role === 'user',
+                          'assistant-bubble': message.role === 'assistant',
                         })}
                       >
                         <Markdown>{sanitizeText(part.text)}</Markdown>

--- a/components/multimodal-input.tsx
+++ b/components/multimodal-input.tsx
@@ -276,7 +276,7 @@ function PureMultimodalInput({
         value={input}
         onChange={handleInput}
         className={cx(
-          'min-h-[24px] max-h-[calc(75dvh)] overflow-hidden resize-none rounded-2xl !text-base bg-muted pb-10 dark:border-zinc-700',
+          'min-h-[24px] max-h-[calc(75dvh)] overflow-hidden resize-none rounded-2xl !text-base bg-[var(--surface-glass)]/40 backdrop-blur-md pb-10 dark:border-zinc-700',
           className,
         )}
         rows={2}
@@ -340,7 +340,7 @@ function PureAttachmentsButton({
   return (
     <Button
       data-testid="attachments-button"
-      className="rounded-md rounded-bl-lg p-[7px] h-fit dark:border-zinc-700 hover:dark:bg-zinc-900 hover:bg-zinc-200"
+      className="glass-pill p-[7px] h-fit"
       onClick={(event) => {
         event.preventDefault();
         fileInputRef.current?.click();
@@ -365,7 +365,7 @@ function PureStopButton({
   return (
     <Button
       data-testid="stop-button"
-      className="rounded-full p-1.5 h-fit border dark:border-zinc-600"
+      className="glass-pill p-1.5 h-fit"
       onClick={(event) => {
         event.preventDefault();
         stop();
@@ -391,7 +391,7 @@ function PureSendButton({
   return (
     <Button
       data-testid="send-button"
-      className="rounded-full p-1.5 h-fit border dark:border-zinc-600"
+      className="glass-pill p-1.5 h-fit"
       onClick={(event) => {
         event.preventDefault();
         submitForm();

--- a/components/sidebar-toggle.tsx
+++ b/components/sidebar-toggle.tsx
@@ -9,6 +9,7 @@ import {
 
 import { SidebarLeftIcon } from './icons';
 import { Button } from './ui/button';
+import { cn } from '@/lib/utils';
 import { useTranslation } from '@/lib/i18n';
 
 export function SidebarToggle({
@@ -23,8 +24,8 @@ export function SidebarToggle({
         <Button
           data-testid="sidebar-toggle-button"
           onClick={toggleSidebar}
-          variant="outline"
-          className="md:px-2 md:h-fit"
+          variant="ghost"
+          className={cn('assistenten-toggle md:h-fit md:px-2', className)}
         >
           <SidebarLeftIcon size={16} />
         </Button>


### PR DESCRIPTION
## Summary
- integrate Assistenten theme into chat layout
- add new design tokens for glassy chat interface
- style message bubbles and inline actions with glass effect
- restyle chat header and sidebar toggle
- update chat container and input styling

## Testing
- `pnpm exec biome format --write "app/(chat)/layout.tsx" app/globals.css components/chat.tsx components/message.tsx components/message-actions.tsx components/sidebar-toggle.tsx components/chat-header.tsx components/multimodal-input.tsx`
- `pnpm lint`
- `pnpm tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_6878acfde6bc832a99576ea93b246433