### PR TITLE
[feat]: enrich agent preview modal

### DIFF
--- a/app/(chat)/api/agents/[id]/chats/route.ts
+++ b/app/(chat)/api/agents/[id]/chats/route.ts
@@ -1,0 +1,18 @@
+import { auth } from '@/app/(auth)/auth';
+import type { NextRequest } from 'next/server';
+import { getChatsByAgentId } from '@/lib/db/queries';
+import { ChatSDKError } from '@/lib/errors';
+
+export async function GET(request: NextRequest, { params }: { params: { id: string } }) {
+  const { searchParams } = request.nextUrl;
+  const limit = Number.parseInt(searchParams.get('limit') || '5');
+  const cursor = searchParams.get('cursor');
+
+  const session = await auth();
+  if (!session?.user) {
+    return new ChatSDKError('unauthorized:chat').toResponse();
+  }
+
+  const result = await getChatsByAgentId({ agentId: params.id, limit, cursor });
+  return Response.json(result);
+}

--- a/app/(chat)/api/chat/route.ts
+++ b/app/(chat)/api/chat/route.ts
@@ -68,8 +68,13 @@ export async function POST(request: Request) {
   }
 
   try {
-    const { id, message, selectedChatModel, selectedVisibilityType } =
-      requestBody;
+    const {
+      id,
+      message,
+      selectedChatModel,
+      selectedVisibilityType,
+      agentId,
+    } = requestBody;
 
     const session = await auth();
     if (!session?.user) {
@@ -86,6 +91,7 @@ export async function POST(request: Request) {
         title,
         visibility: selectedVisibilityType,
         modelId: selectedChatModel,
+        agentId,
       });
     } else if (chat.userId !== session.user.id) {
       return new ChatSDKError('forbidden:chat').toResponse();

--- a/app/(chat)/api/chat/schema.ts
+++ b/app/(chat)/api/chat/schema.ts
@@ -7,6 +7,7 @@ const textPartSchema = z.object({
 
 export const postRequestBodySchema = z.object({
   id: z.string().uuid(),
+  agentId: z.string().optional(),
   message: z.object({
     id: z.string().uuid(),
     createdAt: z.coerce.date(),

--- a/app/(chat)/chat/[id]/page.tsx
+++ b/app/(chat)/chat/[id]/page.tsx
@@ -92,6 +92,7 @@ export default async function Page({
     session: session, // session is guaranteed here
     autoResume: true,
     initialInput: initialPromptFromQuery,
+    agentId: chat.agentId ?? undefined,
   };
 
   return (

--- a/app/(chat)/page.tsx
+++ b/app/(chat)/page.tsx
@@ -25,6 +25,10 @@ export default async function Page({
     typeof resolvedSearchParams?.modelId === 'string'
       ? resolvedSearchParams.modelId
       : null;
+  const agentIdParam =
+    typeof resolvedSearchParams?.agentId === 'string'
+      ? resolvedSearchParams.agentId
+      : null;
 
   if (success && planId && session?.user?.id) {
     const { PostCheckoutUpdater } = await import('@/components/post-checkout-updater');
@@ -71,6 +75,7 @@ export default async function Page({
         isReadonly={false}
         session={session}
         autoResume={false}
+        agentId={agentIdParam ?? undefined}
       />
       <DataStreamHandler id={id} />
     </>

--- a/components/agents/agent-dialog.tsx
+++ b/components/agents/agent-dialog.tsx
@@ -9,10 +9,58 @@ import { VisuallyHidden } from '@radix-ui/react-visually-hidden';
 import { Button } from '@/components/ui/button';
 import { useAgentPopup } from '@/hooks/use-agent-popup';
 import { useTranslation } from '@/lib/i18n';
+import useSWRInfinite from 'swr/infinite';
+import { fetcher } from '@/lib/utils';
+import { format } from 'date-fns';
+import { useEffect, useRef } from 'react';
+import type { Chat } from '@/lib/db/schema';
 
 export function AgentDialog() {
   const { isOpen, closePopup } = useAgentPopup();
   const t = useTranslation();
+
+  const agentId = 'demo-agent';
+
+  const listRef = useRef<HTMLDivElement>(null);
+  const {
+    data: pages,
+    setSize,
+    isValidating,
+  } = useSWRInfinite<{ chats: Array<Chat>; nextCursor: string | null }>(
+    (pageIndex, previousPageData) => {
+      if (previousPageData && !previousPageData.nextCursor) return null;
+      const cursor = previousPageData ? previousPageData.nextCursor : null;
+      return `/api/agents/${agentId}/chats?limit=5${
+        cursor ? `&cursor=${cursor}` : ''
+      }`;
+    },
+    fetcher,
+    { revalidateFirstPage: false, parallel: true, fallbackData: [], shouldRetryOnError: false },
+  );
+
+  const chats = pages ? pages.flatMap((p) => p.chats) : [];
+  const nextCursor = pages?.[pages.length - 1]?.nextCursor;
+
+  useEffect(() => {
+    if (isOpen) {
+      setSize(1);
+    }
+    if (!listRef.current) return;
+    function onScroll() {
+      if (!listRef.current) return;
+      if (
+        listRef.current.scrollTop + listRef.current.clientHeight >=
+          listRef.current.scrollHeight - 4 &&
+        nextCursor &&
+        !isValidating
+      ) {
+        setSize((s) => s + 1);
+      }
+    }
+    const el = listRef.current;
+    el.addEventListener('scroll', onScroll);
+    return () => el.removeEventListener('scroll', onScroll);
+  }, [nextCursor, isValidating, setSize, isOpen]);
 
   if (!isOpen) return null;
 
@@ -23,14 +71,58 @@ export function AgentDialog() {
           <DialogTitle>{t('agents')}</DialogTitle>
         </VisuallyHidden>
         <div className="relative mx-auto w-full max-w-[52rem]">
-          <div className="absolute inset-0 rounded-[28px] bg-[#f0f0f0] pointer-events-none" />
-          <div className="relative p-6 sm:p-8 rounded-[28px] bg-white/90 dark:bg-gray-900/80 backdrop-blur-md shadow transition-transform duration-200 hover:scale-[1.02]">
-          <div className="h-60" />
-          <div className="mt-6 flex justify-center">
-            <Button className="bg-gradient-to-r from-[var(--brand-accent)] to-[#FFE3D2] text-white px-4 h-9 flex items-center shadow transition-shadow hover:shadow-[0_0_8px_rgba(255,255,255,0.5)]">
-              {t('goToChat')}
-            </Button>
-          </div>
+          <div className="absolute inset-0 rounded-[28px] frostedGlow frostedGlow-grey pointer-events-none" />
+          <div className="relative p-6 sm:p-8 rounded-[28px] bg-white/90 dark:bg-gray-900/80 backdrop-blur-md shadow">
+            <h2 className="font-bold text-xl text-center mb-4">Luna</h2>
+            <div className="w-full aspect-video rounded-xl overflow-hidden shadow-inner mb-4">
+              <img
+                src="/images/demo-thumbnail.png"
+                alt=""
+                aria-label={t('agentDemoAria')}
+                className="w-full h-full object-cover"
+              />
+            </div>
+            <p className="text-center opacity-80 max-w-prose mx-auto mb-6">
+              This assistant helps you craft creative narratives quickly.
+            </p>
+            <h3 className="font-medium mb-2 text-left">
+              {t('chatsWithAssistant')}
+            </h3>
+            <div
+              ref={listRef}
+              className="frostedGlow frostedGlow-peach rounded-xl max-h-60 overflow-y-auto divide-y divide-white/10 mb-4"
+            >
+              {chats.map((chat) => (
+                <button
+                  key={chat.id}
+                  type="button"
+                  className="w-full text-left px-3 py-2 hover:bg-white/20 transition-shadow"
+                  onClick={() => {
+                    window.location.href = `/chat/${chat.id}`;
+                  }}
+                >
+                  <div className="flex justify-between">
+                    <span>{chat.title}</span>
+                    <span className="text-xs opacity-70">
+                      {format(new Date(chat.updatedAt), 'P')}
+                    </span>
+                  </div>
+                </button>
+              ))}
+              {isValidating && (
+                <div className="py-2 text-center text-sm opacity-70">
+                  {t('loading')}
+                </div>
+              )}
+            </div>
+            {nextCursor ? (
+              <div className="text-center text-sm opacity-70 mb-2">{t('loadMore')}</div>
+            ) : null}
+            <div className="flex justify-center">
+              <Button className="bg-gradient-to-r from-[var(--brand-accent)] to-[#FFE3D2] text-white px-4 h-9 flex items-center shadow transition-shadow hover:shadow-[0_0_8px_rgba(255,255,255,0.5)]">
+                {t('goToChat')}
+              </Button>
+            </div>
           </div>
         </div>
       </DialogContent>

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -47,6 +47,7 @@ export function Chat({
   session, // This session prop comes from the Server Component page
   autoResume,
   initialInput: propInitialInput,
+  agentId,
 }: {
   id: string;
   initialMessages: Array<UIMessage>;
@@ -56,6 +57,7 @@ export function Chat({
   session: Session; // Session is now guaranteed by the page
   autoResume: boolean;
   initialInput?: string;
+  agentId?: string;
 }) {
   const { mutate: mutateGlobal } = useSWRConfig();
   const { openPopup: openLoginSignupPopup } = useLoginSignupPopup();
@@ -127,6 +129,7 @@ export function Chat({
     fetch: fetchWithErrorHandlers,
     experimental_prepareRequestBody: (body) => ({
       id,
+      agentId,
       message: body.messages.at(-1),
       selectedChatModel: chatModelId,
       selectedVisibilityType: visibilityType,

--- a/lib/db/migrations/0011_add_agent_and_updated.sql
+++ b/lib/db/migrations/0011_add_agent_and_updated.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "Chat" ADD COLUMN IF NOT EXISTS "agentId" varchar(64);
+ALTER TABLE "Chat" ADD COLUMN IF NOT EXISTS "updatedAt" timestamp NOT NULL DEFAULT now();
+UPDATE "Chat" SET "updatedAt" = "createdAt" WHERE "updatedAt" IS NULL;

--- a/lib/db/queries.ts
+++ b/lib/db/queries.ts
@@ -180,21 +180,25 @@ export async function saveChat({
   title,
   visibility,
   modelId,
+  agentId,
 }: {
   id: string;
   userId: string;
   title: string;
   visibility: VisibilityType;
   modelId: string;
+  agentId?: string | null;
 }) {
   try {
     return await db.insert(chat).values({
       id,
       createdAt: new Date(),
+      updatedAt: new Date(),
       userId,
       title,
       visibility,
       modelId,
+      agentId,
     });
   } catch (error) {
     console.error('Error saving chat:', error);
@@ -298,6 +302,52 @@ export async function getChatsByUserId({
   }
 }
 
+export async function getChatsByAgentId({
+  agentId,
+  limit,
+  cursor,
+}: {
+  agentId: string;
+  limit: number;
+  cursor?: string | null;
+}) {
+  try {
+    const extendedLimit = limit + 1;
+
+    let whereClause: SQL<any> = eq(chat.agentId, agentId);
+
+    if (cursor) {
+      const [cursorChat] = await db
+        .select({ updatedAt: chat.updatedAt })
+        .from(chat)
+        .where(eq(chat.id, cursor))
+        .limit(1);
+
+      if (!cursorChat) {
+        throw new ChatSDKError('not_found:database', `Chat with id ${cursor} not found`);
+      }
+
+      whereClause = and(eq(chat.agentId, agentId), lt(chat.updatedAt, cursorChat.updatedAt));
+    }
+
+    const chatsResult = await db
+      .select()
+      .from(chat)
+      .where(whereClause)
+      .orderBy(desc(chat.updatedAt))
+      .limit(extendedLimit);
+
+    const hasMore = chatsResult.length > limit;
+
+    return {
+      chats: hasMore ? chatsResult.slice(0, limit) : chatsResult,
+      nextCursor: hasMore ? chatsResult[limit].id : null,
+    };
+  } catch (error) {
+    throw new ChatSDKError('bad_request:database', 'Failed to get chats by agent id');
+  }
+}
+
 export async function getChatById({ id }: { id: string }) {
   try {
     const [selectedChat] = await db.select().from(chat).where(eq(chat.id, id));
@@ -313,7 +363,14 @@ export async function saveMessages({
   messages: Array<DBMessage>;
 }) {
   try {
-    return await db.insert(message).values(messages);
+    const result = await db.insert(message).values(messages).returning();
+    if (messages.length > 0) {
+      await db
+        .update(chat)
+        .set({ updatedAt: new Date() })
+        .where(eq(chat.id, messages[0].chatId));
+    }
+    return result;
   } catch (error) {
     throw new ChatSDKError('bad_request:database', 'Failed to save messages');
   }
@@ -683,6 +740,11 @@ export async function saveUserMessageWithLimit({
         createdAt: new Date(),
       })
       .returning();
+
+    await tx
+      .update(chat)
+      .set({ updatedAt: new Date() })
+      .where(eq(chat.id, chatId));
 
     return inserted;
   });

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -27,10 +27,12 @@ export type User = InferSelectModel<typeof user>;
 export const chat = pgTable('Chat', {
   id: uuid('id').primaryKey().notNull().defaultRandom(),
   createdAt: timestamp('createdAt').notNull(),
+  updatedAt: timestamp('updatedAt').notNull(),
   title: text('title').notNull(),
   userId: uuid('userId')
     .notNull()
     .references(() => user.id),
+  agentId: varchar('agentId', { length: 64 }),
   visibility: varchar('visibility', { enum: ['public', 'private'] })
     .notNull()
     .default('private'),

--- a/lib/i18n.tsx
+++ b/lib/i18n.tsx
@@ -118,6 +118,9 @@ export const translations = {
     agentUpdateInfo: 'Info about Assistants',
     upgradeModel: 'Upgrade model',
     goToChat: 'Go to chat',
+    chatsWithAssistant: 'Chats with this assistant',
+    loadMore: 'Load more…',
+    agentDemoAria: 'Assistant demo example',
   },
   nl: {
     newChat: 'Nieuw gesprek',
@@ -236,6 +239,9 @@ export const translations = {
     agentUpdateInfo: 'Info over Assistenten',
     upgradeModel: 'Upgrade model',
     goToChat: 'Ga naar chat',
+    chatsWithAssistant: 'Chats met deze assistent',
+    loadMore: 'Meer laden…',
+    agentDemoAria: 'Voorbeeld van de assistent',
   },
 } as const;
 


### PR DESCRIPTION
## Summary
- add Agent Preview modal chat list with SWR pagination
- track agent chats in database
- allow Chat component to pass agentId
- fetch chats by agent via new API route
- update translations

## Testing
- `pnpm lint`
- `pnpm tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6885cb252f60832abb2174dac3fa0cdd