### PR TITLE
feat: frosted glow bubbles

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -346,12 +346,37 @@
         }
     }
 
-    .glassBubble {
+.glassBubble {
         border-radius: 24px;
         backdrop-filter: blur(10px) saturate(160%);
         border: 1px solid var(--glass-stroke);
         box-shadow: 0 2px 6px rgba(0,0,0,.04);
         transition: transform .18s ease, box-shadow .18s ease;
+    }
+
+    .frostedGlow {
+        border-radius: 24px;
+        backdrop-filter: blur(10px) saturate(160%);
+        border: 1px solid var(--glass-stroke);
+        background: radial-gradient(
+            ellipse 130% 100% at center,
+            color-mix(in srgb, var(--bubble-color) 60%, transparent) 0%,
+            transparent 90%
+        );
+        box-shadow: 0 2px 6px rgba(0,0,0,.04);
+        transition: transform .18s ease, box-shadow .18s ease;
+    }
+
+    .frostedGlow-orange { --bubble-color: var(--brand-accent); }
+    .frostedGlow-peach { --bubble-color: #ffe9d6; }
+    .frostedGlow-grey { --bubble-color: #e5e5e5; }
+
+    .frostedGlow:hover,
+    .frostedGlow:focus-visible {
+        box-shadow:
+            0 2px 6px rgba(0,0,0,.04),
+            0 6px 16px rgba(0,0,0,.08),
+            0 0 8px color-mix(in srgb, var(--bubble-color) 60%, transparent);
     }
 
     .glassIcon {
@@ -464,7 +489,7 @@
     .composerDock:focus-within {
         background: radial-gradient(ellipse 130% 100% at center, color-mix(in srgb, var(--brand-accent) 65%, transparent) 0%, transparent 90%);
         transform: translateY(-2px) scaleY(1.1);
-        box-shadow: 0 4px 12px rgba(0,0,0,.08), 0 0 8px rgba(255,185,139,.6);
+        box-shadow: 0 4px 12px rgba(0,0,0,.08), 0 0 8px rgba(255,185,139,.6), inset 0 0 0 2px rgba(255,255,255,.8);
     }
 
     @keyframes composerRipple {

--- a/components/message.tsx
+++ b/components/message.tsx
@@ -128,11 +128,14 @@ const PurePreviewMessage = ({
                       <div
                         data-testid="message-content"
                         className={cn(
-                          'flex flex-col gap-4 glassBubble px-3 py-2 messageContent',
+                          'flex flex-col gap-4 messageContent px-3 py-2',
                           {
-                            'bg-primary text-primary-foreground':
+                            'frostedGlow-orange text-[color:var(--ink)]':
                               message.role === 'user',
-                            'chat-response': message.role === 'assistant',
+                            'frostedGlow-peach text-[color:var(--ink)]':
+                              message.role === 'assistant',
+                            'frostedGlow-grey text-[color:var(--ink)]':
+                              message.role === 'system' || message.role === 'meta',
                           },
                         )}
                       >
@@ -270,7 +273,7 @@ export const ThinkingMessage = () => {
     >
       <div
         className={cx(
-          'flex gap-4 group-data-[role=user]/message:px-3 w-full group-data-[role=user]/message:w-fit group-data-[role=user]/message:ml-auto group-data-[role=user]/message:max-w-[45rem] group-data-[role=user]/message:py-2 glassBubble',
+          'flex gap-4 group-data-[role=user]/message:px-3 w-full group-data-[role=user]/message:w-fit group-data-[role=user]/message:ml-auto group-data-[role=user]/message:max-w-[45rem] group-data-[role=user]/message:py-2 frostedGlow-peach',
           {
             'group-data-[role=user]/message:bg-muted': true,
           },

--- a/components/ui/textarea.tsx
+++ b/components/ui/textarea.tsx
@@ -9,7 +9,7 @@ const Textarea = React.forwardRef<
   return (
     <textarea
       className={cn(
-        'flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+        'flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-0 focus-visible:ring-offset-0 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
         className,
       )}
       ref={ref}


### PR DESCRIPTION
## Summary
- add reusable `frostedGlow` utility with tint modifiers
- give user and assistant messages a frosted-glass look
- soften composer focus outline with inset glow
- remove default ring styles from textarea

## Testing
- `pnpm lint`
- `pnpm tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_687a0068bff4832aab6b2ee0beb71107