### PR TITLE
fix: handle completed streams

### DIFF
--- a/app/(chat)/api/chat/route.ts
+++ b/app/(chat)/api/chat/route.ts
@@ -289,14 +289,20 @@ export async function GET(request: NextRequest) {
     }
 
     // The fallback function MUST return a Promise<ReadableStream | Response> or ReadableStream | Response
-    const resumedStream = await streamContext.resumableStream(
+    let resumedStream = await streamContext.resumableStream(
       streamId || chatId,
-      async () => {
+      () => {
         const data = new StreamData();
         data.close(); // Close the StreamData instance, making its stream end.
         return data.stream; // This is a ReadableStream
       },
     );
+
+    if (!resumedStream) {
+      const data = new StreamData();
+      data.close();
+      resumedStream = data.stream;
+    }
 
     return new Response(resumedStream);
   } catch (err) {

--- a/components/ui/sidebar.tsx
+++ b/components/ui/sidebar.tsx
@@ -10,7 +10,7 @@ import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Separator } from '@/components/ui/separator';
-import { Sheet, SheetContent } from '@/components/ui/sheet';
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet';
 import { Skeleton } from '@/components/ui/skeleton';
 import {
   Tooltip,
@@ -214,6 +214,9 @@ const Sidebar = React.forwardRef<
             }
             side={side}
           >
+            <SheetHeader>
+              <SheetTitle className="sr-only">Sidebar</SheetTitle>
+            </SheetHeader>
             <div className="flex h-full w-full flex-col">{children}</div>
           </SheetContent>
         </Sheet>


### PR DESCRIPTION
## Summary
- handle null stream case to avoid empty responses
- ensure sidebar sheet has hidden title for accessibility

## Testing
- `pnpm lint`
- `pnpm tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_688b159f9598832a9f38aaa4c0a36f63