### PR TITLE
feat: track domain agent chats

### DIFF
--- a/app/domainagent/chat/message/route.ts
+++ b/app/domainagent/chat/message/route.ts
@@ -1,0 +1,53 @@
+import { auth } from '@/app/(auth)/auth';
+import { ChatSDKError } from '@/lib/errors';
+import { entitlementsByUserType } from '@/lib/ai/entitlements';
+import { generateUUID } from '@/lib/utils';
+import { getChatById, saveUserMessageWithLimit } from '@/lib/db/queries';
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+
+export async function POST(request: NextRequest) {
+  try {
+    const { chat_id } = await request.json();
+    if (!chat_id) {
+      return new ChatSDKError('bad_request:api').toResponse();
+    }
+
+    const session = await auth();
+    if (!session?.user) {
+      return new ChatSDKError('unauthorized:chat').toResponse();
+    }
+
+    const chat = await getChatById({ id: chat_id });
+    if (!chat) {
+      return new ChatSDKError('not_found:chat').toResponse();
+    }
+    if (chat.userId !== session.user.id) {
+      return new ChatSDKError('forbidden:chat').toResponse();
+    }
+
+    const maxMessages = entitlementsByUserType[session.user.type].maxMessagesPerDay;
+    const messageId = generateUUID();
+
+    const userMessage = await saveUserMessageWithLimit({
+      userId: session.user.id,
+      chatId: chat_id,
+      messageId,
+      parts: [{ text: '[domain agent continue]' }],
+      attachments: [],
+      maxMessages,
+    });
+
+    if (!userMessage) {
+      return new ChatSDKError('limit_exceeded:chat').toResponse();
+    }
+
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    console.error('POST /domainagent/chat/message failed:', err);
+    if (err instanceof ChatSDKError) {
+      return err.toResponse();
+    }
+    return new NextResponse('Internal Server Error', { status: 500 });
+  }
+}

--- a/app/domainagent/chat/start/route.ts
+++ b/app/domainagent/chat/start/route.ts
@@ -1,0 +1,77 @@
+import { auth } from '@/app/(auth)/auth';
+import { ChatSDKError } from '@/lib/errors';
+import { entitlementsByUserType } from '@/lib/ai/entitlements';
+import { generateUUID } from '@/lib/utils';
+import {
+  saveChat,
+  saveUserMessageWithLimit,
+} from '@/lib/db/queries';
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+
+const API_URL = process.env.DOMAIN_API_URL || 'http://161.35.152.9:8000';
+const API_KEY = process.env.DOMAIN_API_KEY || 'alksdfjoij09U908FHSFJoidhf9s8dfh9g87buvweuih87329UFI';
+
+export async function POST(request: NextRequest) {
+  try {
+    const { initial_brief } = await request.json();
+    if (!initial_brief) {
+      return new ChatSDKError('bad_request:api').toResponse();
+    }
+
+    const session = await auth();
+    if (!session?.user) {
+      return new ChatSDKError('unauthorized:chat').toResponse();
+    }
+
+    const userId = session.user.id;
+    const userType = session.user.type;
+    const maxMessages = entitlementsByUserType[userType].maxMessagesPerDay;
+
+    const chatId = generateUUID();
+    const messageId = generateUUID();
+
+    const userMessage = await saveUserMessageWithLimit({
+      userId,
+      chatId,
+      messageId,
+      parts: [{ text: initial_brief }],
+      attachments: [],
+      maxMessages,
+    });
+
+    if (!userMessage) {
+      return new ChatSDKError('limit_exceeded:chat').toResponse();
+    }
+
+    await saveChat({
+      id: chatId,
+      userId,
+      title: initial_brief.slice(0, 80),
+      visibility: 'private',
+      modelId: 'domain-agent',
+    });
+
+    const res = await fetch(`${API_URL}/sessions`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-API-Key': API_KEY,
+      },
+      body: JSON.stringify({ initial_brief }),
+    });
+
+    const text = await res.text();
+    if (!res.ok) {
+      return new NextResponse(text, { status: res.status });
+    }
+
+    return NextResponse.json({ chat_id: chatId, ...(JSON.parse(text)) });
+  } catch (err) {
+    console.error('POST /domainagent/chat/start failed:', err);
+    if (err instanceof ChatSDKError) {
+      return err.toResponse();
+    }
+    return new NextResponse('Internal Server Error', { status: 500 });
+  }
+}

--- a/app/domainagent/page.tsx
+++ b/app/domainagent/page.tsx
@@ -13,6 +13,8 @@ import { toast } from '@/components/toast';
 import { useTranslation } from '@/lib/i18n';
 import type { DomainSettings } from '@/lib/domainClient';
 import * as api from '@/lib/domainClient';
+import { useSession } from 'next-auth/react';
+import { useSWRConfig } from 'swr';
 import DomainAgentHeader from '@/components/domainagent-header';
 import '../../themes/assistenten.css';
 import { motion } from 'framer-motion';
@@ -24,6 +26,7 @@ interface Question { id: string; text: string; }
 export default function DomainAgentPage() {
   const t = useTranslation();
   const [sessionId, setSessionId] = useState<string | null>(null);
+  const [chatId, setChatId] = useState<string | null>(null);
   const [brief, setBrief] = useState('');
   const [questions, setQuestions] = useState<Question[]>([]);
   const [answers, setAnswers] = useState<Record<string,string>>({});
@@ -40,6 +43,8 @@ export default function DomainAgentPage() {
   const [openLogs, setOpenLogs] = useState(false);
   const [logs, setLogs] = useState<Array<{ id: string; type: string; request: any; response?: any }>>([]);
   const [loading, setLoading] = useState(false);
+  const { data: session } = useSession();
+  const { mutate } = useSWRConfig();
 
   useEffect(() => {
     if (sessionId && openSettings) {
@@ -50,16 +55,20 @@ export default function DomainAgentPage() {
   async function start() {
     setLoading(true);
     try {
-      const res = await api.createSession(brief);
+      const res = await api.startSession(brief);
       setLogs((l) => [
         ...l,
         { id: crypto.randomUUID(), type: 'createSession', request: { initial_brief: brief }, response: res },
       ]);
       setSessionId(res.session_id);
+      setChatId(res.chat_id);
       setQuestions(res.questions);
       await api.saveSettings(res.session_id, settings);
       setLogs((l) => [...l, { id: crypto.randomUUID(), type: 'saveSettings', request: settings }]);
       setPhase('questions');
+      if (session?.user?.id) {
+        mutate(`/api/message-status?userId=${session.user.id}`);
+      }
     } catch (err:any) {
       toast({ type: 'error', description: err.message });
     }
@@ -97,6 +106,12 @@ export default function DomainAgentPage() {
       });
       if (continueLoop) {
         const fb = await api.sendFeedback(sessionId, { liked, disliked });
+        if (chatId) {
+          await api.logContinue(chatId);
+          if (session?.user?.id) {
+            mutate(`/api/message-status?userId=${session.user.id}`);
+          }
+        }
         setLogs((l) => [
           ...l,
           { id: crypto.randomUUID(), type: 'sendFeedback', request: { liked, disliked }, response: fb },

--- a/lib/domainClient.ts
+++ b/lib/domainClient.ts
@@ -10,8 +10,10 @@ interface Question {
   text: string;
 }
 
-// Calls are proxied through an internal Next.js API route to avoid CORS issues
+// Calls to the python service are proxied through an internal Next.js API route
 const API_URL = '/domainagent/api';
+// Internal routes for tracking chats/messages
+const CHAT_API_URL = '/domainagent/chat';
 
 async function request<T>(path: string, options?: RequestInit): Promise<T> {
   const res = await fetch(`${API_URL}${path}`, {
@@ -31,12 +33,32 @@ async function request<T>(path: string, options?: RequestInit): Promise<T> {
   return res.json();
 }
 
-export async function createSession(initialBrief: string): Promise<{ session_id: string; questions: Question[] }>
+export async function startSession(
+  initialBrief: string,
+): Promise<{ session_id: string; questions: Question[]; chat_id: string }>
 {
-  return request('/sessions', {
+  const res = await fetch(`${CHAT_API_URL}/start`, {
     method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ initial_brief: initialBrief }),
   });
+  if (!res.ok) {
+    const data = await res.json();
+    throw new Error(data.message || 'Request failed');
+  }
+  return res.json();
+}
+
+export async function logContinue(chatId: string): Promise<void> {
+  const res = await fetch(`${CHAT_API_URL}/message`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ chat_id: chatId }),
+  });
+  if (!res.ok) {
+    const data = await res.json();
+    throw new Error(data.message || 'Request failed');
+  }
 }
 
 export async function getSettings(sessionId: string): Promise<DomainSettings> {


### PR DESCRIPTION
## Summary
- store domain agent sessions as chats via new API routes
- count each start and continue action against user's message limit
- show domain agent conversations in sidebar history

## Testing
- `pnpm lint`
- `pnpm tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_6889feb61c18832a8478274d3ef7d162