### PR TITLE
feat: add agent-specific chat model support

### DIFF
--- a/app/(assistenten)/assistenten/page.tsx
+++ b/app/(assistenten)/assistenten/page.tsx
@@ -11,14 +11,44 @@ export default function AssistentenPage() {
   const t = useTranslation();
 
   const recentlyUsed: AgentCardProps[] = [
-    { name: 'Luna', description: 'Creative writing assistant', avatar: 'https://avatar.vercel.sh/luna' },
-    { name: 'Moga', description: 'Math tutor bot', avatar: 'https://avatar.vercel.sh/moga' },
+    {
+      name: 'Luna',
+      description: 'Creative writing assistant',
+      avatar: 'https://avatar.vercel.sh/luna',
+      modelId: 'gpt-4.1',
+      instructions: 'You help users write engaging stories.',
+    },
+    {
+      name: 'Moga',
+      description: 'Math tutor bot',
+      avatar: 'https://avatar.vercel.sh/moga',
+      modelId: 'gpt-4.1',
+      instructions: 'Assist with solving math problems.',
+    },
   ];
 
   const recommended: AgentCardProps[] = [
-    { name: 'Rela', description: 'Relationship advice', avatar: 'https://avatar.vercel.sh/rela' },
-    { name: 'Echo', description: 'Quick Q&A', avatar: 'https://avatar.vercel.sh/echo' },
-    { name: 'Beta', description: 'Beta features explorer', avatar: 'https://avatar.vercel.sh/beta' },
+    {
+      name: 'Rela',
+      description: 'Relationship advice',
+      avatar: 'https://avatar.vercel.sh/rela',
+      modelId: 'gpt-4.1',
+      instructions: 'Give thoughtful relationship tips.',
+    },
+    {
+      name: 'Echo',
+      description: 'Quick Q&A',
+      avatar: 'https://avatar.vercel.sh/echo',
+      modelId: 'gpt-4.1',
+      instructions: 'Answer short questions succinctly.',
+    },
+    {
+      name: 'Beta',
+      description: 'Beta features explorer',
+      avatar: 'https://avatar.vercel.sh/beta',
+      modelId: 'gpt-4.1',
+      instructions: 'Help test new features.',
+    },
   ];
 
   const container = {

--- a/app/(chat)/api/history/route.ts
+++ b/app/(chat)/api/history/route.ts
@@ -9,6 +9,7 @@ export async function GET(request: NextRequest) {
   const limit = Number.parseInt(searchParams.get('limit') || '10');
   const startingAfter = searchParams.get('starting_after');
   const endingBefore = searchParams.get('ending_before');
+  const modelId = searchParams.get('modelId');
 
   if (startingAfter && endingBefore) {
     return new ChatSDKError(
@@ -28,6 +29,7 @@ export async function GET(request: NextRequest) {
     limit,
     startingAfter,
     endingBefore,
+    modelId: modelId || undefined,
   });
 
   return Response.json(chats);

--- a/components/agents/agent-card.tsx
+++ b/components/agents/agent-card.tsx
@@ -6,6 +6,8 @@ export interface AgentCardProps {
   name: string;
   description: string;
   avatar: string;
+  modelId: string;
+  instructions: string;
 }
 
 const cardVariants = {
@@ -13,7 +15,13 @@ const cardVariants = {
   animate: { opacity: 1, y: 0 },
 };
 
-export function AgentCard({ name, description, avatar }: AgentCardProps) {
+export function AgentCard({
+  name,
+  description,
+  avatar,
+  modelId,
+  instructions,
+}: AgentCardProps) {
   const { openPopup } = useAgentPopup();
   return (
     <motion.button
@@ -21,7 +29,15 @@ export function AgentCard({ name, description, avatar }: AgentCardProps) {
       whileHover={{ translateY: -4, scale: 1.015 }}
       whileTap={{ scale: 0.98 }}
       className="ripple relative flex items-start gap-5 rounded-[24px] border border-white/30 bg-white/10 px-[2rem] py-[1.75rem] backdrop-blur-[18px] backdrop-saturate-[180%] transition-transform shadow-sm hover:shadow-md focus:outline-none overflow-hidden"
-      onClick={openPopup}
+      onClick={() =>
+        openPopup({
+          name,
+          description,
+          avatar,
+          modelId,
+          instructions,
+        })
+      }
     >
       <span
         className="flex h-[72px] w-[72px] flex-shrink-0 items-center justify-center rounded-full"

--- a/components/agents/agent-dialog.tsx
+++ b/components/agents/agent-dialog.tsx
@@ -12,19 +12,33 @@ import { X } from 'lucide-react';
 import { useAgentPopup } from '@/hooks/use-agent-popup';
 import { useTranslation } from '@/lib/i18n';
 import { useRouter } from 'next/navigation';
+import useSWR from 'swr';
+import { fetcher } from '@/lib/utils';
 
 export function AgentDialog() {
-  const { isOpen, closePopup } = useAgentPopup();
+  const { isOpen, closePopup, agent } = useAgentPopup();
   const t = useTranslation();
   const router = useRouter();
 
+  const { data } = useSWR(
+    isOpen && agent ? `/api/history?limit=50&modelId=${agent.modelId}` : null,
+    fetcher,
+  );
+
   function goToChat() {
+    if (!agent) return;
     closePopup();
-    router.push('/');
+    router.push(`/?modelId=${agent.modelId}`);
     router.refresh();
   }
 
-  if (!isOpen) return null;
+  function openChat(chatId: string) {
+    closePopup();
+    router.push(`/chat/${chatId}`);
+    router.refresh();
+  }
+
+  if (!isOpen || !agent) return null;
 
   return (
     <Dialog open={isOpen} onOpenChange={closePopup}>
@@ -42,19 +56,21 @@ export function AgentDialog() {
             <X className="h-4 w-4" />
             <span className="sr-only">Close</span>
           </DialogClose>
-          <h2>Luna</h2>
+          <h2>{agent.name}</h2>
           <div className="agentPreviewDemo" aria-label={t('agentDemoLabel')} />
-          <p className="agentPreviewDescription">
-            Creative writing assistant helping craft engaging stories.
-          </p>
+          <p className="agentPreviewDescription">{agent.description}</p>
           <div className="agentPreviewDivider" />
           <div className="agentChatListHeader">{t('agentChatListHeading')}</div>
           <div className="agentChatList">
-            <button type="button">How do I start a novel?</button>
-            <button type="button">Generate character ideas</button>
-            <button type="button">Outline a mystery plot</button>
-            <button type="button">Tips for dialogue</button>
-            <button type="button">Suggest a story prompt</button>
+            {data?.chats.map((chat: { id: string; title: string }) => (
+              <button
+                key={chat.id}
+                type="button"
+                onClick={() => openChat(chat.id)}
+              >
+                {chat.title}
+              </button>
+            ))}
           </div>
           <button type="button" className="goToChatButton" onClick={goToChat}>
             {t('goToChat')}

--- a/hooks/use-agent-popup.ts
+++ b/hooks/use-agent-popup.ts
@@ -1,13 +1,23 @@
 import { create } from 'zustand';
 
+export interface AgentInfo {
+  name: string;
+  description: string;
+  avatar: string;
+  modelId: string;
+  instructions: string;
+}
+
 interface AgentPopupState {
   isOpen: boolean;
-  openPopup: () => void;
+  agent: AgentInfo | null;
+  openPopup: (agent: AgentInfo) => void;
   closePopup: () => void;
 }
 
 export const useAgentPopup = create<AgentPopupState>((set) => ({
   isOpen: false,
-  openPopup: () => set({ isOpen: true }),
-  closePopup: () => set({ isOpen: false }),
+  agent: null,
+  openPopup: (agent) => set({ isOpen: true, agent }),
+  closePopup: () => set({ isOpen: false, agent: null }),
 }));

--- a/lib/db/queries.ts
+++ b/lib/db/queries.ts
@@ -227,24 +227,26 @@ export async function getChatsByUserId({
   limit,
   startingAfter,
   endingBefore,
+  modelId,
 }: {
   id: string;
   limit: number;
   startingAfter: string | null;
   endingBefore: string | null;
+  modelId?: string;
 }) {
   try {
     const extendedLimit = limit + 1;
+
+    const baseCondition = modelId
+      ? and(eq(chat.userId, id), eq(chat.modelId, modelId))
+      : eq(chat.userId, id);
 
     const query = (whereCondition?: SQL<any>) =>
       db
         .select()
         .from(chat)
-        .where(
-          whereCondition
-            ? and(whereCondition, eq(chat.userId, id))
-            : eq(chat.userId, id),
-        )
+        .where(whereCondition ? and(whereCondition, baseCondition) : baseCondition)
         .orderBy(desc(chat.createdAt))
         .limit(extendedLimit);
 


### PR DESCRIPTION
## Summary
- assign modelId to each agent
- display agent chats in agent dialog
- fetch chats filtered by model in history API
- include agent info in popup state

## Testing
- `pnpm lint`
- `pnpm tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6885dd444734832abcdd44172b52fbb4