### PR TITLE
feat: add DomainAgent stub

### DIFF
--- a/app/domain-agent/page.tsx
+++ b/app/domain-agent/page.tsx
@@ -1,0 +1,148 @@
+'use client';
+
+import { useState } from 'react';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent, DialogTrigger } from '@/components/ui/dialog';
+import { Select, SelectTrigger, SelectContent, SelectItem, SelectValue } from '@/components/ui/select';
+import { Label } from '@/components/ui/label';
+import { toast } from '@/components/toast';
+import { useTranslation } from '@/lib/i18n';
+import {
+  createSession,
+  updateSettings,
+  sendAnswers,
+  generateDomains,
+} from '@/lib/domainClient';
+
+interface Question {
+  id: string;
+  text: string;
+}
+
+export default function DomainAgentPage() {
+  const t = useTranslation();
+  const [sessionId, setSessionId] = useState<string | null>(null);
+  const [initialBrief, setInitialBrief] = useState('');
+  const [questions, setQuestions] = useState<Question[]>([]);
+  const [answers, setAnswers] = useState<Record<string, string>>({});
+  const [domains, setDomains] = useState<string[]>([]);
+  const [settings, setSettings] = useState({
+    local_dev: false,
+    creators: [] as string[],
+    generation_count: 3,
+    show_logs: false,
+  });
+
+  const [openSettings, setOpenSettings] = useState(false);
+
+  async function start() {
+    try {
+      const res = await createSession(initialBrief);
+      setSessionId(res.id);
+      setQuestions(res.questions || []);
+    } catch (err: any) {
+      toast({ type: 'error', description: err.message || 'Error' });
+    }
+  }
+
+  async function submitAnswers() {
+    if (!sessionId) return;
+    try {
+      await updateSettings(sessionId, settings);
+      const res = await sendAnswers(sessionId, { answers });
+      setQuestions(res.questions || []);
+      const gen = await generateDomains(sessionId);
+      setDomains(gen.available || []);
+    } catch (err: any) {
+      toast({ type: 'error', description: err.message || 'Error' });
+    }
+  }
+
+  return (
+    <div className="max-w-xl mx-auto p-4 space-y-4">
+      {!sessionId && (
+        <div className="space-y-2">
+          <Label htmlFor="brief">{t('domainBriefPrompt')}</Label>
+          <Input
+            id="brief"
+            value={initialBrief}
+            onChange={(e) => setInitialBrief(e.target.value)}
+          />
+          <div className="flex justify-between">
+            <Dialog open={openSettings} onOpenChange={setOpenSettings}>
+              <DialogTrigger asChild>
+                <Button type="button" variant="outline">
+                  {t('settings')}
+                </Button>
+              </DialogTrigger>
+              <DialogContent className="space-y-4">
+                <div className="space-y-2">
+                  <Label>Mode</Label>
+                  <Select
+                    value={settings.local_dev ? 'local' : 'model'}
+                    onValueChange={(v) =>
+                      setSettings((s) => ({ ...s, local_dev: v === 'local' }))
+                    }
+                  >
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="local">local_dev</SelectItem>
+                      <SelectItem value="model">model</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="space-y-2">
+                  <Label>Generation Count</Label>
+                  <Input
+                    type="number"
+                    value={settings.generation_count}
+                    onChange={(e) =>
+                      setSettings((s) => ({
+                        ...s,
+                        generation_count: Number.parseInt(e.target.value, 10),
+                      }))
+                    }
+                  />
+                </div>
+              </DialogContent>
+            </Dialog>
+            <Button type="button" onClick={start} disabled={!initialBrief.trim()}>
+              {t('continue')}
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {sessionId && questions.length > 0 && (
+        <div className="space-y-4">
+          {questions.map((q) => (
+            <div key={q.id} className="space-y-2">
+              <Label htmlFor={q.id}>{q.text}</Label>
+              <Input
+                id={q.id}
+                value={answers[q.id] || ''}
+                onChange={(e) =>
+                  setAnswers((a) => ({ ...a, [q.id]: e.target.value }))
+                }
+              />
+            </div>
+          ))}
+          <Button type="button" onClick={submitAnswers}>
+            {t('send')}
+          </Button>
+        </div>
+      )}
+
+      {sessionId && questions.length === 0 && domains.length > 0 && (
+        <div className="space-y-2">
+          {domains.map((d) => (
+            <div key={d} className="border rounded p-2">{d}</div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/agents/agent-dialog.tsx
+++ b/components/agents/agent-dialog.tsx
@@ -31,7 +31,11 @@ export function AgentDialog() {
     if (chatId) {
       router.push(`/chat/${chatId}`);
     } else if (agent) {
-      router.push(`/?modelId=${agent.modelId}`);
+      if (agent.modelId === 'domain-agent') {
+        router.push('/domain-agent');
+      } else {
+        router.push(`/?modelId=${agent.modelId}`);
+      }
     }
     router.refresh();
   }

--- a/lib/agents.ts
+++ b/lib/agents.ts
@@ -48,4 +48,12 @@ export const agents: Array<Agent> = [
     modelId: 'agent-beta',
     systemInstruction: 'You are Beta exploring new features.',
   },
+  {
+    id: 'domain',
+    name: 'DomainAgent',
+    description: 'Generate unique domain ideas',
+    avatar: 'https://avatar.vercel.sh/domain',
+    modelId: 'domain-agent',
+    systemInstruction: 'You are DomainAgent assisting with domain names.',
+  },
 ];

--- a/lib/domainClient.ts
+++ b/lib/domainClient.ts
@@ -1,0 +1,64 @@
+import { ChatSDKError } from './errors';
+
+const API_URL = process.env.DOMAIN_API_URL || 'http://161.35.152.9:8000';
+const API_KEY = process.env.DOMAIN_API_KEY || 'alksdfjoij09U908FHSFJoidhf9s8dfh9g87buvweuih87329UFI';
+
+async function domainFetch<T>(path: string, options: RequestInit = {}): Promise<T> {
+  const res = await fetch(`${API_URL}${path}`, {
+    ...options,
+    headers: {
+      'Content-Type': 'application/json',
+      'X-API-Key': API_KEY,
+      ...(options.headers || {}),
+    },
+  });
+
+  if (!res.ok) {
+    let message = 'Request failed';
+    try {
+      const err = await res.json();
+      message = err.message || JSON.stringify(err);
+    } catch {}
+    throw new ChatSDKError('bad_request:api', message);
+  }
+
+  return res.json() as Promise<T>;
+}
+
+export async function createSession(initialBrief: string) {
+  return domainFetch<{ id: string; questions: Array<{ id: string; text: string }> }>('/sessions', {
+    method: 'POST',
+    body: JSON.stringify({ initial_brief: initialBrief }),
+  });
+}
+
+export async function getSettings(id: string) {
+  return domainFetch(`/sessions/${id}/settings`);
+}
+
+export async function updateSettings(id: string, settings: any) {
+  return domainFetch(`/sessions/${id}/settings`, {
+    method: 'POST',
+    body: JSON.stringify(settings),
+  });
+}
+
+export async function sendAnswers(id: string, payload: any) {
+  return domainFetch(`/sessions/${id}/answers`, {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  });
+}
+
+export async function generateDomains(id: string) {
+  return domainFetch(`/sessions/${id}/generate`, {
+    method: 'POST',
+  });
+}
+
+export async function sendFeedback(id: string, payload: any) {
+  return domainFetch(`/sessions/${id}/feedback`, {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  });
+}

--- a/lib/i18n.tsx
+++ b/lib/i18n.tsx
@@ -120,6 +120,7 @@ export const translations = {
     goToChat: 'Go to chat',
     agentChatListHeading: 'Chats with this assistant',
     agentDemoLabel: 'Example of the assistant',
+    domainBriefPrompt: 'Describe the business or project:',
   },
   nl: {
     newChat: 'Nieuw gesprek',
@@ -240,6 +241,7 @@ export const translations = {
     goToChat: 'Ga naar chat',
     agentChatListHeading: 'Chats met deze assistent',
     agentDemoLabel: 'Voorbeeld van de assistent',
+    domainBriefPrompt: 'Beschrijf het bedrijf of project:',
   },
 } as const;
 


### PR DESCRIPTION
## Summary
- introduce a simple domain API client
- register DomainAgent in the agent list
- add domain prompt translations
- create minimal DomainAgent page with settings dialog
- route agent dialog to the new page

## Testing
- `pnpm lint`
- `pnpm tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6889255ac2ec832a90c53e124837a081