### PR TITLE
feat: refine bubble styling

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -300,9 +300,9 @@
     .orange .composerDock {
         background: radial-gradient(
                 ellipse 130% 100% at center,
-                color-mix(in srgb, var(--brand-accent) 60%, transparent) 0%,
-                color-mix(in srgb, var(--brand-accent) 55%, transparent) 33%,
-                transparent 85%
+                color-mix(in srgb, var(--brand-accent) 45%, transparent) 0%,
+                color-mix(in srgb, var(--brand-accent) 40%, transparent) 25%,
+                transparent 60%
         );
     }
 
@@ -368,8 +368,14 @@
 }
 
 .frostedGlow-orange {
-    --frosted-color: color-mix(in srgb, var(--brand-accent) 60%, transparent);
+    --frosted-color: var(--brand-accent);
     --frosted-halo: rgba(255,185,139,.6);
+    background: radial-gradient(
+                ellipse 130% 100% at center,
+                var(--brand-accent) 0%,
+                var(--brand-accent) 97%,
+                transparent 100%
+    );
 }
 
 .frostedGlow-peach {
@@ -480,9 +486,9 @@
         border: 1px solid rgba(255,255,255,.12);
         background: radial-gradient(
                 ellipse 130% 100% at center,
-                color-mix(in srgb, var(--brand-accent) 60%, transparent) 0%,
-                color-mix(in srgb, var(--brand-accent) 55%, transparent) 33%,
-                transparent 85%
+                color-mix(in srgb, var(--brand-accent) 45%, transparent) 0%,
+                color-mix(in srgb, var(--brand-accent) 40%, transparent) 25%,
+                transparent 60%
         );
         box-shadow: inset 0 0 0 1px rgba(255,255,255,.12), 0 2px 4px rgba(0,0,0,.05);
         transition: background .2s ease, box-shadow .2s ease, transform .18s ease;
@@ -491,9 +497,9 @@
     .composerDock:hover {
         background: radial-gradient(
                 ellipse 130% 100% at center,
-                color-mix(in srgb, var(--brand-accent) 65%, transparent) 0%,
-                color-mix(in srgb, var(--brand-accent) 60%, transparent) 33%,
-                transparent 85%
+                color-mix(in srgb, var(--brand-accent) 50%, transparent) 0%,
+                color-mix(in srgb, var(--brand-accent) 45%, transparent) 25%,
+                transparent 60%
         );
         transform: translateY(-2px);
         box-shadow: inset 0 0 0 1px rgba(255,255,255,.12), 0 4px 10px rgba(0,0,0,.08);
@@ -503,18 +509,18 @@
     .orange .composerDock:focus-within {
         background: radial-gradient(
                 ellipse 130% 100% at center,
-                color-mix(in srgb, var(--brand-accent) 65%, transparent) 0%,
-                color-mix(in srgb, var(--brand-accent) 60%, transparent) 33%,
-                transparent 85%
+                color-mix(in srgb, var(--brand-accent) 50%, transparent) 0%,
+                color-mix(in srgb, var(--brand-accent) 45%, transparent) 25%,
+                transparent 60%
         );
     }
 
     .composerDock:focus-within {
         background: radial-gradient(
                 ellipse 130% 100% at center,
-                color-mix(in srgb, var(--brand-accent) 65%, transparent) 0%,
-                color-mix(in srgb, var(--brand-accent) 60%, transparent) 33%,
-                transparent 85%
+                color-mix(in srgb, var(--brand-accent) 50%, transparent) 0%,
+                color-mix(in srgb, var(--brand-accent) 45%, transparent) 25%,
+                transparent 60%
         );
         transform: translateY(-2px);
         box-shadow: inset 0 0 0 1px rgba(255,255,255,.12), 0 4px 10px rgba(0,0,0,.08), 0 0 12px rgba(255,185,139,.6);

--- a/components/message.tsx
+++ b/components/message.tsx
@@ -130,7 +130,7 @@ const PurePreviewMessage = ({
                         className={cn(
                           'flex flex-col gap-4 frostedGlow px-3 py-2 messageContent',
                           {
-                            'frostedGlow-orange text-primary-foreground':
+                            'frostedGlow-orange text-[color:var(--ink)]':
                               message.role === 'user',
                             'frostedGlow-peach': message.role === 'assistant',
                           },


### PR DESCRIPTION
## Summary
- tweak user bubble so solid orange fills fade quickly to glass
- lighten composer bar tint and shrink its color area
- set user bubble text to dark ink color

## Testing
- `pnpm tsc --noEmit`
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_687b63139720832aae2a1be5d1e24753