### PR TITLE
feat: apply frosted glow bubbles and custom focus

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -256,9 +256,7 @@
     }
 
     /* Orange theme component tweaks */
-    .orange [data-role="assistant"] [data-testid="message-content"],
-    .orange .chat-response {
-        background-color: #ffd4ad;
+    .orange [data-role="assistant"] [data-testid="message-content"] {
         padding: 0.5rem 0.75rem;
         border-radius: 0.75rem;
     }
@@ -346,13 +344,43 @@
         }
     }
 
-    .glassBubble {
-        border-radius: 24px;
-        backdrop-filter: blur(10px) saturate(160%);
-        border: 1px solid var(--glass-stroke);
-        box-shadow: 0 2px 6px rgba(0,0,0,.04);
-        transition: transform .18s ease, box-shadow .18s ease;
-    }
+.glassBubble {
+    border-radius: 24px;
+    backdrop-filter: blur(10px) saturate(160%);
+    border: 1px solid var(--glass-stroke);
+    box-shadow: 0 2px 6px rgba(0,0,0,.04);
+    transition: transform .18s ease, box-shadow .18s ease;
+}
+
+/* Frosted glow utility */
+.frostedGlow {
+    border-radius: 24px;
+    backdrop-filter: blur(10px) saturate(160%);
+    border: 1px solid var(--glass-stroke);
+    background: radial-gradient(ellipse 130% 100% at center, var(--frosted-color) 0%, transparent 90%);
+    box-shadow: 0 2px 6px rgba(0,0,0,.04);
+    transition: transform .18s ease, box-shadow .18s ease, background .2s ease;
+}
+
+.frostedGlow-orange {
+    --frosted-color: color-mix(in srgb, var(--brand-accent) 60%, transparent);
+    --frosted-halo: rgba(255,185,139,.6);
+}
+
+.frostedGlow-peach {
+    --frosted-color: color-mix(in srgb, #ffd4ad 50%, transparent);
+    --frosted-halo: rgba(255,212,173,.5);
+}
+
+.frostedGlow-grey {
+    --frosted-color: color-mix(in srgb, #f0f0f0 60%, transparent);
+    --frosted-halo: rgba(240,240,240,.5);
+}
+
+.frostedGlow:hover,
+.frostedGlow:focus-visible {
+    box-shadow: 0 2px 6px rgba(0,0,0,.04), 0 6px 16px rgba(0,0,0,.08), 0 0 12px var(--frosted-halo);
+}
 
     .glassIcon {
         position: relative;
@@ -464,7 +492,7 @@
     .composerDock:focus-within {
         background: radial-gradient(ellipse 130% 100% at center, color-mix(in srgb, var(--brand-accent) 65%, transparent) 0%, transparent 90%);
         transform: translateY(-2px) scaleY(1.1);
-        box-shadow: 0 4px 12px rgba(0,0,0,.08), 0 0 8px rgba(255,185,139,.6);
+        box-shadow: 0 4px 12px rgba(0,0,0,.08), 0 0 8px rgba(255,185,139,.6), inset 0 0 0 2px rgba(255,255,255,.9);
     }
 
     @keyframes composerRipple {

--- a/components/message.tsx
+++ b/components/message.tsx
@@ -128,11 +128,11 @@ const PurePreviewMessage = ({
                       <div
                         data-testid="message-content"
                         className={cn(
-                          'flex flex-col gap-4 glassBubble px-3 py-2 messageContent',
+                          'flex flex-col gap-4 frostedGlow px-3 py-2 messageContent',
                           {
-                            'bg-primary text-primary-foreground':
+                            'frostedGlow-orange text-primary-foreground':
                               message.role === 'user',
-                            'chat-response': message.role === 'assistant',
+                            'frostedGlow-peach': message.role === 'assistant',
                           },
                         )}
                       >
@@ -270,7 +270,7 @@ export const ThinkingMessage = () => {
     >
       <div
         className={cx(
-          'flex gap-4 group-data-[role=user]/message:px-3 w-full group-data-[role=user]/message:w-fit group-data-[role=user]/message:ml-auto group-data-[role=user]/message:max-w-[45rem] group-data-[role=user]/message:py-2 glassBubble',
+          'flex gap-4 group-data-[role=user]/message:px-3 w-full group-data-[role=user]/message:w-fit group-data-[role=user]/message:ml-auto group-data-[role=user]/message:max-w-[45rem] group-data-[role=user]/message:py-2 frostedGlow frostedGlow-peach',
           {
             'group-data-[role=user]/message:bg-muted': true,
           },

--- a/components/multimodal-input.tsx
+++ b/components/multimodal-input.tsx
@@ -281,7 +281,7 @@ function PureMultimodalInput({
         value={input}
         onChange={handleInput}
         className={cx(
-          'min-h-[24px] max-h-[calc(75dvh)] overflow-hidden resize-none rounded-2xl !text-base pb-10 bg-transparent border-none text-[color:var(--ink)] placeholder:text-[rgba(29,29,31,0.7)] caret-brand',
+          'min-h-[24px] max-h-[calc(75dvh)] overflow-hidden resize-none rounded-2xl !text-base pb-10 bg-transparent border-none text-[color:var(--ink)] placeholder:text-[rgba(29,29,31,0.7)] caret-brand focus:outline-none focus-visible:outline-none focus-visible:ring-0 focus-visible:ring-offset-0',
           className,
         )}
         rows={2}


### PR DESCRIPTION
## Summary
- implement reusable frostedGlow utility for glass bubbles
- tint chat bubbles according to role
- add custom inner focus glow to composer

## Testing
- `pnpm lint`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_687a0068bff4832aab6b2ee0beb71107