### PR TITLE
feat: restyle message action buttons

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -347,6 +347,47 @@
         transition: transform .18s ease, box-shadow .18s ease;
     }
 
+    .glassIcon {
+        position: relative;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 32px;
+        height: 32px;
+        border-radius: 9999px;
+        background: rgba(255,255,255,.18);
+        backdrop-filter: blur(12px);
+        box-shadow: inset 0 0 0 1px rgb(255 255 255 / .2), 0 1px 3px rgba(0,0,0,.05);
+        transition: transform .18s ease, box-shadow .18s ease, opacity .18s ease, background-color 30ms;
+        cursor: pointer;
+    }
+
+    .glassIcon > svg {
+        opacity: .7;
+    }
+
+    .glassIcon:hover,
+    .glassIcon:focus-visible {
+        box-shadow: inset 0 0 0 1px rgb(255 255 255 / .2), 0 4px 10px rgba(0,0,0,.10);
+    }
+
+    .glassIcon:hover > svg,
+    .glassIcon:focus-visible > svg {
+        opacity: 1;
+    }
+
+    .glassIcon:active {
+        background: rgba(255,255,255,.12);
+    }
+
+    .glassIcon::before {
+        content: "";
+        position: absolute;
+        inset: -6px;
+        border-radius: inherit;
+        pointer-events: none;
+    }
+
     .glassBubble:hover,
     .glassBubble:focus-visible {
         box-shadow: 0 2px 6px rgba(0,0,0,.04), 0 6px 16px rgba(0,0,0,.08);
@@ -356,6 +397,15 @@
         .glassBubble:hover,
         .glassBubble:focus-visible {
             transform: scale(1.015);
+        }
+
+        .glassIcon:hover,
+        .glassIcon:focus-visible {
+            transform: scale(1.12);
+        }
+
+        .glassIcon:active {
+            transform: scale(.95);
         }
     }
 

--- a/components/message-actions.tsx
+++ b/components/message-actions.tsx
@@ -5,7 +5,6 @@ import { useCopyToClipboard } from 'usehooks-ts';
 import type { Vote } from '@/lib/db/schema';
 
 import { CopyIcon, ThumbDownIcon, ThumbUpIcon } from './icons';
-import { Button } from './ui/button';
 import {
   Tooltip,
   TooltipContent,
@@ -42,9 +41,10 @@ export function PureMessageActions({
       >
         <Tooltip>
           <TooltipTrigger asChild>
-            <Button
-              className="py-1 px-2 h-fit text-muted-foreground"
-              variant="outline"
+            <button
+              type="button"
+              className="glassIcon text-muted-foreground"
+              aria-label={t('copy')}
               onClick={async () => {
                 const textFromParts = message.parts
                   ?.filter((part) => part.type === 'text')
@@ -62,18 +62,19 @@ export function PureMessageActions({
               }}
             >
               <CopyIcon />
-            </Button>
+            </button>
           </TooltipTrigger>
           <TooltipContent>{t('copy')}</TooltipContent>
         </Tooltip>
 
         <Tooltip>
           <TooltipTrigger asChild>
-            <Button
+            <button
+              type="button"
               data-testid="message-upvote"
-              className="py-1 px-2 h-fit text-muted-foreground !pointer-events-auto"
+              className="glassIcon text-muted-foreground !pointer-events-auto"
+              aria-label={t('upvoteResponse')}
               disabled={vote?.isUpvoted}
-              variant="outline"
               onClick={async () => {
                 const upvote = fetch('/api/vote', {
                   method: 'PATCH',
@@ -115,17 +116,18 @@ export function PureMessageActions({
               }}
             >
               <ThumbUpIcon />
-            </Button>
+            </button>
           </TooltipTrigger>
           <TooltipContent>{t('upvoteResponse')}</TooltipContent>
         </Tooltip>
 
         <Tooltip>
           <TooltipTrigger asChild>
-            <Button
+            <button
+              type="button"
               data-testid="message-downvote"
-              className="py-1 px-2 h-fit text-muted-foreground !pointer-events-auto"
-              variant="outline"
+              className="glassIcon text-muted-foreground !pointer-events-auto"
+              aria-label={t('downvoteResponse')}
               disabled={vote && !vote.isUpvoted}
               onClick={async () => {
                 const downvote = fetch('/api/vote', {
@@ -168,7 +170,7 @@ export function PureMessageActions({
               }}
             >
               <ThumbDownIcon />
-            </Button>
+            </button>
           </TooltipTrigger>
           <TooltipContent>{t('downvoteResponse')}</TooltipContent>
         </Tooltip>


### PR DESCRIPTION
## Summary
- add `.glassIcon` style for translucent chip buttons
- swap message action buttons to use glass chip style

## Testing
- `pnpm lint`
- `pnpm tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6878bd5caa90832abc80d1ced5cd744f