### PR TITLE
fix: restore agent model selection

### DIFF
--- a/app/(auth)/actions.ts
+++ b/app/(auth)/actions.ts
@@ -5,7 +5,6 @@ import { z } from 'zod';
 import { createUser, getUser, transferChatOwnership } from '@/lib/db/queries';
 import { signIn } from './auth';
 import type { User } from '@/lib/db/schema';
-import { ChatSDKError } from '@/lib/errors';
 
 const authFormSchema = z.object({
   email: z.string().email(),

--- a/app/(chat)/api/chat/route.ts
+++ b/app/(chat)/api/chat/route.ts
@@ -77,6 +77,14 @@ export async function POST(request: Request) {
     }
     const userType: UserType = session.user.type;
 
+    const userModels = session.user.models ?? [];
+    const baseModels =
+      entitlementsByUserType[userType].availableChatModelIds;
+    const availableModels = Array.from(new Set([...baseModels, ...userModels]));
+    if (!availableModels.includes(selectedChatModel)) {
+      return new ChatSDKError('forbidden_model:chat').toResponse();
+    }
+
     const chat = await getChatById({ id });
     if (!chat) {
       const title = await generateTitleFromUserMessage({ message });

--- a/app/(chat)/api/webhook/route.ts
+++ b/app/(chat)/api/webhook/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server';
 import { headers } from 'next/headers';
 import stripeLib from '@/lib/stripe';
 import { addUserModel } from '@/lib/db/queries';
-import Stripe from 'stripe';
+import type Stripe from 'stripe';
 
 export async function POST(req: Request) {
   const body = await req.text();

--- a/app/(chat)/page.tsx
+++ b/app/(chat)/page.tsx
@@ -2,6 +2,7 @@ import { cookies } from 'next/headers';
 
 import { Chat } from '@/components/chat';
 import { DEFAULT_CHAT_MODEL } from '@/lib/ai/models';
+import { entitlementsByUserType } from '@/lib/ai/entitlements';
 import { generateUUID } from '@/lib/utils';
 import { DataStreamHandler } from '@/components/data-stream-handler';
 import { auth } from '../(auth)/auth';
@@ -58,7 +59,14 @@ export default async function Page({
 
   const id = generateUUID();
   const modelIdFromCookie = cookieStore.get('chat-model');
-  const initialModelId = selectedModelIdParam ?? modelIdFromCookie?.value ?? DEFAULT_CHAT_MODEL;
+  const baseModels = entitlementsByUserType[session.user.type].availableChatModelIds;
+  const userModels = session.user.models ?? [];
+  const availableModels = Array.from(new Set([...baseModels, ...userModels]));
+  const desiredModelId = selectedModelIdParam ?? modelIdFromCookie?.value;
+  const initialModelId =
+    desiredModelId && availableModels.includes(desiredModelId)
+      ? desiredModelId
+      : DEFAULT_CHAT_MODEL;
 
   return (
     <>

--- a/artifacts/code/client.tsx
+++ b/artifacts/code/client.tsx
@@ -12,8 +12,8 @@ import { toast } from 'sonner';
 import { generateUUID } from '@/lib/utils';
 import {
   Console,
-  ConsoleOutput,
-  ConsoleOutputContent,
+  type ConsoleOutput,
+  type ConsoleOutputContent,
 } from '@/components/console';
 
 const OUTPUT_HANDLERS = {

--- a/artifacts/text/client.tsx
+++ b/artifacts/text/client.tsx
@@ -10,7 +10,7 @@ import {
   RedoIcon,
   UndoIcon,
 } from '@/components/icons';
-import { Suggestion } from '@/lib/db/schema';
+import type { Suggestion } from '@/lib/db/schema';
 import { toast } from 'sonner';
 import { getSuggestions } from '../actions';
 
@@ -90,8 +90,7 @@ export const textArtifact = new Artifact<'text', TextArtifactMetadata>({
             onSaveContent={onSaveContent}
           />
 
-          {metadata &&
-          metadata.suggestions &&
+          {metadata?.suggestions &&
           metadata.suggestions.length > 0 ? (
             <div className="md:hidden h-dvh w-12 shrink-0" />
           ) : null}

--- a/components/artifact-actions.tsx
+++ b/components/artifact-actions.tsx
@@ -1,8 +1,8 @@
 import { Button } from './ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip';
-import { artifactDefinitions, UIArtifact } from './artifact';
-import { Dispatch, memo, SetStateAction, useState } from 'react';
-import { ArtifactActionContext } from './create-artifact';
+import { artifactDefinitions, type UIArtifact } from './artifact';
+import { type Dispatch, memo, type SetStateAction, useState } from 'react';
+import type { ArtifactActionContext } from './create-artifact';
 import { cn } from '@/lib/utils';
 import { toast } from 'sonner';
 

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -151,6 +151,10 @@ export function Chat({
           }
           return;
         }
+        if (error.type === 'forbidden_model' && error.surface === 'chat') {
+          openUpgradePopup();
+          return;
+        }
         toast({
           type: 'error',
           description: error.message,

--- a/components/code-editor.tsx
+++ b/components/code-editor.tsx
@@ -6,7 +6,7 @@ import { python } from '@codemirror/lang-python';
 import { oneDark } from '@codemirror/theme-one-dark';
 import { basicSetup } from 'codemirror';
 import React, { memo, useEffect, useRef } from 'react';
-import { Suggestion } from '@/lib/db/schema';
+import type { Suggestion } from '@/lib/db/schema';
 
 type EditorProps = {
   content: string;

--- a/components/console.tsx
+++ b/components/console.tsx
@@ -1,8 +1,8 @@
 import { TerminalWindowIcon, LoaderIcon, CrossSmallIcon } from './icons';
 import { Button } from './ui/button';
 import {
-  Dispatch,
-  SetStateAction,
+  type Dispatch,
+  type SetStateAction,
   useCallback,
   useEffect,
   useRef,

--- a/components/create-artifact.tsx
+++ b/components/create-artifact.tsx
@@ -1,8 +1,8 @@
-import { Suggestion } from '@/lib/db/schema';
-import { UseChatHelpers } from '@ai-sdk/react';
-import { ComponentType, Dispatch, ReactNode, SetStateAction } from 'react';
-import { DataStreamDelta } from './data-stream-handler';
-import { UIArtifact } from './artifact';
+import type { Suggestion } from '@/lib/db/schema';
+import type { UseChatHelpers } from '@ai-sdk/react';
+import type { ComponentType, Dispatch, ReactNode, SetStateAction } from 'react';
+import type { DataStreamDelta } from './data-stream-handler';
+import type { UIArtifact } from './artifact';
 
 export type ArtifactActionContext<M = any> = {
   content: string;

--- a/components/data-stream-handler.tsx
+++ b/components/data-stream-handler.tsx
@@ -2,8 +2,8 @@
 
 import { useChat } from '@ai-sdk/react';
 import { useEffect, useRef } from 'react';
-import { artifactDefinitions, ArtifactKind } from './artifact';
-import { Suggestion } from '@/lib/db/schema';
+import { artifactDefinitions, type ArtifactKind } from './artifact';
+import type { Suggestion } from '@/lib/db/schema';
 import { initialArtifactData, useArtifact } from '@/hooks/use-artifact';
 
 export type DataStreamDelta = {

--- a/components/document-preview.tsx
+++ b/components/document-preview.tsx
@@ -2,16 +2,16 @@
 
 import {
   memo,
-  MouseEvent,
+  type MouseEvent,
   useCallback,
   useEffect,
   useMemo,
   useRef,
 } from 'react';
-import { ArtifactKind, UIArtifact } from './artifact';
+import type { ArtifactKind, UIArtifact } from './artifact';
 import { FileIcon, FullscreenIcon, ImageIcon, LoaderIcon } from './icons';
 import { cn, fetcher } from '@/lib/utils';
-import { Document } from '@/lib/db/schema';
+import type { Document } from '@/lib/db/schema';
 import { InlineDocumentSkeleton } from './document-skeleton';
 import useSWR from 'swr';
 import { Editor } from './text-editor';

--- a/components/document-skeleton.tsx
+++ b/components/document-skeleton.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ArtifactKind } from './artifact';
+import type { ArtifactKind } from './artifact';
 
 export const DocumentSkeleton = ({
   artifactKind,

--- a/components/message-editor.tsx
+++ b/components/message-editor.tsx
@@ -1,11 +1,11 @@
 'use client';
 
-import { ChatRequestOptions, Message } from 'ai';
+import type { Message } from 'ai';
 import { Button } from './ui/button';
-import { Dispatch, SetStateAction, useEffect, useRef, useState } from 'react';
+import { type Dispatch, type SetStateAction, useEffect, useRef, useState } from 'react';
 import { Textarea } from './ui/textarea';
 import { deleteTrailingMessages } from '@/app/(chat)/actions';
-import { UseChatHelpers } from '@ai-sdk/react';
+import type { UseChatHelpers } from '@ai-sdk/react';
 import { useTranslation } from '@/lib/i18n';
 
 export type MessageEditorProps = {

--- a/components/suggestion.tsx
+++ b/components/suggestion.tsx
@@ -9,7 +9,7 @@ import type { UISuggestion } from '@/lib/editor/suggestions';
 import { CrossIcon, MessageIcon } from './icons';
 import { Button } from './ui/button';
 import { cn } from '@/lib/utils';
-import { ArtifactKind } from './artifact';
+import type { ArtifactKind } from './artifact';
 import { useTranslation } from '@/lib/i18n';
 
 export const Suggestion = ({

--- a/components/toolbar.tsx
+++ b/components/toolbar.tsx
@@ -1,6 +1,4 @@
 'use client';
-
-import type { Message } from 'ai';
 import cx from 'classnames';
 import {
   AnimatePresence,
@@ -11,7 +9,7 @@ import {
 import {
   type Dispatch,
   memo,
-  ReactNode,
+  type ReactNode,
   type SetStateAction,
   useEffect,
   useRef,
@@ -27,9 +25,9 @@ import {
 } from '@/components/ui/tooltip';
 
 import { ArrowUpIcon, StopIcon, SummarizeIcon } from './icons';
-import { artifactDefinitions, ArtifactKind } from './artifact';
-import { ArtifactToolbarItem } from './create-artifact';
-import { UseChatHelpers } from '@ai-sdk/react';
+import { artifactDefinitions, type ArtifactKind } from './artifact';
+import type { ArtifactToolbarItem } from './create-artifact';
+import type { UseChatHelpers } from '@ai-sdk/react';
 
 type ToolProps = {
   description: string;

--- a/hooks/use-artifact.ts
+++ b/hooks/use-artifact.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import useSWR from 'swr';
-import { UIArtifact } from '@/components/artifact';
+import type { UIArtifact } from '@/components/artifact';
 import { useCallback, useMemo } from 'react';
 
 export const initialArtifactData: UIArtifact = {

--- a/lib/ai/entitlements.ts
+++ b/lib/ai/entitlements.ts
@@ -1,10 +1,13 @@
 import type { UserType } from '@/lib/user-types';
 import type { ChatModel } from './models';
+import { agents } from '@/lib/agents';
 
 interface Entitlements {
   maxMessagesPerDay: number;
   availableChatModelIds: Array<ChatModel['id']>;
 }
+
+const agentModelIds = agents.map((a) => a.modelId);
 
 export const entitlementsByUserType: Record<UserType, Entitlements> = {
   /*
@@ -20,22 +23,22 @@ export const entitlementsByUserType: Record<UserType, Entitlements> = {
    */
   regular: {
     maxMessagesPerDay: 10,
-    availableChatModelIds: ['free-model'],
+    availableChatModelIds: ['free-model', ...agentModelIds],
   },
 
   basis: {
     maxMessagesPerDay: Number.MAX_SAFE_INTEGER,
-    availableChatModelIds: ['basis-model', 'free-model'],
+    availableChatModelIds: ['basis-model', 'free-model', ...agentModelIds],
   },
 
   plus: {
     maxMessagesPerDay: Number.MAX_SAFE_INTEGER,
-    availableChatModelIds: ['plus-model', 'free-model'],
+    availableChatModelIds: ['plus-model', 'free-model', ...agentModelIds],
   },
 
   top: {
     maxMessagesPerDay: Number.MAX_SAFE_INTEGER,
-    availableChatModelIds: ['top-model', 'free-model'],
+    availableChatModelIds: ['top-model', 'free-model', ...agentModelIds],
   },
 
   /*

--- a/lib/ai/tools/create-document.ts
+++ b/lib/ai/tools/create-document.ts
@@ -1,7 +1,7 @@
 import { generateUUID } from '@/lib/utils';
-import { DataStreamWriter, tool } from 'ai';
+import { type DataStreamWriter, tool } from 'ai';
 import { z } from 'zod';
-import { Session } from 'next-auth';
+import type { Session } from 'next-auth';
 import {
   artifactKinds,
   documentHandlersByArtifactKind,

--- a/lib/ai/tools/request-suggestions.ts
+++ b/lib/ai/tools/request-suggestions.ts
@@ -1,8 +1,8 @@
 import { z } from 'zod';
-import { Session } from 'next-auth';
-import { DataStreamWriter, streamObject, tool } from 'ai';
+import type { Session } from 'next-auth';
+import { type DataStreamWriter, streamObject, tool } from 'ai';
 import { getDocumentById, saveSuggestions } from '@/lib/db/queries';
-import { Suggestion } from '@/lib/db/schema';
+import type { Suggestion } from '@/lib/db/schema';
 import { generateUUID } from '@/lib/utils';
 import { myProvider } from '../providers';
 

--- a/lib/ai/tools/update-document.ts
+++ b/lib/ai/tools/update-document.ts
@@ -1,7 +1,7 @@
-import { DataStreamWriter, tool } from 'ai';
-import { Session } from 'next-auth';
+import { type DataStreamWriter, tool } from 'ai';
+import type { Session } from 'next-auth';
 import { z } from 'zod';
-import { getDocumentById, saveDocument } from '@/lib/db/queries';
+import { getDocumentById, } from '@/lib/db/queries';
 import { documentHandlersByArtifactKind } from '@/lib/artifacts/server';
 
 interface UpdateDocumentProps {

--- a/lib/artifacts/server.ts
+++ b/lib/artifacts/server.ts
@@ -2,11 +2,11 @@ import { codeDocumentHandler } from '@/artifacts/code/server';
 import { imageDocumentHandler } from '@/artifacts/image/server';
 import { sheetDocumentHandler } from '@/artifacts/sheet/server';
 import { textDocumentHandler } from '@/artifacts/text/server';
-import { ArtifactKind } from '@/components/artifact';
-import { DataStreamWriter } from 'ai';
-import { Document } from '../db/schema';
+import type { ArtifactKind } from '@/components/artifact';
+import type { DataStreamWriter } from 'ai';
+import type { Document } from '../db/schema';
 import { saveDocument } from '../db/queries';
-import { Session } from 'next-auth';
+import type { Session } from 'next-auth';
 
 export interface SaveDocumentProps {
   id: string;

--- a/lib/editor/suggestions.tsx
+++ b/lib/editor/suggestions.tsx
@@ -9,7 +9,7 @@ import { createRoot } from 'react-dom/client';
 
 import { Suggestion as PreviewSuggestion } from '@/components/suggestion';
 import type { Suggestion } from '@/lib/db/schema';
-import { ArtifactKind } from '@/components/artifact';
+import type { ArtifactKind } from '@/components/artifact';
 
 export interface UISuggestion extends Suggestion {
   selectionStart: number;

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -5,7 +5,8 @@ export type ErrorType =
   | 'not_found'
   | 'rate_limit'
   | 'limit_exceeded' // Added
-  | 'offline';
+  | 'offline'
+  | 'forbidden_model';
 
 export type Surface =
   | 'chat'
@@ -97,6 +98,8 @@ export function getMessageByErrorCode(errorCode: ErrorCode): string {
       return 'The requested chat was not found. Please check the chat ID and try again.';
     case 'forbidden:chat':
       return 'This chat belongs to another user. Please check the chat ID and try again.';
+    case 'forbidden_model:chat':
+      return 'You do not have access to this model. Please upgrade to continue.';
     case 'unauthorized:chat':
       return 'You need to sign in to view this chat. Please sign in and try again.';
     case 'offline:chat':
@@ -139,6 +142,8 @@ function getStatusCodeByType(type: ErrorType) {
       return 429;
     case 'limit_exceeded': // Added
       return 402; // Payment Required, or 403 Forbidden could also work
+    case 'forbidden_model':
+      return 403;
     case 'offline':
       return 503;
     default:

--- a/tests/pages/artifact.ts
+++ b/tests/pages/artifact.ts
@@ -1,4 +1,4 @@
-import { expect, Page } from '@playwright/test';
+import { expect, type Page } from '@playwright/test';
 
 export class ArtifactPage {
   constructor(private page: Page) {}

--- a/tests/prompts/utils.ts
+++ b/tests/prompts/utils.ts
@@ -1,4 +1,4 @@
-import { CoreMessage, LanguageModelV1StreamPart } from 'ai';
+import type { CoreMessage, LanguageModelV1StreamPart } from 'ai';
 import { TEST_PROMPTS } from './basic';
 
 export function compareMessages(
@@ -57,7 +57,7 @@ const reasoningToDeltas = (text: string): LanguageModelV1StreamPart[] => {
 
 export const getResponseChunksByPrompt = (
   prompt: CoreMessage[],
-  isReasoningEnabled: boolean = false,
+  isReasoningEnabled = false,
 ): Array<LanguageModelV1StreamPart> => {
   const recentMessage = prompt.at(-1);
 


### PR DESCRIPTION
## Summary
- allow account holders to use agent models
- keep selected agent model when starting chats

## Testing
- `pnpm lint`
- `pnpm tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6885f51c0398832a8aaab1905b96bd2d