### PR TITLE
fix: deepen user message tint

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -372,6 +372,11 @@
     --frosted-halo: rgba(255,185,139,.6);
 }
 
+.frostedGlow-orangeDeep {
+    --frosted-color: color-mix(in srgb, hsl(25 90% 55%) 60%, transparent);
+    --frosted-halo: rgba(255,185,139,.6);
+}
+
 .frostedGlow-peach {
     --frosted-color: color-mix(in srgb, #ffd4ad 50%, transparent);
     --frosted-halo: rgba(255,212,173,.5);
@@ -461,14 +466,17 @@
             animation: none !important;
         }
         .composerDock,
-        .composerButton {
+        .composerButton,
+        .frostedInputBubble {
             transition: opacity .18s ease, background .18s ease, box-shadow .18s ease;
         }
         .composerDock:hover,
         .composerDock:focus-within,
         .composerButton:hover,
         .composerButton:focus-visible,
-        .composerButton:active {
+        .composerButton:active,
+        .frostedInputBubble:hover,
+        .frostedInputBubble:focus-visible {
             transform: none !important;
         }
     }
@@ -542,6 +550,33 @@
         border-radius: inherit;
         pointer-events: none;
         animation: composerRipple 1s forwards;
+    }
+
+    .frostedInputBubble {
+        position: relative;
+        border-radius: 24px;
+        backdrop-filter: blur(10px) saturate(160%);
+        border: 1px solid rgba(255,255,255,.12);
+        background: radial-gradient(
+                ellipse 130% 100% at center,
+                color-mix(in srgb, hsl(25 90% 55%) 60%, transparent) 0%,
+                color-mix(in srgb, hsl(25 90% 55%) 55%, transparent) 33%,
+                transparent 80%
+        );
+        box-shadow: inset 0 0 0 1px rgba(255,255,255,.12), 0 2px 4px rgba(0,0,0,.05);
+        transition: background .2s ease, box-shadow .2s ease, transform .18s ease;
+    }
+
+    .frostedInputBubble:hover,
+    .frostedInputBubble:focus-visible {
+        background: radial-gradient(
+                ellipse 130% 100% at center,
+                color-mix(in srgb, hsl(25 90% 55%) 65%, transparent) 0%,
+                color-mix(in srgb, hsl(25 90% 55%) 60%, transparent) 33%,
+                transparent 80%
+        );
+        transform: translateY(-2px);
+        box-shadow: inset 0 0 0 1px rgba(255,255,255,.12), 0 4px 10px rgba(0,0,0,.08), 0 0 12px rgba(255,185,139,.6);
     }
 
     .composerButton {

--- a/components/message.tsx
+++ b/components/message.tsx
@@ -130,7 +130,7 @@ const PurePreviewMessage = ({
                         className={cn(
                           'flex flex-col gap-4 frostedGlow px-3 py-2 messageContent',
                           {
-                            'frostedGlow-orange text-primary-foreground':
+                            'frostedInputBubble frostedGlow-orangeDeep text-primary-foreground':
                               message.role === 'user',
                             'frostedGlow-peach': message.role === 'assistant',
                           },


### PR DESCRIPTION
## Summary
- style `.frostedInputBubble` with a richer orange gradient
- add `.frostedGlow-orangeDeep` utility for darker bubbles
- apply the new style to user messages

## Testing
- `pnpm lint`
- `pnpm tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_687bfd9138ec832a808d1aa758eef6e0