### PR TITLE
feat: enforce model access checks

### DIFF
--- a/app/(chat)/api/chat/route.ts
+++ b/app/(chat)/api/chat/route.ts
@@ -77,6 +77,14 @@ export async function POST(request: Request) {
     }
     const userType: UserType = session.user.type;
 
+    const userModels = session.user.models ?? [];
+    const baseModels =
+      entitlementsByUserType[userType].availableChatModelIds;
+    const availableModels = Array.from(new Set([...baseModels, ...userModels]));
+    if (!availableModels.includes(selectedChatModel)) {
+      return new ChatSDKError('forbidden_model:chat').toResponse();
+    }
+
     const chat = await getChatById({ id });
     if (!chat) {
       const title = await generateTitleFromUserMessage({ message });

--- a/app/(chat)/page.tsx
+++ b/app/(chat)/page.tsx
@@ -2,6 +2,7 @@ import { cookies } from 'next/headers';
 
 import { Chat } from '@/components/chat';
 import { DEFAULT_CHAT_MODEL } from '@/lib/ai/models';
+import { entitlementsByUserType } from '@/lib/ai/entitlements';
 import { generateUUID } from '@/lib/utils';
 import { DataStreamHandler } from '@/components/data-stream-handler';
 import { auth } from '../(auth)/auth';
@@ -58,7 +59,14 @@ export default async function Page({
 
   const id = generateUUID();
   const modelIdFromCookie = cookieStore.get('chat-model');
-  const initialModelId = selectedModelIdParam ?? modelIdFromCookie?.value ?? DEFAULT_CHAT_MODEL;
+  const baseModels = entitlementsByUserType[session.user.type].availableChatModelIds;
+  const userModels = session.user.models ?? [];
+  const availableModels = Array.from(new Set([...baseModels, ...userModels]));
+  const desiredModelId = selectedModelIdParam ?? modelIdFromCookie?.value;
+  const initialModelId =
+    desiredModelId && availableModels.includes(desiredModelId)
+      ? desiredModelId
+      : DEFAULT_CHAT_MODEL;
 
   return (
     <>

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -151,6 +151,10 @@ export function Chat({
           }
           return;
         }
+        if (error.type === 'forbidden_model' && error.surface === 'chat') {
+          openUpgradePopup();
+          return;
+        }
         toast({
           type: 'error',
           description: error.message,

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -5,7 +5,8 @@ export type ErrorType =
   | 'not_found'
   | 'rate_limit'
   | 'limit_exceeded' // Added
-  | 'offline';
+  | 'offline'
+  | 'forbidden_model';
 
 export type Surface =
   | 'chat'
@@ -97,6 +98,8 @@ export function getMessageByErrorCode(errorCode: ErrorCode): string {
       return 'The requested chat was not found. Please check the chat ID and try again.';
     case 'forbidden:chat':
       return 'This chat belongs to another user. Please check the chat ID and try again.';
+    case 'forbidden_model:chat':
+      return 'You do not have access to this model. Please upgrade to continue.';
     case 'unauthorized:chat':
       return 'You need to sign in to view this chat. Please sign in and try again.';
     case 'offline:chat':
@@ -139,6 +142,8 @@ function getStatusCodeByType(type: ErrorType) {
       return 429;
     case 'limit_exceeded': // Added
       return 402; // Payment Required, or 403 Forbidden could also work
+    case 'forbidden_model':
+      return 403;
     case 'offline':
       return 503;
     default:


### PR DESCRIPTION
## Summary
- restrict chat POST requests to models the user can access
- validate the initial chat model against user entitlements
- add `forbidden_model` error type and handle in client UI

## Testing
- `pnpm lint`
- `pnpm tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6885f51c0398832a8aaab1905b96bd2d