### PR TITLE
feat: redesign chat composer glass dock

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -423,10 +423,131 @@
         }
     }
 
-    @media (prefers-reduced-motion: reduce) {
+@media (prefers-reduced-motion: reduce) {
         * {
             transition: none !important;
             animation: none !important;
         }
     }
+}
+
+.glassDock {
+    position: fixed;
+    left: 0;
+    right: 0;
+    bottom: 24px;
+    max-width: 55rem;
+    margin-inline: auto;
+    padding: 1rem 3rem;
+    border-radius: 28px;
+    background: rgba(255,255,255,.18);
+    backdrop-filter: blur(14px) saturate(160%);
+    display: flex;
+    flex-direction: column;
+}
+
+.glassDock::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    padding: 2px;
+    border-radius: inherit;
+    background: linear-gradient(90deg,var(--accent-peach),var(--accent-peach-soft),var(--accent-peach));
+    background-size: 400% 100%;
+    -webkit-mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
+    -webkit-mask-composite: xor;
+    mask-composite: exclude;
+    pointer-events: none;
+    animation: dock-pan 45s linear infinite;
+}
+
+@keyframes dock-pan {
+    from { background-position: 0 50%; }
+    to { background-position: 400% 50%; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .glassDock::before { animation: none; }
+}
+
+.dock-chip {
+    position: absolute;
+    bottom: -6px;
+    width: 40px;
+    height: 40px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 9999px;
+    background: rgba(255,255,255,.18);
+    backdrop-filter: blur(14px) saturate(160%);
+    box-shadow: inset 0 0 0 1px rgb(255 255 255 / .2);
+}
+
+.dock-chip.left-0 { left: 0; transform: translate(-50%, 0); }
+.dock-chip.right-0 { right: 0; transform: translate(50%, 0); }
+
+.dock-btn {
+    width: 40px;
+    height: 40px;
+    border-radius: 9999px;
+    backdrop-filter: blur(14px) saturate(160%);
+    background: rgba(255,255,255,.18);
+    box-shadow: inset 0 0 0 1px rgb(255 255 255 / .2);
+    transition: transform .18s ease, box-shadow .18s ease;
+}
+
+.dock-btn:hover,
+.dock-btn:focus-visible {
+    box-shadow: 0 0 8px rgba(255,255,255,.4), inset 0 0 0 1px rgb(255 255 255 / .2);
+    transform: scale(1.08);
+}
+
+.dock-btn:active {
+    transform: scale(.92);
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .dock-btn:hover,
+    .dock-btn:focus-visible,
+    .dock-btn:active {
+        transform: none;
+    }
+}
+
+.focused::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    background: radial-gradient(circle at center, rgba(255,255,255,.12), transparent);
+    animation: focus-fade 600ms forwards;
+    pointer-events: none;
+}
+
+@keyframes focus-fade { from { opacity:.12; } to { opacity:0; } }
+
+.flash::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    background: rgba(255,255,255,.05);
+    animation: flash-fade 1s forwards;
+    pointer-events: none;
+}
+
+@keyframes flash-fade { from { opacity:1; } to { opacity:0; } }
+
+.dock-placeholder {
+    position: absolute;
+    left: 1rem;
+    top: 0.75rem;
+    color: hsl(var(--muted-foreground));
+    transition: transform .18s ease, opacity .18s ease;
+}
+
+.glassDock[data-has-text="true"] .dock-placeholder {
+    transform: translateY(-0.5rem);
+    opacity: 0;
 }

--- a/components/multimodal-input.tsx
+++ b/components/multimodal-input.tsx
@@ -62,6 +62,10 @@ function PureMultimodalInput({
   const { width } = useWindowSize();
   const t = useTranslation();
 
+  const [hasValue, setHasValue] = useState<boolean>(input.length > 0);
+  const [focusGlow, setFocusGlow] = useState<boolean>(false);
+  const [sentFlash, setSentFlash] = useState<boolean>(false);
+
   useEffect(() => {
     if (textareaRef.current) {
       adjustHeight();
@@ -93,6 +97,7 @@ function PureMultimodalInput({
       // Prefer DOM value over localStorage to handle hydration
       const finalValue = domValue || localStorageInput || '';
       setInput(finalValue);
+      setHasValue(finalValue.length > 0);
       adjustHeight();
       if (finalValue) {
         textareaRef.current.focus();
@@ -110,6 +115,7 @@ function PureMultimodalInput({
 
   const handleInput = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
     setInput(event.target.value);
+    setHasValue(event.target.value.length > 0);
     adjustHeight();
   };
 
@@ -126,6 +132,8 @@ function PureMultimodalInput({
     setAttachments([]);
     setLocalStorageInput('');
     resetHeight();
+    setSentFlash(true);
+    setTimeout(() => setSentFlash(false), 1000);
 
     if (width && width > 768) {
       textareaRef.current?.focus();
@@ -201,7 +209,14 @@ function PureMultimodalInput({
   }, [status, scrollToBottom]);
 
   return (
-    <div className="relative w-full flex flex-col gap-4">
+    <div
+      className={cx(
+        'glassDock relative flex w-full flex-col gap-4',
+        focusGlow && 'focused',
+        sentFlash && 'flash',
+      )}
+      data-has-text={hasValue}
+    >
       <AnimatePresence>
         {!isAtBottom && (
           <motion.div
@@ -269,19 +284,24 @@ function PureMultimodalInput({
         </div>
       )}
 
-      <Textarea
-        data-testid="multimodal-input"
-        ref={textareaRef}
-        placeholder={t('sendMessagePlaceholder')}
-        value={input}
-        onChange={handleInput}
-        className={cx(
-          'min-h-[24px] max-h-[calc(75dvh)] overflow-hidden resize-none rounded-2xl !text-base bg-muted pb-10 dark:border-zinc-700',
-          className,
-        )}
-        rows={2}
-        autoFocus
-        onKeyDown={(event) => {
+      <div className="relative">
+        <Textarea
+          data-testid="multimodal-input"
+          ref={textareaRef}
+          placeholder=" "
+          value={input}
+          onChange={handleInput}
+          onFocus={() => {
+            setFocusGlow(true);
+            setTimeout(() => setFocusGlow(false), 600);
+          }}
+          className={cx(
+            'transition-all duration-150 ease-linear min-h-[64px] max-h-[160px] overflow-hidden resize-none rounded-2xl !text-base bg-muted pb-10 dark:border-zinc-700',
+            className,
+          )}
+          rows={2}
+          autoFocus
+          onKeyDown={(event) => {
           if (
             event.key === 'Enter' &&
             !event.shiftKey &&
@@ -296,13 +316,17 @@ function PureMultimodalInput({
             }
           }
         }}
-      />
+        />
+        <span className="dock-placeholder pointer-events-none">
+          {t('sendMessagePlaceholder')}
+        </span>
+      </div>
 
-      <div className="absolute bottom-0 p-2 w-fit flex flex-row justify-start">
+      <div className="dock-chip left-0" aria-hidden="true">
         <AttachmentsButton fileInputRef={fileInputRef} status={status} />
       </div>
 
-      <div className="absolute bottom-0 right-0 p-2 w-fit flex flex-row justify-end">
+      <div className="dock-chip right-0" aria-hidden="true">
         {status === 'submitted' ? (
           <StopButton stop={stop} setMessages={setMessages} />
         ) : (
@@ -340,7 +364,7 @@ function PureAttachmentsButton({
   return (
     <Button
       data-testid="attachments-button"
-      className="rounded-md rounded-bl-lg p-[7px] h-fit dark:border-zinc-700 hover:dark:bg-zinc-900 hover:bg-zinc-200"
+      className="dock-btn"
       onClick={(event) => {
         event.preventDefault();
         fileInputRef.current?.click();
@@ -365,7 +389,7 @@ function PureStopButton({
   return (
     <Button
       data-testid="stop-button"
-      className="rounded-full p-1.5 h-fit border dark:border-zinc-600"
+      className="dock-btn"
       onClick={(event) => {
         event.preventDefault();
         stop();
@@ -391,7 +415,7 @@ function PureSendButton({
   return (
     <Button
       data-testid="send-button"
-      className="rounded-full p-1.5 h-fit border dark:border-zinc-600"
+      className="dock-btn"
       onClick={(event) => {
         event.preventDefault();
         submitForm();


### PR DESCRIPTION
## Summary
- restyle chat input component as floating glass dock
- add animated gradient border and button chips
- update global styles for new dock aesthetics

## Testing
- `pnpm lint`
- `pnpm tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6878c6fa26f4832a84486b8541331e3a