### PR TITLE
[feat]: glass bubble design for messages

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -62,6 +62,8 @@
         --brand-accent: #FFB98B;
         --brand-beige: #F5EFEA;
         --ink: #1D1D1F;
+        --glass-fill: color-mix(in srgb, var(--brand-accent) 12%, rgb(255 255 255 / 0.2));
+        --glass-stroke: rgb(255 255 255 / 0.3);
         --gap-user-to-assistant: 40px;
         --gap-assistant-to-user: 0px;
     }
@@ -103,6 +105,8 @@
         --brand-accent: #FFB98B;
         --brand-beige: #F5EFEA;
         --ink: #1D1D1F;
+        --glass-fill: color-mix(in srgb, var(--brand-accent) 12%, rgb(255 255 255 / 0.2));
+        --glass-stroke: rgb(255 255 255 / 0.3);
         --gap-user-to-assistant: 40px;
         --gap-assistant-to-user: 0px;
     }
@@ -146,6 +150,8 @@
         --brand-accent: #FFB98B;
         --brand-beige: #F5EFEA;
         --ink: #1D1D1F;
+        --glass-fill: color-mix(in srgb, var(--brand-accent) 12%, rgb(255 255 255 / 0.2));
+        --glass-stroke: rgb(255 255 255 / 0.3);
         --gap-user-to-assistant: 40px;
         --gap-assistant-to-user: 0px;
     }
@@ -243,12 +249,7 @@
     }
 
     /* Orange theme component tweaks */
-    .orange [data-role="assistant"] [data-testid="message-content"],
-    .orange .chat-response {
-        background-color: #ffd4ad;
-        padding: 0.5rem 0.75rem;
-        border-radius: 0.75rem;
-    }
+
 
     .orange [data-testid="attachments-button"] svg {
         color: hsl(var(--primary));
@@ -330,6 +331,43 @@
         .recent,
         .recommended {
             grid-template-columns: 1fr;
+        }
+    }
+
+    .glassBubble {
+        border-radius: 24px;
+        background: var(--glass-fill);
+        backdrop-filter: blur(10px) saturate(160%);
+        border: 1px solid var(--glass-stroke);
+        box-shadow: 0 2px 6px rgba(0,0,0,.04);
+        transition: transform .18s ease, box-shadow .18s ease;
+        color: rgb(29 29 31 / 0.9);
+    }
+
+    .dark .glassBubble {
+        color: rgb(255 255 255 / 0.9);
+    }
+
+    .orange .glassBubble {
+        color: rgb(29 29 31 / 0.9);
+    }
+
+    .glassBubble:hover,
+    .glassBubble:focus-visible {
+        box-shadow: 0 2px 6px rgba(0,0,0,.04), 0 6px 16px rgba(0,0,0,.08);
+    }
+
+    @media (prefers-reduced-motion: no-preference) {
+        .glassBubble:hover,
+        .glassBubble:focus-visible {
+            transform: scale(1.015);
+        }
+    }
+
+    @media (hover: none) {
+        .glassBubble:active {
+            opacity: .9;
+            transition: opacity 40ms;
         }
     }
 

--- a/components/message-actions.tsx
+++ b/components/message-actions.tsx
@@ -37,7 +37,9 @@ export function PureMessageActions({
 
   return (
     <TooltipProvider delayDuration={0}>
-      <div className="flex flex-row gap-2">
+      <div
+        className="flex flex-row gap-2 opacity-0 group-hover/message:opacity-100 group-focus-visible/message:opacity-100 focus-within:opacity-100 transition-opacity"
+      >
         <Tooltip>
           <TooltipTrigger asChild>
             <Button

--- a/components/message.tsx
+++ b/components/message.tsx
@@ -127,11 +127,7 @@ const PurePreviewMessage = ({
 
                       <div
                         data-testid="message-content"
-                        className={cn('flex flex-col gap-4', {
-                          'bg-primary text-primary-foreground px-3 py-2 rounded-xl':
-                            message.role === 'user',
-                          'chat-response': message.role === 'assistant',
-                        })}
+                        className={cn('flex flex-col gap-4 glassBubble px-3 py-2')}
                       >
                         <Markdown>{sanitizeText(part.text)}</Markdown>
                       </div>
@@ -267,10 +263,7 @@ export const ThinkingMessage = () => {
     >
       <div
         className={cx(
-          'flex gap-4 group-data-[role=user]/message:px-3 w-full group-data-[role=user]/message:w-fit group-data-[role=user]/message:ml-auto group-data-[role=user]/message:max-w-[45rem] group-data-[role=user]/message:py-2 rounded-xl',
-          {
-            'group-data-[role=user]/message:bg-muted': true,
-          },
+          'flex gap-4 group-data-[role=user]/message:px-3 w-full group-data-[role=user]/message:w-fit group-data-[role=user]/message:ml-auto group-data-[role=user]/message:max-w-[45rem] group-data-[role=user]/message:py-2 glassBubble',
         )}
       >
         <div className="size-8 -ml-12 flex items-center rounded-full justify-center ring-1 shrink-0 ring-border">


### PR DESCRIPTION
## Summary
- implement frosted glass message style
- animate message actions on hover
- expose glass variables for all themes

## Testing
- `pnpm lint`
- `pnpm tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6878b2bb31ec832aac43162eb3087c74