### PR TITLE
fix: avoid duplicate keys on chat page

### DIFF
--- a/app/(chat)/chat/[id]/page.tsx
+++ b/app/(chat)/chat/[id]/page.tsx
@@ -96,8 +96,9 @@ export default async function Page({
 
   return (
     <>
-      <Chat {...chatComponentProps} />
-      <DataStreamHandler id={chatId} /> {/* Ensure consistent use of chatId */}
+      <Chat key={chat.id} {...chatComponentProps} />
+      {/* Use a unique key to avoid duplicate keys */}
+      <DataStreamHandler key={`stream-${chat.id}`} id={chatId} />
     </>
   );
 }

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -66,6 +66,10 @@ export function Chat({
 
   const [chatModelId, setChatModelId] = useState(initialChatModel);
 
+  useEffect(() => {
+    setChatModelId(initialChatModel);
+  }, [id, initialChatModel]);
+
   const handleModelChange = useCallback(
     (modelId: string) => {
       if (modelId === chatModelId) return;


### PR DESCRIPTION
## Summary
- ensure DataStreamHandler gets a unique key

## Testing
- `pnpm lint`
- `pnpm tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6885ef1cce68832a863c16bf35fc26a8