### PR TITLE
feat: redesign domain agent UI

### DIFF
--- a/app/domainagent/layout.tsx
+++ b/app/domainagent/layout.tsx
@@ -1,0 +1,29 @@
+import { cookies } from 'next/headers';
+import { AppSidebar } from '@/components/app-sidebar';
+import { SidebarInset, SidebarProvider } from '@/components/ui/sidebar';
+import { auth } from '../(auth)/auth';
+import Script from 'next/script';
+
+export const experimental_ppr = true;
+
+export default async function Layout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const [session, cookieStore] = await Promise.all([auth(), cookies()]);
+  const isCollapsed = cookieStore.get('sidebar:state')?.value === 'false';
+
+  return (
+    <>
+      <Script
+        src="https://cdn.jsdelivr.net/pyodide/v0.23.4/full/pyodide.js"
+        strategy="beforeInteractive"
+      />
+      <SidebarProvider defaultOpen={!isCollapsed}>
+        <AppSidebar user={session?.user} />
+        <SidebarInset>{children}</SidebarInset>
+      </SidebarProvider>
+    </>
+  );
+}

--- a/app/domainagent/page.tsx
+++ b/app/domainagent/page.tsx
@@ -3,11 +3,20 @@ import { useState, useEffect } from 'react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
-import { Sheet, SheetTrigger, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet';
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from '@/components/ui/sheet';
 import { toast } from '@/components/toast';
 import { useTranslation } from '@/lib/i18n';
 import type { DomainSettings } from '@/lib/domainClient';
 import * as api from '@/lib/domainClient';
+import DomainAgentHeader from '@/components/domainagent-header';
+import '../../themes/assistenten.css';
+import { motion } from 'framer-motion';
+import { LoaderIcon } from '@/components/icons';
 
 interface Question { id: string; text: string; }
 
@@ -29,6 +38,7 @@ export default function DomainAgentPage() {
   const [openSettings, setOpenSettings] = useState(false);
   const [openLogs, setOpenLogs] = useState(false);
   const [logs, setLogs] = useState<Array<{ id: string; type: string; request: any; response?: any }>>([]);
+  const [loading, setLoading] = useState(false);
 
   useEffect(() => {
     if (sessionId && openSettings) {
@@ -37,6 +47,7 @@ export default function DomainAgentPage() {
   }, [sessionId, openSettings]);
 
   async function start() {
+    setLoading(true);
     try {
       const res = await api.createSession(brief);
       setLogs((l) => [
@@ -51,10 +62,12 @@ export default function DomainAgentPage() {
     } catch (err:any) {
       toast({ type: 'error', description: err.message });
     }
+    setLoading(false);
   }
 
   async function submitAnswers() {
     if (!sessionId) return;
+    setLoading(true);
     try {
       const ansRes = await api.sendAnswers(sessionId, { answers });
       setLogs((l) => [
@@ -68,10 +81,12 @@ export default function DomainAgentPage() {
     } catch (err:any) {
       toast({ type: 'error', description: err.message });
     }
+    setLoading(false);
   }
 
   async function sendFeedback(continueLoop: boolean) {
     if (!sessionId) return;
+    setLoading(true);
     try {
       const liked: Record<string,string> = {};
       const disliked: Record<string,string> = {};
@@ -100,6 +115,7 @@ export default function DomainAgentPage() {
     } catch (err:any) {
       toast({ type: 'error', description: err.message });
     }
+    setLoading(false);
   }
 
   function updateAnswer(id: string, value: string) {
@@ -115,11 +131,14 @@ export default function DomainAgentPage() {
   }
 
   return (
-    <div className="mx-auto max-w-2xl p-4 space-y-6">
+    <>
+      <DomainAgentHeader
+        onOpenSettings={() => setOpenSettings(true)}
+        onOpenLogs={() => setOpenLogs(true)}
+        showLogs={settings.show_logs}
+      />
+      <div className="mx-auto max-w-2xl p-4 space-y-6">
       <Sheet open={openSettings} onOpenChange={setOpenSettings}>
-        <SheetTrigger asChild>
-          <Button variant="outline">{t('settings')}</Button>
-        </SheetTrigger>
         <SheetContent>
           <SheetHeader>
             <SheetTitle>{t('settings')}</SheetTitle>
@@ -160,9 +179,6 @@ export default function DomainAgentPage() {
 
       {settings.show_logs && (
         <Sheet open={openLogs} onOpenChange={setOpenLogs}>
-          <SheetTrigger asChild>
-            <Button variant="outline">{t('logs')}</Button>
-          </SheetTrigger>
           <SheetContent side="right">
             <SheetHeader>
               <SheetTitle>{t('logs')}</SheetTitle>
@@ -190,41 +206,91 @@ export default function DomainAgentPage() {
       )}
 
       {phase === 'start' && (
-        <div className="space-y-4">
-          <div>{t('domainAgentPrompt')}</div>
-          <Textarea value={brief} onChange={(e)=>setBrief(e.target.value)} />
-          <Button onClick={start} className="mt-2">{t('send')}</Button>
+        <div className="space-y-4 text-center mt-10">
+          <div className="text-lg font-semibold">{t('domainAgentPrompt')}</div>
+          <Textarea
+            className="rounded-xl bg-white/10 backdrop-blur-md border border-white/30 shadow-lg"
+            value={brief}
+            onChange={(e) => setBrief(e.target.value)}
+          />
+          <Button onClick={start} className="mt-2 h-11 px-6" disabled={loading}>
+            {loading ? <LoaderIcon className="animate-spin" /> : t('send')}
+          </Button>
         </div>
       )}
 
       {phase === 'questions' && (
-        <div className="space-y-4">
-          {questions.map((q)=>{
+        <motion.div className="space-y-4" initial="hidden" animate="show" variants={{hidden:{},show:{transition:{staggerChildren:0.1}}}}>
+          {questions.map((q) => {
             const inputId = `q-${q.id}`;
             return (
-              <label key={q.id} htmlFor={inputId} className="flex flex-col gap-1">
+              <motion.label
+                key={q.id}
+                htmlFor={inputId}
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+                whileHover={{ scale: 1.02 }}
+                className="flex flex-col gap-1 p-4 rounded-xl border border-white/30 bg-white/10 backdrop-blur-md shadow"
+              >
                 {q.text}
-                <Input id={inputId} value={answers[q.id]||''} onChange={(e)=>updateAnswer(q.id,e.target.value)} />
-              </label>
+                <Input
+                  id={inputId}
+                  value={answers[q.id] || ''}
+                  onChange={(e) => updateAnswer(q.id, e.target.value)}
+                />
+              </motion.label>
             );
           })}
-          <Button onClick={submitAnswers}>{t('send')}</Button>
-        </div>
+          <Button onClick={submitAnswers} disabled={loading} className="h-11 px-6">
+            {loading ? <LoaderIcon className="animate-spin" /> : t('send')}
+          </Button>
+        </motion.div>
       )}
 
       {phase === 'suggestions' && (
         <div className="space-y-4">
-          {domains.map((d)=>(
-            <div key={d} className="flex items-center gap-2 border rounded p-2">
-              <button type="button" onClick={()=>updateFeedback(d,true)} className={feedback[d]?.liked?'text-green-600':''}>👍</button>
-              <button type="button" onClick={()=>updateFeedback(d,false)} className={!feedback[d] || feedback[d]?.liked ? '':'text-red-600'}>👎</button>
+          {domains.map((d) => (
+            <motion.div
+              key={d}
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              className="flex items-center gap-2 border rounded p-2 bg-white/10 backdrop-blur-md shadow"
+            >
+              <button
+                type="button"
+                onClick={() => updateFeedback(d, true)}
+                className={
+                  feedback[d]?.liked ? 'text-green-600' : 'text-muted-foreground'
+                }
+              >
+                👍
+              </button>
+              <button
+                type="button"
+                onClick={() => updateFeedback(d, false)}
+                className={
+                  feedback[d] && !feedback[d].liked
+                    ? 'text-red-600'
+                    : 'text-muted-foreground'
+                }
+              >
+                👎
+              </button>
               <span className="flex-1 text-center">{d}</span>
-              <Input placeholder="" value={feedback[d]?.comment||''} onChange={(e)=>updateComment(d,e.target.value)} />
-            </div>
+              <Input
+                placeholder=""
+                value={feedback[d]?.comment || ''}
+                onChange={(e) => updateComment(d, e.target.value)}
+              />
+            </motion.div>
           ))}
           <div className="flex gap-2">
-            <Button onClick={()=>sendFeedback(true)}>{t('continue')}</Button>
-            <Button variant="outline" onClick={()=>sendFeedback(false)}>{t('stop')}</Button>
+            <Button onClick={() => sendFeedback(true)} disabled={loading} className="h-10 px-6">
+              {loading ? <LoaderIcon className="animate-spin" /> : t('continue')}
+            </Button>
+            <Button variant="outline" onClick={() => sendFeedback(false)} disabled={loading} className="h-10 px-6">
+              {t('stop')}
+            </Button>
           </div>
         </div>
       )}
@@ -233,5 +299,6 @@ export default function DomainAgentPage() {
         <div>{t('done')}</div>
       )}
     </div>
+    </>
   );
 }

--- a/components/domainagent-header.tsx
+++ b/components/domainagent-header.tsx
@@ -1,0 +1,68 @@
+'use client';
+import { motion } from 'framer-motion';
+import { SidebarLeftIcon } from '@/components/icons';
+import { useSidebar } from '@/components/ui/sidebar';
+import { useTranslation } from '@/lib/i18n';
+import { Button } from '@/components/ui/button';
+import { useUpgradePopup } from '@/hooks/use-upgrade-popup';
+import { MessageLimitIndicator } from '@/components/message-limit-indicator';
+import { SubscriptionIndicator } from '@/components/subscription-indicator';
+import { useSession } from 'next-auth/react';
+import clsx from 'clsx';
+
+export default function DomainAgentHeader({
+  onOpenSettings,
+  onOpenLogs,
+  showLogs,
+}: {
+  onOpenSettings: () => void;
+  onOpenLogs: () => void;
+  showLogs: boolean;
+}) {
+  const { toggleSidebar, open: isSidebarOpen } = useSidebar();
+  const { data: session } = useSession();
+  const { openPopup: openUpgradePopup } = useUpgradePopup();
+  const t = useTranslation();
+
+  return (
+    <motion.header
+      initial={{ opacity: 0, y: -8 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.18, ease: 'easeOut' }}
+      className={clsx('stickyHeader flex items-center gap-2 h-14 md:h-16 px-4 md:px-6', {
+        withSidebar: isSidebarOpen,
+      })}
+      style={{ background: 'rgba(255,255,255,.15)' }}
+    >
+      <button
+        type="button"
+        onClick={toggleSidebar}
+        aria-label={t('toggleSidebar')}
+        className="assistenten-toggle md:hidden mr-3 size-10 rounded-full backdrop-blur-sm bg-white/20 flex items-center justify-center hover:shadow-[0_0_8px_rgba(255,255,255,0.5)]"
+      >
+        <SidebarLeftIcon size={24} />
+      </button>
+      {session?.user?.models?.length ? (
+        <SubscriptionIndicator className="hidden sm:block" />
+      ) : (
+        session?.user && (
+          <MessageLimitIndicator userId={session.user.id} className="hidden sm:block" />
+        )
+      )}
+      <div className="flex-1" />
+      {session?.user && session.user.models?.length !== 3 && (
+        <Button variant="outline" className="hidden md:flex h-9 px-3" onClick={() => openUpgradePopup()}>
+          {t('upgrade')}
+        </Button>
+      )}
+      <Button variant="outline" onClick={onOpenSettings} className="h-9 px-3">
+        {t('settings')}
+      </Button>
+      {showLogs && (
+        <Button variant="outline" onClick={onOpenLogs} className="h-9 px-3">
+          {t('logs')}
+        </Button>
+      )}
+    </motion.header>
+  );
+}


### PR DESCRIPTION
## Summary
- create glassy header for DomainAgent page
- add layout so DomainAgent matches rest of UI
- modernize DomainAgent chat flow with animations and loaders

## Testing
- `pnpm lint`
- `pnpm tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6889f713c448832a8d6ba0a0ba74d6fd