### PR TITLE
feat: style user message bubble

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -461,14 +461,17 @@
             animation: none !important;
         }
         .composerDock,
-        .composerButton {
+        .composerButton,
+        .frostedInputBubble {
             transition: opacity .18s ease, background .18s ease, box-shadow .18s ease;
         }
         .composerDock:hover,
         .composerDock:focus-within,
         .composerButton:hover,
         .composerButton:focus-visible,
-        .composerButton:active {
+        .composerButton:active,
+        .frostedInputBubble:hover,
+        .frostedInputBubble:focus-visible {
             transform: none !important;
         }
     }
@@ -542,6 +545,33 @@
         border-radius: inherit;
         pointer-events: none;
         animation: composerRipple 1s forwards;
+    }
+
+    .frostedInputBubble {
+        position: relative;
+        border-radius: 24px;
+        backdrop-filter: blur(10px) saturate(160%);
+        border: 1px solid rgba(255,255,255,.12);
+        background: radial-gradient(
+                ellipse 130% 100% at center,
+                color-mix(in srgb, var(--brand-accent) 60%, transparent) 0%,
+                color-mix(in srgb, var(--brand-accent) 55%, transparent) 33%,
+                transparent 80%
+        );
+        box-shadow: inset 0 0 0 1px rgba(255,255,255,.12), 0 2px 4px rgba(0,0,0,.05);
+        transition: background .2s ease, box-shadow .2s ease, transform .18s ease;
+    }
+
+    .frostedInputBubble:hover,
+    .frostedInputBubble:focus-visible {
+        background: radial-gradient(
+                ellipse 130% 100% at center,
+                color-mix(in srgb, var(--brand-accent) 65%, transparent) 0%,
+                color-mix(in srgb, var(--brand-accent) 60%, transparent) 33%,
+                transparent 80%
+        );
+        transform: translateY(-2px);
+        box-shadow: inset 0 0 0 1px rgba(255,255,255,.12), 0 4px 10px rgba(0,0,0,.08), 0 0 12px rgba(255,185,139,.6);
     }
 
     .composerButton {

--- a/components/message.tsx
+++ b/components/message.tsx
@@ -130,7 +130,7 @@ const PurePreviewMessage = ({
                         className={cn(
                           'flex flex-col gap-4 frostedGlow px-3 py-2 messageContent',
                           {
-                            'frostedGlow-orange text-primary-foreground':
+                            'frostedInputBubble frostedGlow-orange text-primary-foreground':
                               message.role === 'user',
                             'frostedGlow-peach': message.role === 'assistant',
                           },


### PR DESCRIPTION
## Summary
- match the user message bubble to the polished composer styles
- add `.frostedInputBubble` styles with radial gradient, glass blur, and hover effects
- use the new bubble class on user messages

## Testing
- `pnpm lint`
- `pnpm tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_687bfd9138ec832a808d1aa758eef6e0