### PR TITLE
feat: add agent-specific models and chat history

### DIFF
--- a/app/(assistenten)/assistenten/page.tsx
+++ b/app/(assistenten)/assistenten/page.tsx
@@ -1,25 +1,18 @@
 'use client';
 
-import { AgentCard, type AgentCardProps } from '@/components/agents/agent-card';
+import { AgentCard } from '@/components/agents/agent-card';
 import { useTranslation } from '@/lib/i18n';
 import { SearchInput } from '@/components/search-input';
 import AssistentenHeader from '@/components/assistenten-header';
 import '../../../themes/assistenten.css';
 import { motion } from 'framer-motion';
+import { agents } from '@/lib/agents';
 
 export default function AssistentenPage() {
   const t = useTranslation();
 
-  const recentlyUsed: AgentCardProps[] = [
-    { name: 'Luna', description: 'Creative writing assistant', avatar: 'https://avatar.vercel.sh/luna' },
-    { name: 'Moga', description: 'Math tutor bot', avatar: 'https://avatar.vercel.sh/moga' },
-  ];
-
-  const recommended: AgentCardProps[] = [
-    { name: 'Rela', description: 'Relationship advice', avatar: 'https://avatar.vercel.sh/rela' },
-    { name: 'Echo', description: 'Quick Q&A', avatar: 'https://avatar.vercel.sh/echo' },
-    { name: 'Beta', description: 'Beta features explorer', avatar: 'https://avatar.vercel.sh/beta' },
-  ];
+  const recentlyUsed = agents.slice(0, 2);
+  const recommended = agents.slice(2);
 
   const container = {
     hidden: {},
@@ -46,7 +39,7 @@ export default function AssistentenPage() {
           className="grid gap-4 recent md:grid-cols-2"
         >
           {recentlyUsed.map((agent) => (
-            <AgentCard key={agent.name} {...agent} />
+            <AgentCard key={agent.id} agent={agent} />
           ))}
         </motion.div>
       </section>
@@ -62,7 +55,7 @@ export default function AssistentenPage() {
           className="grid gap-4 recommended"
         >
           {recommended.map((agent) => (
-            <AgentCard key={agent.name} {...agent} />
+            <AgentCard key={agent.id} agent={agent} />
           ))}
         </motion.div>
       </section>

--- a/app/(chat)/api/chat/schema.ts
+++ b/app/(chat)/api/chat/schema.ts
@@ -29,6 +29,11 @@ export const postRequestBodySchema = z.object({
     'basis-model',
     'plus-model',
     'top-model',
+    'agent-luna',
+    'agent-moga',
+    'agent-rela',
+    'agent-echo',
+    'agent-beta',
   ]),
   selectedVisibilityType: z.enum(['public', 'private']),
 });

--- a/app/(chat)/api/history/route.ts
+++ b/app/(chat)/api/history/route.ts
@@ -9,6 +9,7 @@ export async function GET(request: NextRequest) {
   const limit = Number.parseInt(searchParams.get('limit') || '10');
   const startingAfter = searchParams.get('starting_after');
   const endingBefore = searchParams.get('ending_before');
+  const modelId = searchParams.get('modelId');
 
   if (startingAfter && endingBefore) {
     return new ChatSDKError(
@@ -28,6 +29,7 @@ export async function GET(request: NextRequest) {
     limit,
     startingAfter,
     endingBefore,
+    modelId,
   });
 
   return Response.json(chats);

--- a/components/agents/agent-card.tsx
+++ b/components/agents/agent-card.tsx
@@ -1,11 +1,10 @@
 import { motion } from 'framer-motion';
 import Image from 'next/image';
 import { useAgentPopup } from '@/hooks/use-agent-popup';
+import type { Agent } from '@/lib/agents';
 
 export interface AgentCardProps {
-  name: string;
-  description: string;
-  avatar: string;
+  agent: Agent;
 }
 
 const cardVariants = {
@@ -13,7 +12,7 @@ const cardVariants = {
   animate: { opacity: 1, y: 0 },
 };
 
-export function AgentCard({ name, description, avatar }: AgentCardProps) {
+export function AgentCard({ agent }: AgentCardProps) {
   const { openPopup } = useAgentPopup();
   return (
     <motion.button
@@ -21,17 +20,17 @@ export function AgentCard({ name, description, avatar }: AgentCardProps) {
       whileHover={{ translateY: -4, scale: 1.015 }}
       whileTap={{ scale: 0.98 }}
       className="ripple relative flex items-start gap-5 rounded-[24px] border border-white/30 bg-white/10 px-[2rem] py-[1.75rem] backdrop-blur-[18px] backdrop-saturate-[180%] transition-transform shadow-sm hover:shadow-md focus:outline-none overflow-hidden"
-      onClick={openPopup}
+      onClick={() => openPopup(agent)}
     >
       <span
         className="flex h-[72px] w-[72px] flex-shrink-0 items-center justify-center rounded-full"
         style={{ background: 'radial-gradient(circle at 30% 30%, var(--brand-accent), #FFE3D2)' }}
       >
-        <Image src={avatar} alt="" width={64} height={64} className="h-12 w-12 rounded-full object-cover" loading="lazy" />
+        <Image src={agent.avatar} alt="" width={64} height={64} className="h-12 w-12 rounded-full object-cover" loading="lazy" />
       </span>
       <span className="text-left">
-        <h3 className="font-bold [font-size:clamp(1.1rem,0.9rem+0.6vw,1.35rem)]">{name}</h3>
-        <p className="[font-size:clamp(.85rem,.75rem+.4vw,1rem)] opacity-80">{description}</p>
+        <h3 className="font-bold [font-size:clamp(1.1rem,0.9rem+0.6vw,1.35rem)]">{agent.name}</h3>
+        <p className="[font-size:clamp(.85rem,.75rem+.4vw,1rem)] opacity-80">{agent.description}</p>
       </span>
     </motion.button>
   );

--- a/components/agents/agent-dialog.tsx
+++ b/components/agents/agent-dialog.tsx
@@ -12,19 +12,31 @@ import { X } from 'lucide-react';
 import { useAgentPopup } from '@/hooks/use-agent-popup';
 import { useTranslation } from '@/lib/i18n';
 import { useRouter } from 'next/navigation';
+import useSWR from 'swr';
+import { fetcher } from '@/lib/utils';
 
 export function AgentDialog() {
-  const { isOpen, closePopup } = useAgentPopup();
+  const { isOpen, agent, closePopup } = useAgentPopup();
   const t = useTranslation();
   const router = useRouter();
 
-  function goToChat() {
+  const { data } = useSWR(
+    isOpen && agent ? `/api/history?limit=20&modelId=${agent.modelId}` : null,
+    fetcher,
+  );
+  const chats = (data?.chats as Array<{ id: string; title: string }> | undefined) ?? [];
+
+  function goToChat(chatId?: string) {
     closePopup();
-    router.push('/');
+    if (chatId) {
+      router.push(`/chat/${chatId}`);
+    } else if (agent) {
+      router.push(`/?modelId=${agent.modelId}`);
+    }
     router.refresh();
   }
 
-  if (!isOpen) return null;
+  if (!isOpen || !agent) return null;
 
   return (
     <Dialog open={isOpen} onOpenChange={closePopup}>
@@ -42,21 +54,23 @@ export function AgentDialog() {
             <X className="h-4 w-4" />
             <span className="sr-only">Close</span>
           </DialogClose>
-          <h2>Luna</h2>
+          <h2>{agent.name}</h2>
           <div className="agentPreviewDemo" aria-label={t('agentDemoLabel')} />
-          <p className="agentPreviewDescription">
-            Creative writing assistant helping craft engaging stories.
-          </p>
+          <p className="agentPreviewDescription">{agent.description}</p>
           <div className="agentPreviewDivider" />
           <div className="agentChatListHeader">{t('agentChatListHeading')}</div>
           <div className="agentChatList">
-            <button type="button">How do I start a novel?</button>
-            <button type="button">Generate character ideas</button>
-            <button type="button">Outline a mystery plot</button>
-            <button type="button">Tips for dialogue</button>
-            <button type="button">Suggest a story prompt</button>
+            {chats.map((chat) => (
+              <button
+                type="button"
+                key={chat.id}
+                onClick={() => goToChat(chat.id)}
+              >
+                {chat.title}
+              </button>
+            ))}
           </div>
-          <button type="button" className="goToChatButton" onClick={goToChat}>
+          <button type="button" className="goToChatButton" onClick={() => goToChat()}>
             {t('goToChat')}
           </button>
         </motion.div>

--- a/hooks/use-agent-popup.ts
+++ b/hooks/use-agent-popup.ts
@@ -1,13 +1,16 @@
 import { create } from 'zustand';
+import type { Agent } from '@/lib/agents';
 
 interface AgentPopupState {
   isOpen: boolean;
-  openPopup: () => void;
+  agent: Agent | null;
+  openPopup: (agent: Agent) => void;
   closePopup: () => void;
 }
 
 export const useAgentPopup = create<AgentPopupState>((set) => ({
   isOpen: false,
-  openPopup: () => set({ isOpen: true }),
-  closePopup: () => set({ isOpen: false }),
+  agent: null,
+  openPopup: (agent) => set({ isOpen: true, agent }),
+  closePopup: () => set({ isOpen: false, agent: null }),
 }));

--- a/lib/agents.ts
+++ b/lib/agents.ts
@@ -1,0 +1,51 @@
+export interface Agent {
+  id: string;
+  name: string;
+  description: string;
+  avatar: string;
+  modelId: string;
+  systemInstruction: string;
+}
+
+export const agents: Array<Agent> = [
+  {
+    id: 'luna',
+    name: 'Luna',
+    description: 'Creative writing assistant',
+    avatar: 'https://avatar.vercel.sh/luna',
+    modelId: 'agent-luna',
+    systemInstruction: 'You are Luna, a creative writing assistant.',
+  },
+  {
+    id: 'moga',
+    name: 'Moga',
+    description: 'Math tutor bot',
+    avatar: 'https://avatar.vercel.sh/moga',
+    modelId: 'agent-moga',
+    systemInstruction: 'You are Moga, a helpful math tutor.',
+  },
+  {
+    id: 'rela',
+    name: 'Rela',
+    description: 'Relationship advice',
+    avatar: 'https://avatar.vercel.sh/rela',
+    modelId: 'agent-rela',
+    systemInstruction: 'You are Rela giving relationship advice.',
+  },
+  {
+    id: 'echo',
+    name: 'Echo',
+    description: 'Quick Q&A',
+    avatar: 'https://avatar.vercel.sh/echo',
+    modelId: 'agent-echo',
+    systemInstruction: 'You are Echo answering quick questions.',
+  },
+  {
+    id: 'beta',
+    name: 'Beta',
+    description: 'Beta features explorer',
+    avatar: 'https://avatar.vercel.sh/beta',
+    modelId: 'agent-beta',
+    systemInstruction: 'You are Beta exploring new features.',
+  },
+];

--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -117,11 +117,16 @@ export const myProvider = isTestEnvironment
     customProvider({
       languageModels: {
         /* flagship model for normal chat                                */
-        'free-model': openai('gpt-4.1'), // GPT‑4.1 :contentReference[oaicite:4]{index=4}
+        'free-model': openai('gpt-4.1'), // GPT‑4.1
 
         'basis-model': openai('gpt-4.1'),
         'plus-model': geminiLanguageModel(false),
         'top-model': geminiLanguageModel(true),
+        'agent-luna': openai('gpt-4.1'),
+        'agent-moga': openai('gpt-4.1'),
+        'agent-rela': openai('gpt-4.1'),
+        'agent-echo': openai('gpt-4.1'),
+        'agent-beta': openai('gpt-4.1'),
 
         /* reasoning stream with <think> traces, using 4o‑mini           */
         'chat-model-reasoning': wrapLanguageModel({

--- a/lib/db/queries.ts
+++ b/lib/db/queries.ts
@@ -227,24 +227,23 @@ export async function getChatsByUserId({
   limit,
   startingAfter,
   endingBefore,
+  modelId,
 }: {
   id: string;
   limit: number;
   startingAfter: string | null;
   endingBefore: string | null;
+  modelId?: string | null;
 }) {
   try {
     const extendedLimit = limit + 1;
 
+    const baseCondition = modelId ? and(eq(chat.modelId, modelId), eq(chat.userId, id)) : eq(chat.userId, id);
     const query = (whereCondition?: SQL<any>) =>
       db
         .select()
         .from(chat)
-        .where(
-          whereCondition
-            ? and(whereCondition, eq(chat.userId, id))
-            : eq(chat.userId, id),
-        )
+        .where(whereCondition ? and(whereCondition, baseCondition) : baseCondition)
         .orderBy(desc(chat.createdAt))
         .limit(extendedLimit);
 


### PR DESCRIPTION
## Summary
- add Agent definitions
- allow opening agent dialog with selected agent
- show agent chats in agent dialog
- update agents page to use agent definitions
- support filtering chat history by modelId
- map agent models to GPT-4.1
- extend schema to allow new agent modelIds

## Testing
- `pnpm lint`
- `pnpm tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6885dd444734832abcdd44172b52fbb4