### PR TITLE
feat: refine composer interactions

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -300,7 +300,7 @@
 
     /* send message input background */
     .orange .composerDock {
-        background: radial-gradient(circle at center, color-mix(in srgb, var(--brand-accent) 70%, transparent), transparent 70%);
+        background: radial-gradient(ellipse 130% 100% at center, color-mix(in srgb, var(--brand-accent) 70%, transparent) 0%, transparent 90%);
     }
 
     /* Ripple effect for buttons */
@@ -425,8 +425,18 @@
 
     @media (prefers-reduced-motion: reduce) {
         * {
-            transition: none !important;
             animation: none !important;
+        }
+        .composerDock,
+        .composerButton {
+            transition: opacity .18s ease, background .18s ease, box-shadow .18s ease;
+        }
+        .composerDock:hover,
+        .composerDock:focus-within,
+        .composerButton:hover,
+        .composerButton:focus-visible,
+        .composerButton:active {
+            transform: none !important;
         }
     }
 
@@ -435,13 +445,26 @@
         border-radius: 24px;
         backdrop-filter: blur(10px) saturate(160%);
         border: 1px solid var(--glass-stroke);
-        background: radial-gradient(circle at center, color-mix(in srgb, var(--brand-accent) 60%, transparent), transparent 70%);
+        background: radial-gradient(ellipse 130% 100% at center, color-mix(in srgb, var(--brand-accent) 60%, transparent) 0%, transparent 90%);
         box-shadow: 0 2px 6px rgba(0,0,0,.04);
-        transition: background .2s ease, box-shadow .2s ease;
+        transition: background .2s ease, box-shadow .2s ease, transform .18s ease;
+    }
+
+    .composerDock:hover {
+        background: radial-gradient(ellipse 130% 100% at center, color-mix(in srgb, var(--brand-accent) 65%, transparent) 0%, transparent 90%);
+        transform: scaleY(1.1);
+        box-shadow: 0 4px 12px rgba(0,0,0,.08);
+    }
+
+    .orange .composerDock:hover,
+    .orange .composerDock:focus-within {
+        background: radial-gradient(ellipse 130% 100% at center, color-mix(in srgb, var(--brand-accent) 75%, transparent) 0%, transparent 90%);
     }
 
     .composerDock:focus-within {
-        box-shadow: 0 2px 6px rgba(0,0,0,.04), 0 0 8px rgba(255,185,139,.6);
+        background: radial-gradient(ellipse 130% 100% at center, color-mix(in srgb, var(--brand-accent) 65%, transparent) 0%, transparent 90%);
+        transform: translateY(-2px) scaleY(1.1);
+        box-shadow: 0 4px 12px rgba(0,0,0,.08), 0 0 8px rgba(255,185,139,.6);
     }
 
     @keyframes composerRipple {
@@ -471,8 +494,14 @@
 
     .composerButton:hover,
     .composerButton:focus-visible {
-        transform: translateY(-1px);
+        background: rgba(255,255,255,.22);
+        transform: translateY(-2px);
         box-shadow: inset 0 0 0 1px rgb(255 255 255 / .2), 0 4px 10px rgba(255,185,139,.6);
+    }
+
+    .composerButton:active {
+        transform: translateY(0);
+        background: rgba(255,255,255,.18);
     }
 
     .caret-brand {


### PR DESCRIPTION
## Summary
- adjust composer dock glow
- add hover/focus motion to composer dock
- tweak icon hover and active behavior
- respect reduced-motion with fade transitions

## Testing
- `pnpm lint`
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_6879ed3a5110832a805d42ea2cdc4619