### PR TITLE
feat: enforce model access on chat

### DIFF
--- a/app/(chat)/api/chat/route.ts
+++ b/app/(chat)/api/chat/route.ts
@@ -17,6 +17,7 @@ import {
   saveChat,
   saveUserMessageWithLimit,
   saveMessages,
+  getUserModelIds,
 } from '@/lib/db/queries';
 import {
   generateUUID,
@@ -76,6 +77,13 @@ export async function POST(request: Request) {
       return new ChatSDKError('unauthorized:chat').toResponse();
     }
     const userType: UserType = session.user.type;
+
+    const userModels = await getUserModelIds({ userId: session.user.id });
+    const baseModels = entitlementsByUserType[userType].availableChatModelIds;
+    const availableModels = new Set([...baseModels, ...userModels]);
+    if (!availableModels.has(selectedChatModel)) {
+      return new ChatSDKError('forbidden_model:chat').toResponse();
+    }
 
     const chat = await getChatById({ id });
     if (!chat) {

--- a/app/(chat)/chat/[id]/page.tsx
+++ b/app/(chat)/chat/[id]/page.tsx
@@ -3,7 +3,11 @@ import { notFound, redirect } from 'next/navigation';
 
 import { auth } from '@/app/(auth)/auth';
 import { Chat } from '@/components/chat';
-import { getChatById, getMessagesByChatId } from '@/lib/db/queries';
+import {
+  getChatById,
+  getMessagesByChatId,
+  getUserModelIds,
+} from '@/lib/db/queries';
 import { DataStreamHandler } from '@/components/data-stream-handler';
 import { entitlementsByUserType } from '@/lib/ai/entitlements';
 import type { DBMessage } from '@/lib/db/schema';
@@ -77,7 +81,7 @@ export default async function Page({
     }));
   }
 
-  const userModels = session.user.models ?? [];
+  const userModels = await getUserModelIds({ userId: session.user.id });
   const baseModels =
     entitlementsByUserType[session.user.type].availableChatModelIds;
   const availableModels = Array.from(new Set([...baseModels, ...userModels]));

--- a/app/(chat)/page.tsx
+++ b/app/(chat)/page.tsx
@@ -2,6 +2,8 @@ import { cookies } from 'next/headers';
 
 import { Chat } from '@/components/chat';
 import { DEFAULT_CHAT_MODEL } from '@/lib/ai/models';
+import { entitlementsByUserType } from '@/lib/ai/entitlements';
+import { getUserModelIds } from '@/lib/db/queries';
 import { generateUUID } from '@/lib/utils';
 import { DataStreamHandler } from '@/components/data-stream-handler';
 import { auth } from '../(auth)/auth';
@@ -58,7 +60,13 @@ export default async function Page({
 
   const id = generateUUID();
   const modelIdFromCookie = cookieStore.get('chat-model');
-  const initialModelId = selectedModelIdParam ?? modelIdFromCookie?.value ?? DEFAULT_CHAT_MODEL;
+  const userModels = await getUserModelIds({ userId: session.user.id });
+  const baseModels = entitlementsByUserType[session.user.type].availableChatModelIds;
+  const availableModels = Array.from(new Set([...baseModels, ...userModels]));
+  let initialModelId = selectedModelIdParam ?? modelIdFromCookie?.value ?? DEFAULT_CHAT_MODEL;
+  if (!availableModels.includes(initialModelId)) {
+    initialModelId = DEFAULT_CHAT_MODEL;
+  }
 
   return (
     <>

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -151,6 +151,10 @@ export function Chat({
           }
           return;
         }
+        if (error.type === 'forbidden_model' && error.surface === 'chat') {
+          openUpgradePopup();
+          return;
+        }
         toast({
           type: 'error',
           description: error.message,

--- a/lib/ai/entitlements.ts
+++ b/lib/ai/entitlements.ts
@@ -17,9 +17,9 @@ export const entitlementsByUserType: Record<UserType, Entitlements> = {
 
   /*
    * For users with an account
-   */
+  */
   regular: {
-    maxMessagesPerDay: 10,
+    maxMessagesPerDay: Number.MAX_SAFE_INTEGER,
     availableChatModelIds: ['free-model'],
   },
 

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -5,6 +5,7 @@ export type ErrorType =
   | 'not_found'
   | 'rate_limit'
   | 'limit_exceeded' // Added
+  | 'forbidden_model'
   | 'offline';
 
 export type Surface =
@@ -97,6 +98,8 @@ export function getMessageByErrorCode(errorCode: ErrorCode): string {
       return 'The requested chat was not found. Please check the chat ID and try again.';
     case 'forbidden:chat':
       return 'This chat belongs to another user. Please check the chat ID and try again.';
+    case 'forbidden_model:chat':
+      return 'You do not have access to this model. Please upgrade your plan.';
     case 'unauthorized:chat':
       return 'You need to sign in to view this chat. Please sign in and try again.';
     case 'offline:chat':
@@ -139,6 +142,8 @@ function getStatusCodeByType(type: ErrorType) {
       return 429;
     case 'limit_exceeded': // Added
       return 402; // Payment Required, or 403 Forbidden could also work
+    case 'forbidden_model':
+      return 403;
     case 'offline':
       return 503;
     default:


### PR DESCRIPTION
## Summary
- ensure regular users have unlimited messages
- add `forbidden_model` error type
- show upgrade popup when model access is missing
- verify available models on chat pages and API

## Testing
- `pnpm lint`
- `pnpm tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6885f51c0398832a8aaab1905b96bd2d