### PR TITLE
fix: persist chat model on page load

### DIFF
--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -66,6 +66,10 @@ export function Chat({
 
   const [chatModelId, setChatModelId] = useState(initialChatModel);
 
+  useEffect(() => {
+    document.cookie = `chat-model=${chatModelId}; path=/`;
+  }, [chatModelId]);
+
   const handleModelChange = useCallback(
     (modelId: string) => {
       if (modelId === chatModelId) return;


### PR DESCRIPTION
## Summary
- persist selected chat model in the cookie when a chat opens

## Testing
- `pnpm lint`
- `pnpm tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6885ef1cce68832a863c16bf35fc26a8