### PR TITLE
feat: style composer dock with glass effects

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -299,8 +299,8 @@
     }
 
     /* send message input background */
-    .orange [data-testid="multimodal-input"] {
-        background-color: #fcedde; /* lighter orange */
+    .orange .composerDock {
+        background: radial-gradient(circle at center, color-mix(in srgb, var(--brand-accent) 70%, transparent), transparent 70%);
     }
 
     /* Ripple effect for buttons */
@@ -428,5 +428,54 @@
             transition: none !important;
             animation: none !important;
         }
+    }
+
+    .composerDock {
+        position: relative;
+        border-radius: 24px;
+        backdrop-filter: blur(10px) saturate(160%);
+        border: 1px solid var(--glass-stroke);
+        background: radial-gradient(circle at center, color-mix(in srgb, var(--brand-accent) 60%, transparent), transparent 70%);
+        box-shadow: 0 2px 6px rgba(0,0,0,.04);
+        transition: background .2s ease, box-shadow .2s ease;
+    }
+
+    .composerDock:focus-within {
+        box-shadow: 0 2px 6px rgba(0,0,0,.04), 0 0 8px rgba(255,185,139,.6);
+    }
+
+    @keyframes composerRipple {
+        from { transform: translateX(-50%); opacity: 0.3; }
+        to { transform: translateX(100%); opacity: 0; }
+    }
+
+    .composerDock.typing::after {
+        content: "";
+        position: absolute;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        height: 2px;
+        background: linear-gradient(90deg, transparent, var(--brand-accent), transparent);
+        border-radius: inherit;
+        pointer-events: none;
+        animation: composerRipple 1s forwards;
+    }
+
+    .composerButton {
+        background: rgba(255,255,255,.18);
+        backdrop-filter: blur(12px);
+        box-shadow: inset 0 0 0 1px rgb(255 255 255 / .2), 0 1px 3px rgba(0,0,0,.05);
+        transition: transform .18s ease, box-shadow .18s ease;
+    }
+
+    .composerButton:hover,
+    .composerButton:focus-visible {
+        transform: translateY(-1px);
+        box-shadow: inset 0 0 0 1px rgb(255 255 255 / .2), 0 4px 10px rgba(255,185,139,.6);
+    }
+
+    .caret-brand {
+        caret-color: var(--brand-accent);
     }
 }

--- a/components/multimodal-input.tsx
+++ b/components/multimodal-input.tsx
@@ -61,6 +61,8 @@ function PureMultimodalInput({
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const { width } = useWindowSize();
   const t = useTranslation();
+  const typingTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const [isTyping, setIsTyping] = useState(false);
 
   useEffect(() => {
     if (textareaRef.current) {
@@ -111,6 +113,9 @@ function PureMultimodalInput({
   const handleInput = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
     setInput(event.target.value);
     adjustHeight();
+    setIsTyping(true);
+    if (typingTimeoutRef.current) clearTimeout(typingTimeoutRef.current);
+    typingTimeoutRef.current = setTimeout(() => setIsTyping(false), 500);
   };
 
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -201,7 +206,7 @@ function PureMultimodalInput({
   }, [status, scrollToBottom]);
 
   return (
-    <div className="relative w-full flex flex-col gap-4">
+    <div className={cx('relative w-full flex flex-col gap-4 composerDock', isTyping && 'typing')}>
       <AnimatePresence>
         {!isAtBottom && (
           <motion.div
@@ -276,7 +281,7 @@ function PureMultimodalInput({
         value={input}
         onChange={handleInput}
         className={cx(
-          'min-h-[24px] max-h-[calc(75dvh)] overflow-hidden resize-none rounded-2xl !text-base bg-muted pb-10 dark:border-zinc-700',
+          'min-h-[24px] max-h-[calc(75dvh)] overflow-hidden resize-none rounded-2xl !text-base pb-10 bg-transparent border-none text-[color:var(--ink)] placeholder:text-[rgba(29,29,31,0.7)] caret-brand',
           className,
         )}
         rows={2}
@@ -340,7 +345,7 @@ function PureAttachmentsButton({
   return (
     <Button
       data-testid="attachments-button"
-      className="rounded-md rounded-bl-lg p-[7px] h-fit dark:border-zinc-700 hover:dark:bg-zinc-900 hover:bg-zinc-200"
+      className="glassIcon composerButton"
       onClick={(event) => {
         event.preventDefault();
         fileInputRef.current?.click();
@@ -391,12 +396,13 @@ function PureSendButton({
   return (
     <Button
       data-testid="send-button"
-      className="rounded-full p-1.5 h-fit border dark:border-zinc-600"
+      className="glassIcon composerButton"
       onClick={(event) => {
         event.preventDefault();
         submitForm();
       }}
       disabled={input.length === 0 || uploadQueue.length > 0}
+      variant="ghost"
     >
       <ArrowUpIcon size={14} />
     </Button>


### PR DESCRIPTION
## Summary
- revamp chat composer dock with frosted glass look
- animate small glow and ripple on typing
- restyle attach/send buttons as glass medallions

## Testing
- `pnpm tsc --noEmit`
- `pnpm lint` *(fails to keep repo untouched, reverted other changes)*

------
https://chatgpt.com/codex/tasks/task_e_6878cae31568832ab61a92cec772c56e