### PR TITLE
feat: enhance agent preview modal

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -63,6 +63,8 @@
         --brand-beige: #F5EFEA;
         --ink: #1D1D1F;
         --glass-fill: color-mix(in srgb, var(--brand-accent) 12%, rgb(255 255 255 / 0.2));
+        --glass-fill-light: rgba(255,255,255,.85);
+        --glass-fill-dark: rgba(30,30,30,.70);
         --glass-stroke: rgb(255 255 255 / 0.3);
         --gap-user-to-assistant: 40px;
         --gap-assistant-to-user: 0px;
@@ -106,6 +108,8 @@
         --brand-beige: #F5EFEA;
         --ink: #1D1D1F;
         --glass-fill: color-mix(in srgb, var(--brand-accent) 12%, rgb(255 255 255 / 0.2));
+        --glass-fill-light: rgba(255,255,255,.85);
+        --glass-fill-dark: rgba(30,30,30,.70);
         --glass-stroke: rgb(255 255 255 / 0.3);
         --gap-user-to-assistant: 40px;
         --gap-assistant-to-user: 0px;
@@ -151,6 +155,8 @@
         --brand-beige: #F5EFEA;
         --ink: #1D1D1F;
         --glass-fill: color-mix(in srgb, var(--brand-accent) 12%, rgb(255 255 255 / 0.2));
+        --glass-fill-light: rgba(255,255,255,.85);
+        --glass-fill-dark: rgba(30,30,30,.70);
         --glass-stroke: rgb(255 255 255 / 0.3);
         --gap-user-to-assistant: 40px;
         --gap-assistant-to-user: 0px;

--- a/components/agents/agent-dialog.tsx
+++ b/components/agents/agent-dialog.tsx
@@ -4,35 +4,60 @@ import {
   Dialog,
   DialogContent,
   DialogTitle,
+  DialogClose,
 } from '@/components/ui/dialog';
 import { VisuallyHidden } from '@radix-ui/react-visually-hidden';
-import { Button } from '@/components/ui/button';
+import { motion } from 'framer-motion';
 import { useAgentPopup } from '@/hooks/use-agent-popup';
 import { useTranslation } from '@/lib/i18n';
+import { useRouter } from 'next/navigation';
 
 export function AgentDialog() {
   const { isOpen, closePopup } = useAgentPopup();
   const t = useTranslation();
+  const router = useRouter();
+
+  function goToChat() {
+    closePopup();
+    router.push('/');
+    router.refresh();
+  }
 
   if (!isOpen) return null;
 
   return (
     <Dialog open={isOpen} onOpenChange={closePopup}>
-      <DialogContent className="bg-transparent shadow-none border-none p-0 max-w-none rounded-none">
+      <DialogContent className="agentPreviewDialog bg-transparent shadow-none border-none p-0 max-w-none rounded-none">
         <VisuallyHidden>
           <DialogTitle>{t('agents')}</DialogTitle>
         </VisuallyHidden>
-        <div className="relative mx-auto w-full max-w-[52rem]">
-          <div className="absolute inset-0 rounded-[28px] bg-[#f0f0f0] pointer-events-none" />
-          <div className="relative p-6 sm:p-8 rounded-[28px] bg-white/90 dark:bg-gray-900/80 backdrop-blur-md shadow transition-transform duration-200 hover:scale-[1.02]">
-          <div className="h-60" />
-          <div className="mt-6 flex justify-center">
-            <Button className="bg-gradient-to-r from-[var(--brand-accent)] to-[#FFE3D2] text-white px-4 h-9 flex items-center shadow transition-shadow hover:shadow-[0_0_8px_rgba(255,255,255,0.5)]">
-              {t('goToChat')}
-            </Button>
+        <motion.div
+          initial={{ opacity: 0, scale: 0.96 }}
+          animate={{ opacity: 1, scale: 1 }}
+          transition={{ duration: 0.16 }}
+          className="agentPreviewCard mx-auto"
+        >
+          <DialogClose className="agentPreviewClose">
+            <span className="sr-only">Close</span>
+          </DialogClose>
+          <h2>Luna</h2>
+          <div className="agentPreviewDemo" aria-label={t('agentDemoLabel')} />
+          <p className="agentPreviewDescription">
+            Creative writing assistant helping craft engaging stories.
+          </p>
+          <div className="agentPreviewDivider" />
+          <div className="agentChatListHeader">{t('agentChatListHeading')}</div>
+          <div className="agentChatList">
+            <button type="button">How do I start a novel?</button>
+            <button type="button">Generate character ideas</button>
+            <button type="button">Outline a mystery plot</button>
+            <button type="button">Tips for dialogue</button>
+            <button type="button">Suggest a story prompt</button>
           </div>
-          </div>
-        </div>
+          <button type="button" className="goToChatButton" onClick={goToChat}>
+            {t('goToChat')}
+          </button>
+        </motion.div>
       </DialogContent>
     </Dialog>
   );

--- a/lib/i18n.tsx
+++ b/lib/i18n.tsx
@@ -118,6 +118,8 @@ export const translations = {
     agentUpdateInfo: 'Info about Assistants',
     upgradeModel: 'Upgrade model',
     goToChat: 'Go to chat',
+    agentChatListHeading: 'Chats with this assistant',
+    agentDemoLabel: 'Example of the assistant',
   },
   nl: {
     newChat: 'Nieuw gesprek',
@@ -236,6 +238,8 @@ export const translations = {
     agentUpdateInfo: 'Info over Assistenten',
     upgradeModel: 'Upgrade model',
     goToChat: 'Ga naar chat',
+    agentChatListHeading: 'Chats met deze assistent',
+    agentDemoLabel: 'Voorbeeld van de assistent',
   },
 } as const;
 

--- a/themes/assistenten.css
+++ b/themes/assistenten.css
@@ -34,3 +34,147 @@
 .assistenten-toggle:hover{
   box-shadow:0 0 8px rgba(255,255,255,.5);
 }
+
+/* Agent preview modal */
+.agentPreviewDialog [data-radix-dialog-close]{display:none;}
+.agentPreviewClose{
+  width:32px;
+  height:32px;
+  position:absolute;
+  top:16px;
+  right:16px;
+  border-radius:9999px;
+  backdrop-filter:blur(8px);
+  background:rgba(255,255,255,.2);
+  box-shadow:inset 0 0 0 1px rgb(255 255 255 /.2),0 1px 3px rgba(0,0,0,.05);
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  transition:box-shadow .2s,transform .2s;
+}
+.dark .agentPreviewClose{background:rgba(255,255,255,.1);}
+.agentPreviewClose:hover{
+  transform:translateY(-1px);
+  box-shadow:inset 0 0 0 1px rgb(255 255 255 /.2),0 4px 10px rgba(0,0,0,.1);
+}
+.agentPreviewClose:focus-visible{
+  outline:none;
+  box-shadow:0 0 0 2px rgba(255,185,139,.5) inset;
+}
+
+.agentPreviewCard{
+  width:min(640px,90vw);
+  border-radius:28px;
+  padding:32px;
+  padding-bottom:40px;
+  background:var(--glass-fill-light);
+  backdrop-filter:blur(14px) saturate(160%);
+  box-shadow:0 2px 10px rgba(0,0,0,.08);
+  border:1px solid rgba(255,255,255,.1);
+  position:relative;
+}
+.dark .agentPreviewCard{background:var(--glass-fill-dark);}
+.agentPreviewCard h2{
+  font-weight:700;
+  font-size:22px;
+  letter-spacing:-0.25px;
+  text-align:center;
+  margin-bottom:1rem;
+  background:linear-gradient(90deg,var(--brand-accent),#FFE3D2);
+  -webkit-background-clip:text;
+  -webkit-text-fill-color:transparent;
+}
+.agentPreviewDemo{
+  width:56%;
+  aspect-ratio:16/9;
+  margin:0 auto 1.5rem;
+  border-radius:16px;
+  background:rgba(255,185,139,.2);
+  position:relative;
+}
+.dark .agentPreviewDemo{background:rgba(255,185,139,.15);}
+.agentPreviewDescription{
+  max-width:60ch;
+  margin:0 auto 1.5rem;
+  font-size:16px;
+  text-align:center;
+  color:#1d1d1fcc;
+}
+.dark .agentPreviewDescription{color:#ffffffe6;}
+.agentPreviewDivider{
+  height:1px;
+  background:rgba(255,255,255,.08);
+  margin-bottom:1rem;
+}
+.dark .agentPreviewDivider{background:rgba(255,255,255,.14);}
+.agentChatListHeader{
+  font-size:14px;
+  font-weight:500;
+  text-align:left;
+  margin-bottom:0.5rem;
+}
+.agentChatList{
+  height:240px;
+  overflow-y:auto;
+  padding:0.25rem;
+  border-radius:12px;
+  background:rgba(255,255,255,.10);
+  backdrop-filter:blur(8px);
+  -webkit-mask-image:linear-gradient(to bottom,transparent,black 12px,black calc(100% - 12px),transparent);
+  mask-image:linear-gradient(to bottom,transparent,black 12px,black calc(100% - 12px),transparent);
+}
+.dark .agentChatList{background:rgba(255,255,255,.04);}
+.agentChatList button{
+  height:40px;
+  width:100%;
+  text-align:left;
+  padding:0 1rem;
+  border-radius:9999px;
+  display:flex;
+  align-items:center;
+  transition:background .15s,transform .15s,box-shadow .15s;
+}
+.agentChatList button:hover{
+  transform:translateY(-1px);
+  background:rgba(255,185,139,.12);
+  box-shadow:0 0 0 2px rgba(255,185,139,.3);
+}
+.dark .agentChatList button:hover{
+  background:rgba(255,185,139,.08);
+  box-shadow:0 0 0 2px rgba(255,185,139,.25);
+}
+.agentChatList button:focus-visible{
+  outline:none;
+  box-shadow:0 0 0 2px rgba(255,185,139,.5) inset;
+}
+
+.goToChatButton{
+  width:120px;
+  height:40px;
+  margin-top:32px;
+  margin-bottom:40px;
+  border-radius:9999px;
+  background:linear-gradient(90deg,var(--brand-accent),#FFE3D2);
+  color:#fff;
+  display:block;
+  margin-left:auto;
+  margin-right:auto;
+  box-shadow:0 0 0 0 rgba(255,185,139,.4);
+  transition:box-shadow .15s,filter .15s,transform .15s;
+}
+.goToChatButton:hover{
+  filter:brightness(1.05);
+  box-shadow:0 0 8px rgba(255,185,139,.4);
+  transform:translateY(-1px);
+}
+.goToChatButton:focus-visible{
+  outline:none;
+  box-shadow:0 0 0 2px rgba(255,185,139,.5) inset;
+}
+
+@media(max-width:480px){
+  .agentPreviewCard{width:95vw;padding-left:0;padding-right:0;}
+  .agentPreviewDescription{font-size:14px;}
+  .agentChatList{height:180px;}
+  .agentPreviewClose{top:12px;right:12px;}
+}


### PR DESCRIPTION
## Summary
- add go-to-chat button in AgentDialog
- move close icon inside the preview card
- update Assistenten theme styles for new button and close coin

## Testing
- `pnpm lint`
- `pnpm exec tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6885d04bbe5c832aa120d46037fbcf23