### PR TITLE
feat: refine orange bubble and composer tint

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -300,9 +300,8 @@
     .orange .composerDock {
         background: radial-gradient(
                 ellipse 130% 100% at center,
-                color-mix(in srgb, var(--brand-accent) 60%, transparent) 0%,
-                color-mix(in srgb, var(--brand-accent) 55%, transparent) 33%,
-                transparent 85%
+                color-mix(in srgb, var(--brand-accent) 50%, transparent) 0%,
+                transparent 33%
         );
     }
 
@@ -368,8 +367,14 @@
 }
 
 .frostedGlow-orange {
-    --frosted-color: color-mix(in srgb, var(--brand-accent) 60%, transparent);
+    --frosted-color: var(--brand-accent);
     --frosted-halo: rgba(255,185,139,.6);
+    background: radial-gradient(
+            ellipse 130% 100% at center,
+            var(--frosted-color) 0%,
+            var(--frosted-color) 96%,
+            transparent 100%
+    );
 }
 
 .frostedGlow-peach {
@@ -480,9 +485,8 @@
         border: 1px solid rgba(255,255,255,.12);
         background: radial-gradient(
                 ellipse 130% 100% at center,
-                color-mix(in srgb, var(--brand-accent) 60%, transparent) 0%,
-                color-mix(in srgb, var(--brand-accent) 55%, transparent) 33%,
-                transparent 85%
+                color-mix(in srgb, var(--brand-accent) 50%, transparent) 0%,
+                transparent 33%
         );
         box-shadow: inset 0 0 0 1px rgba(255,255,255,.12), 0 2px 4px rgba(0,0,0,.05);
         transition: background .2s ease, box-shadow .2s ease, transform .18s ease;
@@ -491,9 +495,8 @@
     .composerDock:hover {
         background: radial-gradient(
                 ellipse 130% 100% at center,
-                color-mix(in srgb, var(--brand-accent) 65%, transparent) 0%,
-                color-mix(in srgb, var(--brand-accent) 60%, transparent) 33%,
-                transparent 85%
+                color-mix(in srgb, var(--brand-accent) 55%, transparent) 0%,
+                transparent 33%
         );
         transform: translateY(-2px);
         box-shadow: inset 0 0 0 1px rgba(255,255,255,.12), 0 4px 10px rgba(0,0,0,.08);
@@ -503,18 +506,16 @@
     .orange .composerDock:focus-within {
         background: radial-gradient(
                 ellipse 130% 100% at center,
-                color-mix(in srgb, var(--brand-accent) 65%, transparent) 0%,
-                color-mix(in srgb, var(--brand-accent) 60%, transparent) 33%,
-                transparent 85%
+                color-mix(in srgb, var(--brand-accent) 55%, transparent) 0%,
+                transparent 33%
         );
     }
 
     .composerDock:focus-within {
         background: radial-gradient(
                 ellipse 130% 100% at center,
-                color-mix(in srgb, var(--brand-accent) 65%, transparent) 0%,
-                color-mix(in srgb, var(--brand-accent) 60%, transparent) 33%,
-                transparent 85%
+                color-mix(in srgb, var(--brand-accent) 55%, transparent) 0%,
+                transparent 33%
         );
         transform: translateY(-2px);
         box-shadow: inset 0 0 0 1px rgba(255,255,255,.12), 0 4px 10px rgba(0,0,0,.08), 0 0 12px rgba(255,185,139,.6);


### PR DESCRIPTION
## Summary
- update user bubble to use solid orange with quick fade to glass
- adjust composer input bar tint for earlier fade

## Testing
- `pnpm lint`
- `pnpm tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_687b63139720832aae2a1be5d1e24753