### PR TITLE
fix: ensure resumable streams return correct type

### DIFF
--- a/app/(chat)/api/chat/route.ts
+++ b/app/(chat)/api/chat/route.ts
@@ -291,7 +291,7 @@ export async function GET(request: NextRequest) {
     // The fallback function MUST return a Promise<ReadableStream | Response> or ReadableStream | Response
     const resumedStream = await streamContext.resumableStream(
       streamId || chatId,
-      async () => {
+      () => {
         const data = new StreamData();
         data.close(); // Close the StreamData instance, making its stream end.
         return data.stream; // This is a ReadableStream


### PR DESCRIPTION
## Summary
- fix resumable stream fallback to return a stream synchronously

## Testing
- `pnpm lint`
- `pnpm tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_688b159f9598832a9f38aaa4c0a36f63