### PR TITLE
fix: await params in dynamic API route

### DIFF
--- a/app/api/domain/[...slug]/route.ts
+++ b/app/api/domain/[...slug]/route.ts
@@ -24,10 +24,18 @@ async function proxy(request: NextRequest, slug: string[]) {
   });
 }
 
-export async function GET(request: NextRequest, { params }: { params: { slug: string[] } }) {
-  return proxy(request, params.slug);
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ slug: string[] }> },
+) {
+  const { slug } = await params;
+  return proxy(request, slug);
 }
 
-export async function POST(request: NextRequest, { params }: { params: { slug: string[] } }) {
-  return proxy(request, params.slug);
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ slug: string[] }> },
+) {
+  const { slug } = await params;
+  return proxy(request, slug);
 }


### PR DESCRIPTION
## Summary
- fix dynamic params access in Domain API proxy

## Testing
- `pnpm lint`
- `pnpm tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68891e56e444832abe219994939f46a9