### PR TITLE
fix: ensure chats load with saved model

### DIFF
--- a/app/(chat)/chat/[id]/page.tsx
+++ b/app/(chat)/chat/[id]/page.tsx
@@ -96,8 +96,8 @@ export default async function Page({
 
   return (
     <>
-      <Chat {...chatComponentProps} />
-      <DataStreamHandler id={chatId} /> {/* Ensure consistent use of chatId */}
+      <Chat key={chat.id} {...chatComponentProps} />
+      <DataStreamHandler key={chat.id} id={chatId} /> {/* Ensure consistent use of chatId */}
     </>
   );
 }

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -66,6 +66,10 @@ export function Chat({
 
   const [chatModelId, setChatModelId] = useState(initialChatModel);
 
+  useEffect(() => {
+    setChatModelId(initialChatModel);
+  }, [id, initialChatModel]);
+
   const handleModelChange = useCallback(
     (modelId: string) => {
       if (modelId === chatModelId) return;


### PR DESCRIPTION
## Summary
- update `Chat` component state when chat changes
- key chat components by chat ID so state resets

## Testing
- `pnpm lint`
- `pnpm tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6885ef1cce68832a863c16bf35fc26a8