### PR TITLE
feat: redesign domainagent ui

### DIFF
--- a/app/domainagent/page.tsx
+++ b/app/domainagent/page.tsx
@@ -8,6 +8,9 @@ import { toast } from '@/components/toast';
 import { useTranslation } from '@/lib/i18n';
 import type { DomainSettings } from '@/lib/domainClient';
 import * as api from '@/lib/domainClient';
+import { DomainAgentHeader } from '@/components/domainagent-header';
+import { LoaderIcon, ThumbUpIcon, ThumbDownIcon } from '@/components/icons';
+import { motion } from 'framer-motion';
 
 interface Question { id: string; text: string; }
 
@@ -29,6 +32,7 @@ export default function DomainAgentPage() {
   const [openSettings, setOpenSettings] = useState(false);
   const [openLogs, setOpenLogs] = useState(false);
   const [logs, setLogs] = useState<Array<{ id: string; type: string; request: any; response?: any }>>([]);
+  const [loading, setLoading] = useState(false);
 
   useEffect(() => {
     if (sessionId && openSettings) {
@@ -38,6 +42,7 @@ export default function DomainAgentPage() {
 
   async function start() {
     try {
+      setLoading(true);
       const res = await api.createSession(brief);
       setLogs((l) => [
         ...l,
@@ -50,12 +55,15 @@ export default function DomainAgentPage() {
       setPhase('questions');
     } catch (err:any) {
       toast({ type: 'error', description: err.message });
+    } finally {
+      setLoading(false);
     }
   }
 
   async function submitAnswers() {
     if (!sessionId) return;
     try {
+      setLoading(true);
       const ansRes = await api.sendAnswers(sessionId, { answers });
       setLogs((l) => [
         ...l,
@@ -67,12 +75,15 @@ export default function DomainAgentPage() {
       setPhase('suggestions');
     } catch (err:any) {
       toast({ type: 'error', description: err.message });
+    } finally {
+      setLoading(false);
     }
   }
 
   async function sendFeedback(continueLoop: boolean) {
     if (!sessionId) return;
     try {
+      setLoading(true);
       const liked: Record<string,string> = {};
       const disliked: Record<string,string> = {};
       Object.entries(feedback).forEach(([d, f]) => {
@@ -99,6 +110,8 @@ export default function DomainAgentPage() {
       }
     } catch (err:any) {
       toast({ type: 'error', description: err.message });
+    } finally {
+      setLoading(false);
     }
   }
 
@@ -115,12 +128,17 @@ export default function DomainAgentPage() {
   }
 
   return (
-    <div className="mx-auto max-w-2xl p-4 space-y-6">
+    <>
+      <DomainAgentHeader
+        onOpenSettings={() => setOpenSettings(true)}
+        onOpenLogs={() => setOpenLogs(true)}
+      />
+      <div className="mx-auto max-w-2xl p-4 space-y-6">
       <Sheet open={openSettings} onOpenChange={setOpenSettings}>
         <SheetTrigger asChild>
           <Button variant="outline">{t('settings')}</Button>
         </SheetTrigger>
-        <SheetContent>
+        <SheetContent className="p-6">
           <SheetHeader>
             <SheetTitle>{t('settings')}</SheetTitle>
           </SheetHeader>
@@ -163,7 +181,7 @@ export default function DomainAgentPage() {
           <SheetTrigger asChild>
             <Button variant="outline">{t('logs')}</Button>
           </SheetTrigger>
-          <SheetContent side="right">
+          <SheetContent side="right" className="p-6">
             <SheetHeader>
               <SheetTitle>{t('logs')}</SheetTitle>
             </SheetHeader>
@@ -190,41 +208,97 @@ export default function DomainAgentPage() {
       )}
 
       {phase === 'start' && (
-        <div className="space-y-4">
-          <div>{t('domainAgentPrompt')}</div>
-          <Textarea value={brief} onChange={(e)=>setBrief(e.target.value)} />
-          <Button onClick={start} className="mt-2">{t('send')}</Button>
+        <div className="space-y-4 text-center">
+          <div className="text-lg font-medium">{t('domainAgentPrompt')}</div>
+          <Textarea
+            value={brief}
+            onChange={(e) => setBrief(e.target.value)}
+            className="glassBubble w-full h-32 text-lg p-4"
+          />
+          <Button onClick={start} className="mt-2 frostedGlow-orangeDeep relative px-6">
+            {loading ? (
+              <span className="absolute inset-y-0 right-4 flex items-center animate-spin"><LoaderIcon /></span>
+            ) : null}
+            {t('send')}
+          </Button>
         </div>
       )}
 
       {phase === 'questions' && (
         <div className="space-y-4">
-          {questions.map((q)=>{
+          {questions.map((q, index) => {
             const inputId = `q-${q.id}`;
             return (
-              <label key={q.id} htmlFor={inputId} className="flex flex-col gap-1">
+              <motion.label
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ delay: 0.05 * index }}
+                key={q.id}
+                htmlFor={inputId}
+                className="flex flex-col gap-2 glassBubble p-4"
+              >
                 {q.text}
-                <Input id={inputId} value={answers[q.id]||''} onChange={(e)=>updateAnswer(q.id,e.target.value)} />
-              </label>
+                <Input
+                  id={inputId}
+                  value={answers[q.id] || ''}
+                  onChange={(e) => updateAnswer(q.id, e.target.value)}
+                />
+              </motion.label>
             );
           })}
-          <Button onClick={submitAnswers}>{t('send')}</Button>
+          <Button onClick={submitAnswers} className="relative">
+            {loading ? (
+              <span className="absolute inset-y-0 right-4 flex items-center animate-spin"><LoaderIcon /></span>
+            ) : null}
+            {t('send')}
+          </Button>
         </div>
       )}
 
       {phase === 'suggestions' && (
         <div className="space-y-4">
           {domains.map((d)=>(
-            <div key={d} className="flex items-center gap-2 border rounded p-2">
-              <button type="button" onClick={()=>updateFeedback(d,true)} className={feedback[d]?.liked?'text-green-600':''}>👍</button>
-              <button type="button" onClick={()=>updateFeedback(d,false)} className={!feedback[d] || feedback[d]?.liked ? '':'text-red-600'}>👎</button>
+            <motion.div
+              key={d}
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              className="flex items-center gap-3 glassBubble p-3"
+            >
+              <button
+                type="button"
+                onClick={() => updateFeedback(d, true)}
+                className={`glassIcon ${feedback[d]?.liked ? 'bg-green-600 text-white' : ''}`}
+              >
+                <ThumbUpIcon />
+              </button>
+              <button
+                type="button"
+                onClick={() => updateFeedback(d, false)}
+                className={`glassIcon ${feedback[d] && !feedback[d]?.liked ? 'bg-red-600 text-white' : ''}`}
+              >
+                <ThumbDownIcon />
+              </button>
               <span className="flex-1 text-center">{d}</span>
-              <Input placeholder="" value={feedback[d]?.comment||''} onChange={(e)=>updateComment(d,e.target.value)} />
-            </div>
+              <Input
+                placeholder=""
+                value={feedback[d]?.comment || ''}
+                onChange={(e) => updateComment(d, e.target.value)}
+              />
+            </motion.div>
           ))}
           <div className="flex gap-2">
-            <Button onClick={()=>sendFeedback(true)}>{t('continue')}</Button>
-            <Button variant="outline" onClick={()=>sendFeedback(false)}>{t('stop')}</Button>
+            <Button onClick={() => sendFeedback(true)} className="relative">
+              {loading ? (
+                <span className="absolute inset-y-0 right-4 flex items-center animate-spin"><LoaderIcon /></span>
+              ) : null}
+              {t('continue')}
+            </Button>
+            <Button variant="outline" onClick={() => sendFeedback(false)} className="relative">
+              {loading ? (
+                <span className="absolute inset-y-0 right-4 flex items-center animate-spin"><LoaderIcon /></span>
+              ) : null}
+              {t('stop')}
+            </Button>
           </div>
         </div>
       )}
@@ -232,6 +306,7 @@ export default function DomainAgentPage() {
       {phase === 'done' && (
         <div>{t('done')}</div>
       )}
-    </div>
+      </div>
+    </>
   );
 }

--- a/components/domainagent-header.tsx
+++ b/components/domainagent-header.tsx
@@ -1,0 +1,74 @@
+'use client';
+import { motion } from 'framer-motion';
+import { useEffect, useState } from 'react';
+import clsx from 'clsx';
+import { useSidebar } from '@/components/ui/sidebar';
+import { SidebarToggle } from '@/components/sidebar-toggle';
+import { MessageLimitIndicator } from '@/components/message-limit-indicator';
+import { Button } from '@/components/ui/button';
+import { useUpgradePopup } from '@/hooks/use-upgrade-popup';
+import { useTranslation } from '@/lib/i18n';
+import { useSession } from 'next-auth/react';
+
+export function DomainAgentHeader({
+  onOpenSettings,
+  onOpenLogs,
+}: {
+  onOpenSettings: () => void;
+  onOpenLogs: () => void;
+}) {
+  const { toggleSidebar, open: isSidebarOpen } = useSidebar();
+  const { openPopup: openUpgradePopup } = useUpgradePopup();
+  const { data: session } = useSession();
+  const t = useTranslation();
+  const [hidden, setHidden] = useState(false);
+  const [lastY, setLastY] = useState(0);
+
+  useEffect(() => {
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+    function onScroll() {
+      const y = window.scrollY;
+      if (y > lastY && y > 64) {
+        setHidden(true);
+      } else {
+        setHidden(false);
+      }
+      setLastY(y);
+    }
+    window.addEventListener('scroll', onScroll);
+    return () => window.removeEventListener('scroll', onScroll);
+  }, [lastY]);
+
+  return (
+    <motion.header
+      initial={{ opacity: 0, y: -8 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.18, ease: 'easeOut' }}
+      className={clsx(
+        'stickyHeader px-4 md:px-6 h-14 md:h-16 flex items-center gap-2 transition-transform duration-200 ease-out',
+        { withSidebar: isSidebarOpen },
+        hidden && '-translate-y-full',
+      )}
+      style={{ background: 'rgba(255,255,255,.15)' }}
+    >
+      <SidebarToggle />
+      <div className="flex-1" />
+      {session?.user && (
+        <MessageLimitIndicator userId={session.user.id} className="hidden md:flex" />
+      )}
+      <Button variant="ghost" onClick={onOpenSettings} className="h-8 px-3 text-sm">
+        {t('settings')}
+      </Button>
+      <Button variant="ghost" onClick={onOpenLogs} className="h-8 px-3 text-sm">
+        {t('logs')}
+      </Button>
+      <Button
+        variant="outline"
+        className="ml-2 h-8 px-3 text-sm"
+        onClick={() => openUpgradePopup()}
+      >
+        {t('upgrade')}
+      </Button>
+    </motion.header>
+  );
+}


### PR DESCRIPTION
## Summary
- add `DomainAgentHeader` for glassy controls
- modernize domainagent page layout
- show loading spinner while actions run
- animate question and domain sections

## Testing
- `pnpm lint`
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_6889f713c448832a8d6ba0a0ba74d6fd