### PR TITLE
feat: update message action buttons with glass icon chips

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -260,16 +260,12 @@
         color: hsl(var(--primary));
     }
 
-    .orange header button,
-    .orange [data-testid="message-upvote"],
-    .orange [data-testid="message-downvote"] {
+    .orange header button {
         border-color: hsl(var(--primary));
         color: hsl(var(--primary));
     }
 
-    .orange header button:hover,
-    .orange [data-testid="message-upvote"]:hover,
-    .orange [data-testid="message-downvote"]:hover {
+    .orange header button:hover {
         background-color: hsl(25 90% 55%);
         color: hsl(var(--primary-foreground));
     }
@@ -364,6 +360,59 @@
             opacity: .9;
             transition: opacity 40ms;
         }
+    }
+
+    .glassIcon {
+        position: relative;
+        width: 32px;
+        height: 32px;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        border-radius: 9999px;
+        background: rgba(255,255,255,.18);
+        backdrop-filter: blur(12px);
+        -webkit-backdrop-filter: blur(12px);
+        border: 1px solid rgb(255 255 255 / 0.2);
+        box-shadow: 0 1px 3px rgba(0,0,0,.05);
+        cursor: pointer;
+        transition: transform .18s ease, box-shadow .18s ease, opacity .18s ease, background .18s ease;
+    }
+
+    .glassIcon svg {
+        opacity: .7;
+        transition: opacity .18s ease;
+    }
+
+    .glassIcon:hover,
+    .glassIcon:focus-visible {
+        box-shadow: 0 4px 10px rgba(0,0,0,.10);
+    }
+
+    .glassIcon:hover svg,
+    .glassIcon:focus-visible svg {
+        opacity: 1;
+    }
+
+    @media (prefers-reduced-motion: no-preference) {
+        .glassIcon:hover,
+        .glassIcon:focus-visible {
+            transform: scale(1.12);
+        }
+    }
+
+    .glassIcon:active {
+        transform: scale(.95);
+        background: rgba(255,255,255,.12);
+        transition-duration: 30ms;
+    }
+
+    .glassIcon::before {
+        content: "";
+        position: absolute;
+        inset: -6px;
+        border-radius: inherit;
+        pointer-events: none;
     }
 
     @media (prefers-reduced-motion: reduce) {

--- a/components/message-actions.tsx
+++ b/components/message-actions.tsx
@@ -5,7 +5,6 @@ import { useCopyToClipboard } from 'usehooks-ts';
 import type { Vote } from '@/lib/db/schema';
 
 import { CopyIcon, ThumbDownIcon, ThumbUpIcon } from './icons';
-import { Button } from './ui/button';
 import {
   Tooltip,
   TooltipContent,
@@ -42,9 +41,10 @@ export function PureMessageActions({
       >
         <Tooltip>
           <TooltipTrigger asChild>
-            <Button
-              className="py-1 px-2 h-fit text-muted-foreground"
-              variant="outline"
+            <button
+              aria-label={t('copy')}
+              type="button"
+              className="glassIcon text-muted-foreground disabled:opacity-50 disabled:pointer-events-none focus-visible:outline-none"
               onClick={async () => {
                 const textFromParts = message.parts
                   ?.filter((part) => part.type === 'text')
@@ -62,18 +62,19 @@ export function PureMessageActions({
               }}
             >
               <CopyIcon />
-            </Button>
+            </button>
           </TooltipTrigger>
           <TooltipContent>{t('copy')}</TooltipContent>
         </Tooltip>
 
         <Tooltip>
           <TooltipTrigger asChild>
-            <Button
+            <button
               data-testid="message-upvote"
-              className="py-1 px-2 h-fit text-muted-foreground !pointer-events-auto"
+              type="button"
+              aria-label={t('upvoteResponse')}
+              className="glassIcon text-muted-foreground !pointer-events-auto disabled:opacity-50 disabled:pointer-events-none focus-visible:outline-none"
               disabled={vote?.isUpvoted}
-              variant="outline"
               onClick={async () => {
                 const upvote = fetch('/api/vote', {
                   method: 'PATCH',
@@ -115,17 +116,18 @@ export function PureMessageActions({
               }}
             >
               <ThumbUpIcon />
-            </Button>
+            </button>
           </TooltipTrigger>
           <TooltipContent>{t('upvoteResponse')}</TooltipContent>
         </Tooltip>
 
         <Tooltip>
           <TooltipTrigger asChild>
-            <Button
+            <button
               data-testid="message-downvote"
-              className="py-1 px-2 h-fit text-muted-foreground !pointer-events-auto"
-              variant="outline"
+              type="button"
+              aria-label={t('downvoteResponse')}
+              className="glassIcon text-muted-foreground !pointer-events-auto disabled:opacity-50 disabled:pointer-events-none focus-visible:outline-none"
               disabled={vote && !vote.isUpvoted}
               onClick={async () => {
                 const downvote = fetch('/api/vote', {
@@ -168,7 +170,7 @@ export function PureMessageActions({
               }}
             >
               <ThumbDownIcon />
-            </Button>
+            </button>
           </TooltipTrigger>
           <TooltipContent>{t('downvoteResponse')}</TooltipContent>
         </Tooltip>


### PR DESCRIPTION
## Summary
- redesign copy, upvote and downvote controls as glass icon chips
- remove obsolete orange theme overrides
- implement `glassIcon` utility styles for consistent behavior

## Testing
- `pnpm lint`
- `pnpm tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6878bd5caa90832abc80d1ced5cd744f