### PR TITLE
feat: apply frosted glass style to composer

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -429,4 +429,58 @@
             animation: none !important;
         }
     }
+
+    .composerDock {
+        position: relative;
+        border-radius: 24px;
+        background: radial-gradient(circle at 50% 50%, color-mix(in srgb, var(--brand-accent) 40%, transparent), transparent 70%);
+        backdrop-filter: blur(12px) saturate(160%);
+        border: 1px solid var(--glass-stroke);
+        box-shadow: 0 2px 3px rgba(0,0,0,.06);
+    }
+
+    .composerDock::before {
+        content: "";
+        position: absolute;
+        inset: 0;
+        border-radius: inherit;
+        box-shadow: inset 0 0 0 1px rgb(255 255 255 / .45);
+        pointer-events: none;
+    }
+
+    .composerDock:focus-within::before {
+        animation: composerPulse 800ms ease-out;
+    }
+
+    @keyframes composerPulse {
+        0%,100% { box-shadow: inset 0 0 0 1px rgb(255 255 255 / .45); }
+        50% { box-shadow: inset 0 0 0 2px rgb(255 255 255 / .6); }
+    }
+
+    .composerDock.typing::after {
+        content: "";
+        position: absolute;
+        left: 10%;
+        right: 10%;
+        bottom: 4px;
+        height: 2px;
+        background: radial-gradient(circle, rgb(255 185 139 / .4), transparent);
+        animation: typingRipple 600ms ease-out;
+        pointer-events: none;
+    }
+
+    @keyframes typingRipple {
+        from { transform: translateX(-100%); opacity: .4; }
+        to { transform: translateX(100%); opacity: 0; }
+    }
+
+    .composerTextarea {
+        color: var(--ink);
+        caret-color: var(--brand-accent);
+    }
+
+    .composerTextarea::placeholder {
+        color: var(--ink);
+        opacity: .6;
+    }
 }

--- a/components/artifact.tsx
+++ b/components/artifact.tsx
@@ -336,7 +336,7 @@ function PureArtifact({
                     setAttachments={setAttachments}
                     messages={messages}
                     append={append}
-                    className="bg-background dark:bg-muted"
+                    inputClassName="bg-background dark:bg-muted"
                     setMessages={setMessages}
                     selectedVisibilityType={selectedVisibilityType}
                   />

--- a/components/multimodal-input.tsx
+++ b/components/multimodal-input.tsx
@@ -42,6 +42,7 @@ function PureMultimodalInput({
   append,
   handleSubmit,
   className,
+  inputClassName,
   selectedVisibilityType,
 }: {
   chatId: string;
@@ -56,6 +57,7 @@ function PureMultimodalInput({
   append: UseChatHelpers['append'];
   handleSubmit: UseChatHelpers['handleSubmit'];
   className?: string;
+  inputClassName?: string;
   selectedVisibilityType: VisibilityType;
 }) {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -193,6 +195,15 @@ function PureMultimodalInput({
   );
 
   const { isAtBottom, scrollToBottom } = useScrollToBottom();
+  const [isTyping, setIsTyping] = useState(false);
+
+  useEffect(() => {
+    if (input) {
+      setIsTyping(true);
+      const t = setTimeout(() => setIsTyping(false), 400);
+      return () => clearTimeout(t);
+    }
+  }, [input]);
 
   useEffect(() => {
     if (status === 'submitted') {
@@ -201,7 +212,13 @@ function PureMultimodalInput({
   }, [status, scrollToBottom]);
 
   return (
-    <div className="relative w-full flex flex-col gap-4">
+    <div
+      className={cx(
+        'relative w-full flex flex-col gap-4 composerDock',
+        className,
+        { typing: isTyping },
+      )}
+    >
       <AnimatePresence>
         {!isAtBottom && (
           <motion.div
@@ -276,8 +293,8 @@ function PureMultimodalInput({
         value={input}
         onChange={handleInput}
         className={cx(
-          'min-h-[24px] max-h-[calc(75dvh)] overflow-hidden resize-none rounded-2xl !text-base bg-muted pb-10 dark:border-zinc-700',
-          className,
+          'min-h-[24px] max-h-[calc(75dvh)] overflow-hidden resize-none rounded-2xl !text-base bg-transparent pb-10 dark:border-zinc-700 composerTextarea',
+          inputClassName,
         )}
         rows={2}
         autoFocus
@@ -323,6 +340,8 @@ export const MultimodalInput = memo(
     if (prevProps.input !== nextProps.input) return false;
     if (prevProps.status !== nextProps.status) return false;
     if (!equal(prevProps.attachments, nextProps.attachments)) return false;
+    if (prevProps.className !== nextProps.className) return false;
+    if (prevProps.inputClassName !== nextProps.inputClassName) return false;
     if (prevProps.selectedVisibilityType !== nextProps.selectedVisibilityType)
       return false;
 
@@ -340,7 +359,7 @@ function PureAttachmentsButton({
   return (
     <Button
       data-testid="attachments-button"
-      className="rounded-md rounded-bl-lg p-[7px] h-fit dark:border-zinc-700 hover:dark:bg-zinc-900 hover:bg-zinc-200"
+      className="glassIcon"
       onClick={(event) => {
         event.preventDefault();
         fileInputRef.current?.click();
@@ -391,7 +410,7 @@ function PureSendButton({
   return (
     <Button
       data-testid="send-button"
-      className="rounded-full p-1.5 h-fit border dark:border-zinc-600"
+      className="glassIcon"
       onClick={(event) => {
         event.preventDefault();
         submitForm();


### PR DESCRIPTION
## Summary
- restyle the chat composer dock with glass effect
- refine the composer textarea and buttons
- support artifact page by passing `inputClassName`

## Testing
- `pnpm lint`
- `pnpm tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6878cae31568832ab61a92cec772c56e