### PR TITLE
feat: add DomainAgent frontend

### DIFF
--- a/app/domain-agent/page.tsx
+++ b/app/domain-agent/page.tsx
@@ -1,0 +1,5 @@
+import { DomainAgent } from '@/components/domain-agent';
+
+export default function Page() {
+  return <DomainAgent />;
+}

--- a/components/agents/agent-dialog.tsx
+++ b/components/agents/agent-dialog.tsx
@@ -31,7 +31,11 @@ export function AgentDialog() {
     if (chatId) {
       router.push(`/chat/${chatId}`);
     } else if (agent) {
-      router.push(`/?modelId=${agent.modelId}`);
+      if (agent.id === 'domain') {
+        router.push('/domain-agent');
+      } else {
+        router.push(`/?modelId=${agent.modelId}`);
+      }
     }
     router.refresh();
   }

--- a/components/domain-agent.tsx
+++ b/components/domain-agent.tsx
@@ -1,0 +1,277 @@
+'use client';
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Label } from '@/components/ui/label';
+import { useTranslation } from '@/lib/i18n';
+import {
+  createSession,
+  getSettings,
+  saveSettings,
+  sendAnswers,
+  generateDomains,
+  sendFeedback,
+  type DomainSettings,
+} from '@/lib/domainClient';
+import { ThumbUpIcon, ThumbDownIcon } from '@/components/icons';
+import { toast } from './toast';
+
+export function DomainAgent() {
+  const t = useTranslation();
+  const [sessionId, setSessionId] = useState<string | null>(null);
+  const [initial, setInitial] = useState('');
+  const [questions, setQuestions] = useState<string[]>([]);
+  const [answers, setAnswers] = useState<Record<string, string>>({});
+  const [domains, setDomains] = useState<string[]>([]);
+  const [liked, setLiked] = useState<Record<string, string>>({});
+  const [disliked, setDisliked] = useState<Record<string, string>>({});
+  const [settings, setSettingsState] = useState<DomainSettings>({
+    local_dev: false,
+    creators: [],
+    generation_count: 2,
+    show_logs: false,
+  });
+  const [openSettings, setOpenSettings] = useState(false);
+
+  async function loadSettings(id: string) {
+    try {
+      const data = await getSettings(id);
+      setSettingsState(data);
+    } catch (err) {
+      toast({ type: 'error', description: (err as Error).message });
+    }
+  }
+
+  async function handleInitialSend() {
+    try {
+      const { id } = await createSession(initial);
+      setSessionId(id);
+      await loadSettings(id);
+      const res = await sendAnswers(id, {
+        answers: { brief: initial },
+      });
+      setQuestions(res.questions);
+    } catch (err) {
+      toast({ type: 'error', description: (err as Error).message });
+    }
+  }
+
+  async function handleAnswerSend() {
+    if (!sessionId) return;
+    try {
+      const res = await sendAnswers(sessionId, { answers });
+      setQuestions([]);
+      setAnswers({});
+      const gen = await generateDomains(sessionId);
+      setDomains(gen.available);
+    } catch (err) {
+      toast({ type: 'error', description: (err as Error).message });
+    }
+  }
+
+  async function handleContinue() {
+    if (!sessionId) return;
+    try {
+      const res = await sendFeedback(sessionId, { liked, disliked });
+      setQuestions(res.questions);
+      setDomains([]);
+      setLiked({});
+      setDisliked({});
+    } catch (err) {
+      toast({ type: 'error', description: (err as Error).message });
+    }
+  }
+
+  function toggleLike(name: string) {
+    setLiked((p) => {
+      const copy = { ...p };
+      if (copy[name]) delete copy[name];
+      else copy[name] = '';
+      return copy;
+    });
+    setDisliked((p) => {
+      const copy = { ...p };
+      delete copy[name];
+      return copy;
+    });
+  }
+
+  function toggleDislike(name: string) {
+    setDisliked((p) => {
+      const copy = { ...p };
+      if (copy[name]) delete copy[name];
+      else copy[name] = '';
+      return copy;
+    });
+    setLiked((p) => {
+      const copy = { ...p };
+      delete copy[name];
+      return copy;
+    });
+  }
+
+  return (
+    <div className="mx-auto max-w-2xl space-y-4 p-4">
+      <div className="flex justify-between items-center">
+        <h2 className="text-xl font-semibold">{t('domainAgentDescription')}</h2>
+        <Button variant="secondary" onClick={() => setOpenSettings(true)}>
+          {t('settings')}
+        </Button>
+      </div>
+      {!sessionId && (
+        <div className="space-y-2">
+          <p>{t('domainDescribePrompt')}</p>
+          <Input value={initial} onChange={(e) => setInitial(e.target.value)} />
+          <Button onClick={handleInitialSend}>{t('send')}</Button>
+        </div>
+      )}
+      {sessionId && questions.length > 0 && (
+        <div className="space-y-2">
+          {questions.map((q) => (
+            <div key={q} className="space-y-1">
+              <Label>{q}</Label>
+              <Input
+                value={answers[q] ?? ''}
+                onChange={(e) =>
+                  setAnswers({ ...answers, [q]: e.target.value })
+                }
+              />
+            </div>
+          ))}
+          <Button onClick={handleAnswerSend}>{t('send')}</Button>
+        </div>
+      )}
+      {sessionId && domains.length > 0 && (
+        <div className="space-y-4">
+          {domains.map((d) => (
+            <div
+              key={d}
+              className="flex items-center gap-2 border rounded-md p-2"
+            >
+              <button
+                type="button"
+                onClick={() => toggleLike(d)}
+                aria-label="like"
+                className={liked[d] ? 'text-green-600' : 'text-muted-foreground'}
+              >
+                <ThumbUpIcon />
+              </button>
+              <button
+                type="button"
+                onClick={() => toggleDislike(d)}
+                aria-label="dislike"
+                className={
+                  disliked[d] ? 'text-red-600' : 'text-muted-foreground'
+                }
+              >
+                <ThumbDownIcon />
+              </button>
+              <span className="flex-1 text-center">{d}</span>
+              <Input
+                placeholder="Feedback"
+                value={liked[d] ?? disliked[d] ?? ''}
+                onChange={(e) => {
+                  if (liked[d] !== undefined) {
+                    setLiked({ ...liked, [d]: e.target.value });
+                  } else if (disliked[d] !== undefined) {
+                    setDisliked({ ...disliked, [d]: e.target.value });
+                  }
+                }}
+              />
+            </div>
+          ))}
+          <div className="flex gap-2">
+            <Button onClick={handleContinue}>{t('continue')}</Button>
+            <Button variant="ghost" onClick={() => setDomains([])}>
+              {t('cancel')}
+            </Button>
+          </div>
+        </div>
+      )}
+      <Dialog open={openSettings} onOpenChange={setOpenSettings}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{t('settings')}</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-4">
+            <div className="flex items-center gap-2">
+              <Label htmlFor="mode">Mode</Label>
+              <select
+                id="mode"
+                value={settings.local_dev ? 'local' : 'model'}
+                onChange={(e) =>
+                  setSettingsState({
+                    ...settings,
+                    local_dev: e.target.value === 'local',
+                  })
+                }
+                className="border rounded-md px-2 py-1"
+              >
+                <option value="local">local_dev</option>
+                <option value="model">model</option>
+              </select>
+            </div>
+            <div className="space-x-2">
+              {['A', 'B', 'C'].map((c) => (
+                <label key={c} className="space-x-1">
+                  <input
+                    type="checkbox"
+                    checked={settings.creators.includes(c)}
+                    onChange={(e) => {
+                      const arr = settings.creators.slice();
+                      if (e.target.checked) arr.push(c);
+                      else {
+                        const idx = arr.indexOf(c);
+                        if (idx > -1) arr.splice(idx, 1);
+                      }
+                      setSettingsState({ ...settings, creators: arr });
+                    }}
+                  />
+                  <span>{c}</span>
+                </label>
+              ))}
+            </div>
+            <div className="space-y-1">
+              <Label htmlFor="count">Generation Count</Label>
+              <Input
+                id="count"
+                type="number"
+                value={settings.generation_count}
+                onChange={(e) =>
+                  setSettingsState({
+                    ...settings,
+                    generation_count: Number(e.target.value),
+                  })
+                }
+              />
+            </div>
+            <label className="space-x-1 flex items-center">
+              <input
+                type="checkbox"
+                checked={settings.show_logs}
+                onChange={(e) =>
+                  setSettingsState({ ...settings, show_logs: e.target.checked })
+                }
+              />
+              <span>Show Logs</span>
+            </label>
+            <Button
+              onClick={async () => {
+                if (!sessionId) return;
+                try {
+                  await saveSettings(sessionId, settings);
+                  setOpenSettings(false);
+                } catch (err) {
+                  toast({ type: 'error', description: (err as Error).message });
+                }
+              }}
+            >
+              {t('apply')}
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/lib/agents.ts
+++ b/lib/agents.ts
@@ -48,4 +48,12 @@ export const agents: Array<Agent> = [
     modelId: 'agent-beta',
     systemInstruction: 'You are Beta exploring new features.',
   },
+  {
+    id: 'domain',
+    name: 'DomainAgent',
+    description: 'Generate catchy domain ideas',
+    avatar: 'https://avatar.vercel.sh/domain',
+    modelId: 'domain-agent',
+    systemInstruction: 'You help users find domain names.',
+  },
 ];

--- a/lib/domainClient.ts
+++ b/lib/domainClient.ts
@@ -1,0 +1,82 @@
+export interface DomainSettings {
+  local_dev: boolean;
+  creators: string[];
+  generation_count: number;
+  show_logs: boolean;
+}
+
+const API_URL = process.env.NEXT_PUBLIC_DOMAIN_API_URL ?? '';
+const API_KEY = process.env.NEXT_PUBLIC_DOMAIN_API_KEY ?? '';
+
+function buildInit(method: string, body?: unknown): RequestInit {
+  return {
+    method,
+    headers: {
+      'Content-Type': 'application/json',
+      'X-API-Key': API_KEY,
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  };
+}
+
+async function request<T>(path: string, init: RequestInit) {
+  const res = await fetch(`${API_URL}${path}`, init);
+  if (!res.ok) {
+    const msg = await res.text();
+    throw new Error(msg || res.statusText);
+  }
+  return (await res.json()) as T;
+}
+
+export function createSession(initial_brief: string) {
+  return request<{ id: string }>(
+    '/sessions',
+    buildInit('POST', { initial_brief }),
+  );
+}
+
+export function getSettings(id: string) {
+  return request<DomainSettings>(
+    `/sessions/${id}/settings`,
+    buildInit('GET'),
+  );
+}
+
+export function saveSettings(id: string, settings: DomainSettings) {
+  return request<void>(
+    `/sessions/${id}/settings`,
+    buildInit('POST', settings),
+  );
+}
+
+export function sendAnswers(
+  id: string,
+  payload: {
+    answers: Record<string, string>;
+    liked_domains?: Record<string, string>;
+    disliked_domains?: Record<string, string>;
+  },
+) {
+  return request<{ questions: string[] }>(
+    `/sessions/${id}/answers`,
+    buildInit('POST', payload),
+  );
+}
+
+export function generateDomains(id: string) {
+  return request<{
+    available: string[];
+    taken: string[];
+    history: unknown;
+  }>(`/sessions/${id}/generate`, buildInit('POST'));
+}
+
+export function sendFeedback(
+  id: string,
+  payload: { liked: Record<string, string>; disliked: Record<string, string> },
+) {
+  return request<{ refined_brief: string; questions: string[] }>(
+    `/sessions/${id}/feedback`,
+    buildInit('POST', payload),
+  );
+}

--- a/lib/i18n.tsx
+++ b/lib/i18n.tsx
@@ -120,6 +120,8 @@ export const translations = {
     goToChat: 'Go to chat',
     agentChatListHeading: 'Chats with this assistant',
     agentDemoLabel: 'Example of the assistant',
+    domainAgentDescription: 'Generate domain name ideas',
+    domainDescribePrompt: 'Describe the business or project:',
   },
   nl: {
     newChat: 'Nieuw gesprek',
@@ -240,6 +242,8 @@ export const translations = {
     goToChat: 'Ga naar chat',
     agentChatListHeading: 'Chats met deze assistent',
     agentDemoLabel: 'Voorbeeld van de assistent',
+    domainAgentDescription: 'Genereer domeinnaamideeën',
+    domainDescribePrompt: 'Beschrijf het bedrijf of project:',
   },
 } as const;
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -9,6 +9,8 @@ const nextConfig: NextConfig = {
       process.env.GOOGLE_CLIENT_SECRET
       ? 'true'
       : 'false',
+    NEXT_PUBLIC_DOMAIN_API_URL: process.env.DOMAIN_API_URL,
+    NEXT_PUBLIC_DOMAIN_API_KEY: process.env.DOMAIN_API_KEY,
   },
   images: {
     remotePatterns: [


### PR DESCRIPTION
## Summary
- add DomainAgent card and routing
- support environment variables for Domain API
- implement DomainAgent chat with settings and feedback

## Testing
- `pnpm lint`
- `pnpm tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_6889255ac2ec832a90c53e124837a081