### PR TITLE
feat: add glass bubble style

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -62,6 +62,8 @@
         --brand-accent: #FFB98B;
         --brand-beige: #F5EFEA;
         --ink: #1D1D1F;
+        --glass-fill: rgba(255, 255, 255, 0.2);
+        --glass-stroke: rgba(255, 255, 255, 0.3);
         --gap-user-to-assistant: 40px;
         --gap-assistant-to-user: 0px;
     }
@@ -103,6 +105,8 @@
         --brand-accent: #FFB98B;
         --brand-beige: #F5EFEA;
         --ink: #1D1D1F;
+        --glass-fill: rgba(255, 255, 255, 0.2);
+        --glass-stroke: rgba(255, 255, 255, 0.3);
         --gap-user-to-assistant: 40px;
         --gap-assistant-to-user: 0px;
     }
@@ -146,6 +150,8 @@
         --brand-accent: #FFB98B;
         --brand-beige: #F5EFEA;
         --ink: #1D1D1F;
+        --glass-fill: rgba(255, 255, 255, 0.2);
+        --glass-stroke: rgba(255, 255, 255, 0.3);
         --gap-user-to-assistant: 40px;
         --gap-assistant-to-user: 0px;
     }
@@ -242,12 +248,30 @@
         @apply block w-full object-cover rounded-t-lg;
     }
 
+    .glassBubble {
+        background: var(--glass-fill);
+        backdrop-filter: blur(10px) saturate(160%);
+        border: 1px solid var(--glass-stroke);
+        border-radius: 1.5rem;
+        box-shadow: 0 2px 6px rgba(0,0,0,.04);
+        transition: transform .18s ease, box-shadow .18s ease;
+    }
+
+    @media (prefers-reduced-motion: no-preference) {
+        .glassBubble:hover,
+        .glassBubble:focus-within {
+            transform: scale(1.015);
+        }
+    }
+
+    .glassBubble:hover,
+    .glassBubble:focus-within {
+        box-shadow: 0 2px 6px rgba(0,0,0,.04), 0 6px 16px rgba(0,0,0,.08);
+    }
+
     /* Orange theme component tweaks */
-    .orange [data-role="assistant"] [data-testid="message-content"],
-    .orange .chat-response {
-        background-color: #ffd4ad;
-        padding: 0.5rem 0.75rem;
-        border-radius: 0.75rem;
+    .orange .glassBubble {
+        background: var(--glass-fill);
     }
 
     .orange [data-testid="attachments-button"] svg {

--- a/components/message.tsx
+++ b/components/message.tsx
@@ -127,11 +127,9 @@ const PurePreviewMessage = ({
 
                       <div
                         data-testid="message-content"
-                        className={cn('flex flex-col gap-4', {
-                          'bg-primary text-primary-foreground px-3 py-2 rounded-xl':
-                            message.role === 'user',
-                          'chat-response': message.role === 'assistant',
-                        })}
+                        className={cn(
+                          'flex flex-col gap-4 px-3 py-2 cursor-text glassBubble text-[#1D1D1F]/90 dark:text-white/90'
+                        )}
                       >
                         <Markdown>{sanitizeText(part.text)}</Markdown>
                       </div>
@@ -267,10 +265,7 @@ export const ThinkingMessage = () => {
     >
       <div
         className={cx(
-          'flex gap-4 group-data-[role=user]/message:px-3 w-full group-data-[role=user]/message:w-fit group-data-[role=user]/message:ml-auto group-data-[role=user]/message:max-w-[45rem] group-data-[role=user]/message:py-2 rounded-xl',
-          {
-            'group-data-[role=user]/message:bg-muted': true,
-          },
+          'flex gap-4 w-full group-data-[role=user]/message:ml-auto group-data-[role=user]/message:max-w-[45rem]'
         )}
       >
         <div className="size-8 -ml-12 flex items-center rounded-full justify-center ring-1 shrink-0 ring-border">
@@ -278,7 +273,7 @@ export const ThinkingMessage = () => {
         </div>
 
         <div className="flex flex-col gap-2 w-full">
-          <div className="flex flex-col gap-4 text-muted-foreground">
+          <div className="flex flex-col gap-4 px-3 py-2 cursor-text glassBubble text-[#1D1D1F]/90 dark:text-white/90">
             Hmm...
           </div>
         </div>


### PR DESCRIPTION
## Summary
- redesign chat message bubbles with frosted glass look
- introduce `.glassBubble` styles and new CSS variables

## Testing
- `pnpm lint`
- `pnpm tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6878b2bb31ec832aac43162eb3087c74